### PR TITLE
Working VPC and Subnet Creation

### DIFF
--- a/cmd/goplugin-aws/aws/start.go
+++ b/cmd/goplugin-aws/aws/start.go
@@ -20,8 +20,10 @@ func Start() {
 
 		sb := service.NewServerBuilder(c, `Aws`)
 
-		evs := sb.RegisterTypes("Aws::Vpc", resource.VPC{})
+		evs := sb.RegisterTypes("Aws", resource.Vpc{})
 		sb.RegisterHandler("Aws::VPCHandler", &resource.VPCHandler{}, evs[0])
+		evs = sb.RegisterTypes("Aws", resource.Subnet{})
+		sb.RegisterHandler("Aws::SubnetHandler", &resource.SubnetHandler{}, evs[0])
 
 		s := sb.Server()
 		grpc.Serve(c, s)

--- a/cmd/goplugin-aws/resource/acceptance_test.go
+++ b/cmd/goplugin-aws/resource/acceptance_test.go
@@ -16,8 +16,8 @@ var publicKeyFingerprint = "c5:5d:ee:ed:13:c4:da:46:d9:88:a4:8a:34:e9:1f:52"
 
 //vpcHandler defines the contract.  this is unnecessary but for illustrative purposes
 type vpcHandler interface {
-	Create(desiredState *VPC) (actualState *VPC, externalID string, err error)
-	Read(externalID string) (*VPC, error)
+	Create(desiredState *Vpc) (actualState *Vpc, externalID string, err error)
+	Read(externalID string) (*Vpc, error)
 	Delete(externalID string) error
 }
 
@@ -79,7 +79,7 @@ func createVPC(t *testing.T) string {
 func createSubnet(t *testing.T, vpcExternalID string) string {
 	sh := SubnetHandler{}
 	subnet := aTestSubnet()
-	subnet.VpcID = vpcExternalID
+	subnet.VpcId = vpcExternalID
 
 	//Create and check Subnet
 	actualSubnet, subnetExternalID, err := sh.Create(subnet)
@@ -111,8 +111,8 @@ func createRouteTable(t *testing.T, vpcExternalID string, subnetExternalID strin
 	rth := RouteTableHandler{}
 
 	rt := aRouteTable()
-	rt.VpcID = vpcExternalID
-	rt.SubnetID = subnetExternalID
+	rt.VpcId = vpcExternalID
+	rt.SubnetId = subnetExternalID
 
 	//Create and check RouteTable
 	actualRT, rtExternalID, err := rth.Create(rt)
@@ -234,8 +234,8 @@ func createKeyPair(t *testing.T) string {
 	return externalID
 }
 
-func aTestVPC() *VPC {
-	r := VPC{}
+func aTestVPC() *Vpc {
+	r := Vpc{}
 	r.CidrBlock = "10.90.0.0/24"
 	r.Tags = make(map[string]string)
 	r.Tags["created-by"] = "lyra-acceptance-test-vpc"

--- a/cmd/goplugin-aws/resource/internet_gateway.go
+++ b/cmd/goplugin-aws/resource/internet_gateway.go
@@ -12,7 +12,7 @@ const defaultRetryBackoff = 1 * time.Second
 
 // InternetGateway is the managed resource
 type InternetGateway struct {
-	InternetGatewayID string
+	InternetGatewayId string
 	Tags              map[string]string
 	Attachments       []InternetGatewayAttachment
 }
@@ -98,7 +98,7 @@ func (h *InternetGatewayHandler) Delete(externalID string) error {
 
 func (h *InternetGatewayHandler) fromAWS(wanted *InternetGateway, actual *ec2.InternetGateway) *InternetGateway {
 	ig := InternetGateway{
-		InternetGatewayID: *actual.InternetGatewayId,
+		InternetGatewayId: *actual.InternetGatewayId,
 		Tags:              convertTags(actual.Tags),
 	}
 

--- a/cmd/goplugin-aws/resource/route_table.go
+++ b/cmd/goplugin-aws/resource/route_table.go
@@ -9,9 +9,9 @@ import (
 
 // RouteTable is the managed resource
 type RouteTable struct {
-	VpcID           string
-	RouteTableID    string
-	SubnetID        string
+	VpcId           string
+	RouteTableId    string
+	SubnetId        string
 	Routes          []Route
 	Associations    []RouteTableAssociation
 	PropagatingVgws []PropagatingVgw
@@ -57,7 +57,7 @@ func (h *RouteTableHandler) Create(desired *RouteTable) (*RouteTable, string, er
 	client := newClient()
 	response, err := client.CreateRouteTable(
 		&ec2.CreateRouteTableInput{
-			VpcId: aws.String(desired.VpcID),
+			VpcId: aws.String(desired.VpcId),
 		})
 	if err != nil {
 		log.Debug("Error creating RouteTable", "error", err)
@@ -121,8 +121,8 @@ func (h *RouteTableHandler) Delete(externalID string) error {
 
 func (h *RouteTableHandler) fromAWS(desired *RouteTable, actual *ec2.RouteTable) *RouteTable {
 	routeTable := RouteTable{
-		VpcID:           *actual.VpcId,
-		RouteTableID:    *actual.RouteTableId,
+		VpcId:           *actual.VpcId,
+		RouteTableId:    *actual.RouteTableId,
 		Tags:            convertTags(actual.Tags),
 		Associations:    convertAssociations(actual.Associations),
 		PropagatingVgws: convertPropagatingVgws(actual.PropagatingVgws),

--- a/cmd/goplugin-aws/resource/shared.go
+++ b/cmd/goplugin-aws/resource/shared.go
@@ -35,7 +35,8 @@ func newClient() *ec2.EC2 {
 }
 
 func tagResource(client ec2.EC2, tags map[string]string, resourceIds ...*string) error {
-	if len(resourceIds) == 0 {
+	if len(resourceIds) == 0 || tags == nil || len(tags) == 0 {
+		log.Debug("Nothing to tag", "resourceIds", resourceIds, "tags", tags)
 		return nil
 	}
 	awsTags := []*ec2.Tag{}
@@ -48,6 +49,9 @@ func tagResource(client ec2.EC2, tags map[string]string, resourceIds ...*string)
 			DryRun:    aws.Bool(false),
 			Tags:      awsTags,
 		})
+	if err != nil {
+		log.Debug("Error tagging", "error", err, "resourceIds", resourceIds, "tags", tags, "awsTags", awsTags)
+	}
 	return err
 }
 

--- a/cmd/goplugin-aws/resource/subnet.go
+++ b/cmd/goplugin-aws/resource/subnet.go
@@ -7,17 +7,17 @@ import (
 
 // Subnet is the managed resource
 type Subnet struct {
-	VpcID                       string // TODO what TypeDef is required to make this a property (required on present, optional on absent)
+	VpcId                       string // TODO what TypeDef is required to make this a property (required on present, optional on absent)
 	CidrBlock                   string
 	AvailabilityZone            string
 	Ipv6CidrBlock               string
 	Tags                        map[string]string
 	AssignIpv6AddressOnCreation bool
-	MapPublicIPOnLaunch         bool
-	AvailableIPAddressCount     int64
+	MapPublicIpOnLaunch         bool
+	AvailableIpAddressCount     int64
 	DefaultForAz                bool
 	State                       string
-	SubnetID                    string
+	SubnetId                    string
 }
 
 //SubnetHandler creates, reads and deletes the Subnet Resource
@@ -30,7 +30,7 @@ func (h *SubnetHandler) Create(desired *Subnet) (*Subnet, string, error) {
 	response, err := client.CreateSubnet(
 		&ec2.CreateSubnetInput{
 			CidrBlock: aws.String(desired.CidrBlock),
-			VpcId:     aws.String(desired.VpcID),
+			VpcId:     aws.String(desired.VpcId),
 		})
 	if err != nil {
 		log.Debug("Error creating Subnet", "error", err)
@@ -95,16 +95,16 @@ func (h *SubnetHandler) Delete(externalID string) error {
 
 func (h *SubnetHandler) fromAWS(desired *Subnet, actual *ec2.Subnet) *Subnet {
 	subnet := &Subnet{
-		VpcID:            *actual.VpcId,
+		VpcId:            *actual.VpcId,
 		CidrBlock:        *actual.CidrBlock,
 		AvailabilityZone: *actual.AvailabilityZone,
 
 		Tags:                        convertTags(actual.Tags),
 		AssignIpv6AddressOnCreation: desired.AssignIpv6AddressOnCreation, // TODO DescribeSubnetAttribute
-		MapPublicIPOnLaunch:         desired.MapPublicIPOnLaunch,         // TODO DescribeSubnetAttribute
-		AvailableIPAddressCount:     *actual.AvailableIpAddressCount,
+		MapPublicIpOnLaunch:         desired.MapPublicIpOnLaunch,         // TODO DescribeSubnetAttribute
+		AvailableIpAddressCount:     *actual.AvailableIpAddressCount,
 		DefaultForAz:                *actual.DefaultForAz,
-		SubnetID:                    *actual.SubnetId,
+		SubnetId:                    *actual.SubnetId,
 		State:                       *actual.State,
 	}
 

--- a/cmd/goplugin-aws/resource/vpc.go
+++ b/cmd/goplugin-aws/resource/vpc.go
@@ -5,26 +5,25 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-// VPC is the managed resource
-type VPC struct {
+// Vpc is the managed resource
+type Vpc struct {
 	AmazonProvidedIpv6CidrBlock bool
 	CidrBlock                   string
 	InstanceTenancy             string
-	EnableDNSHostnames          bool
-	EnableDNSSupport            bool
+	EnableDnsHostnames          bool
+	EnableDnsSupport            bool
 	Tags                        map[string]string
-	VpcID                       string
+	VpcId                       string
 	IsDefault                   bool
 	State                       string
-	DhcpOptionsID               string
-	// CidrBlockAssociationSet not supported
+	DhcpOptionsId               string
 }
 
 //VPCHandler creates, reads and deletes the VPC Resource
 type VPCHandler struct{}
 
 // Create a VPC
-func (h *VPCHandler) Create(desired *VPC) (*VPC, string, error) {
+func (h *VPCHandler) Create(desired *Vpc) (*Vpc, string, error) {
 	log.Debug("Creating VPC", "desired", desired)
 	client := newClient()
 	response, err := client.CreateVpc(
@@ -57,7 +56,7 @@ func (h *VPCHandler) Create(desired *VPC) (*VPC, string, error) {
 }
 
 // Read a VPC
-func (h *VPCHandler) Read(externalID string) (*VPC, error) {
+func (h *VPCHandler) Read(externalID string) (*Vpc, error) {
 	log.Debug("Reading VPC", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeVpcs(
@@ -73,7 +72,7 @@ func (h *VPCHandler) Read(externalID string) (*VPC, error) {
 	if len(response.Vpcs) > 1 {
 		log.Error("Expected to find one VPC but found more.  Returning the first one anyway", "externalID", externalID, "count", len(response.Vpcs))
 	}
-	actual := h.fromAWS(&VPC{}, response.Vpcs[0])
+	actual := h.fromAWS(&Vpc{}, response.Vpcs[0])
 	log.Debug("Completed VPC read", "actual", actual)
 	return actual, nil
 }
@@ -94,17 +93,17 @@ func (h *VPCHandler) Delete(externalID string) error {
 	return err
 }
 
-func (h *VPCHandler) fromAWS(wanted *VPC, actual *ec2.Vpc) *VPC {
-	return &VPC{
+func (h *VPCHandler) fromAWS(wanted *Vpc, actual *ec2.Vpc) *Vpc {
+	return &Vpc{
 		AmazonProvidedIpv6CidrBlock: wanted.AmazonProvidedIpv6CidrBlock, // TODO look at (s *AssociateSubnetCidrBlockInput) Validate()
-		EnableDNSHostnames:          wanted.EnableDNSHostnames,          // TODO DescribeVpcAttribute
-		EnableDNSSupport:            wanted.EnableDNSSupport,            // TODO DescribeVpcAttribute
+		EnableDnsHostnames:          wanted.EnableDnsHostnames,          // TODO DescribeVpcAttribute
+		EnableDnsSupport:            wanted.EnableDnsSupport,            // TODO DescribeVpcAttribute
 		CidrBlock:                   *actual.CidrBlock,
 		InstanceTenancy:             *actual.InstanceTenancy,
 		Tags:                        convertTags(actual.Tags),
-		VpcID:                       *actual.VpcId,
+		VpcId:                       *actual.VpcId,
 		IsDefault:                   *actual.IsDefault,
 		State:                       *actual.State,
-		DhcpOptionsID:               *actual.DhcpOptionsId,
+		DhcpOptionsId:               *actual.DhcpOptionsId,
 	}
 }


### PR DESCRIPTION
* Rename fields in AWS types away from golint preferred common initialisms to work better with evaluator (subnetId rather than subnetID)
* Register subnet type and handler
* Better error handling and logging of tagging logic.