### PR TITLE
(GEN-154) Ensure that hclog.Default is configured and used.

### DIFF
--- a/3RDPARTY_LICENSES.txt
+++ b/3RDPARTY_LICENSES.txt
@@ -1,59 +1,24 @@
-github.com/lyraproj/lyra/vendor/github.com/aws/aws-sdk-go                             Apache License 2.0
-github.com/lyraproj/lyra/vendor/github.com/bmatcuk/doublestar                         MIT License
-github.com/lyraproj/lyra/vendor/github.com/boltdb/bolt                                MIT License
-github.com/lyraproj/lyra/vendor/github.com/golang/protobuf                            BSD 3-clause "New" or "Revised" License (96%)
-github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-hclog                         MIT License
-github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-plugin                        Mozilla Public License 2.0
-github.com/lyraproj/lyra/vendor/github.com/hashicorp/yamux                            Mozilla Public License 2.0
-github.com/lyraproj/lyra/vendor/github.com/jmespath/go-jmespath                       ? (The Unlicense, 35%)
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/data-protobuf/datapb              ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/hiera/config                      ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/hiera/functions                   ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/hiera/impl                        ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/hiera/lookup                      ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/hiera/provider                    ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/issue/issue                       ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/errors           ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/eval             ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/functions        ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/hash             ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/impl             ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/loader           ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/pcore            ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/proto            ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/serialization    ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/threadlocal      ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/types            ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-evaluator/utils            ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-parser/literal             ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-parser/parser              ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-parser/pn                  ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-parser/validator           ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-workflow/puppet            ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/puppet-workflow/puppet/functions  ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/semver/semver                     ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/condition              ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/grpc                   ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/service                ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/serviceapi             ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/servicepb              ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/wf                     ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/servicesdk/wfapi                  ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/wfe/api                           ?
-github.com/lyraproj/lyra/vendor/github.com/lyraproj/wfe/wfe                           ?
-github.com/lyraproj/lyra/vendor/github.com/mattn/go-colorable                         MIT License
-github.com/lyraproj/lyra/vendor/github.com/mattn/go-isatty                            MIT License (95%)
-github.com/lyraproj/lyra/vendor/github.com/mgutz/ansi                                 MIT License
-github.com/lyraproj/lyra/vendor/github.com/mitchellh/go-testing-interface             MIT License
-github.com/lyraproj/lyra/vendor/github.com/oklog/run                                  Apache License 2.0
-github.com/lyraproj/lyra/vendor/github.com/spf13/cobra                                Apache License 2.0 (95%)
-github.com/lyraproj/lyra/vendor/github.com/spf13/pflag                                BSD 3-clause "New" or "Revised" License (96%)
-github.com/lyraproj/lyra/vendor/github.com/toqueteos/trie                             MIT License
-github.com/lyraproj/lyra/vendor/golang.org/x/net                                      BSD 3-clause "New" or "Revised" License (96%)
-github.com/lyraproj/lyra/vendor/golang.org/x/text                                     BSD 3-clause "New" or "Revised" License (96%)
-github.com/lyraproj/lyra/vendor/gonum.org/v1/gonum                                    BSD 3-clause "New" or "Revised" License (97%)
-github.com/lyraproj/lyra/vendor/google.golang.org/genproto/googleapis/rpc/status      Apache License 2.0
-github.com/lyraproj/lyra/vendor/google.golang.org/grpc                                Apache License 2.0
-github.com/lyraproj/lyra/vendor/gopkg.in/src-d/enry.v1                                Apache License 2.0
-github.com/lyraproj/lyra/vendor/gopkg.in/toqueteos/substring.v1                       MIT License
-github.com/lyraproj/lyra/vendor/gopkg.in/yaml.v2                                      Apache License 2.0
+github.com/lyraproj/lyra/vendor/github.com/aws/aws-sdk-go                         Apache License 2.0
+github.com/lyraproj/lyra/vendor/github.com/bmatcuk/doublestar                     MIT License
+github.com/lyraproj/lyra/vendor/github.com/boltdb/bolt                            MIT License
+github.com/lyraproj/lyra/vendor/github.com/golang/protobuf                        BSD 3-clause "New" or "Revised" License (96%)
+github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-hclog                     MIT License
+github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-plugin                    Mozilla Public License 2.0
+github.com/lyraproj/lyra/vendor/github.com/hashicorp/yamux                        Mozilla Public License 2.0
+github.com/lyraproj/lyra/vendor/github.com/jmespath/go-jmespath                   ? (The Unlicense, 35%)
+github.com/lyraproj/lyra/vendor/github.com/mattn/go-colorable                     MIT License
+github.com/lyraproj/lyra/vendor/github.com/mattn/go-isatty                        MIT License (95%)
+github.com/lyraproj/lyra/vendor/github.com/mgutz/ansi                             MIT License
+github.com/lyraproj/lyra/vendor/github.com/mitchellh/go-testing-interface         MIT License
+github.com/lyraproj/lyra/vendor/github.com/oklog/run                              Apache License 2.0
+github.com/lyraproj/lyra/vendor/github.com/spf13/cobra                            Apache License 2.0 (95%)
+github.com/lyraproj/lyra/vendor/github.com/spf13/pflag                            BSD 3-clause "New" or "Revised" License (96%)
+github.com/lyraproj/lyra/vendor/github.com/toqueteos/trie                         MIT License
+github.com/lyraproj/lyra/vendor/golang.org/x/net                                  BSD 3-clause "New" or "Revised" License (96%)
+github.com/lyraproj/lyra/vendor/golang.org/x/text                                 BSD 3-clause "New" or "Revised" License (96%)
+github.com/lyraproj/lyra/vendor/gonum.org/v1/gonum                                BSD 3-clause "New" or "Revised" License (97%)
+github.com/lyraproj/lyra/vendor/google.golang.org/genproto/googleapis/rpc/status  Apache License 2.0
+github.com/lyraproj/lyra/vendor/google.golang.org/grpc                            Apache License 2.0
+github.com/lyraproj/lyra/vendor/gopkg.in/src-d/enry.v1                            Apache License 2.0
+github.com/lyraproj/lyra/vendor/gopkg.in/toqueteos/substring.v1                   MIT License
+github.com/lyraproj/lyra/vendor/gopkg.in/yaml.v2                                  Apache License 2.0

--- a/cmd/goplugin-aws/resource/instance.go
+++ b/cmd/goplugin-aws/resource/instance.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -26,6 +27,7 @@ type InstanceHandler struct{}
 
 // Create Instance
 func (h *InstanceHandler) Create(desired *Instance) (*Instance, string, error) {
+	log := hclog.Default()
 	log.Debug("Creating Instance", "desired", desired)
 	client := newClient()
 	response, err := client.RunInstances(runInstancesInput(*desired))
@@ -55,6 +57,7 @@ func (h *InstanceHandler) Create(desired *Instance) (*Instance, string, error) {
 
 // Read Instance
 func (h *InstanceHandler) Read(externalID string) (*Instance, error) {
+	log := hclog.Default()
 	log.Debug("Reading Instance", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeInstances(
@@ -90,6 +93,7 @@ func (h *InstanceHandler) Read(externalID string) (*Instance, error) {
 
 // Delete Instance
 func (h *InstanceHandler) Delete(externalID string) error {
+	log := hclog.Default()
 	log.Debug("Deleting Instance", "externalID", externalID)
 	client := newClient()
 

--- a/cmd/goplugin-aws/resource/internet_gateway.go
+++ b/cmd/goplugin-aws/resource/internet_gateway.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-hclog"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -30,6 +31,7 @@ type InternetGatewayHandler struct{}
 
 // Create a InternetGateway
 func (h *InternetGatewayHandler) Create(desired *InternetGateway) (*InternetGateway, string, error) {
+	log := hclog.Default()
 	log.Debug("Creating InternetGateway", "desired", desired)
 	client := newClient()
 	response, err := client.CreateInternetGateway(
@@ -60,6 +62,7 @@ func (h *InternetGatewayHandler) Create(desired *InternetGateway) (*InternetGate
 
 // Read a InternetGateway
 func (h *InternetGatewayHandler) Read(externalID string) (*InternetGateway, error) {
+	log := hclog.Default()
 	log.Debug("Reading InternetGateway", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeInternetGateways(
@@ -82,6 +85,7 @@ func (h *InternetGatewayHandler) Read(externalID string) (*InternetGateway, erro
 
 // Delete a InternetGateway
 func (h *InternetGatewayHandler) Delete(externalID string) error {
+	log := hclog.Default()
 	log.Debug("Deleting InternetGateway", "externalID", externalID)
 	client := newClient()
 	_, err := client.DeleteInternetGateway(
@@ -118,6 +122,7 @@ func (h *InternetGatewayHandler) fromAWS(wanted *InternetGateway, actual *ec2.In
 }
 
 func waitForInternetGateway(client *ec2.EC2, externalID string) error {
+	log := hclog.Default()
 	log.Debug("Polling for internet gateway")
 	return poll(func() (bool, error) {
 		response, err := client.DescribeInternetGateways(

--- a/cmd/goplugin-aws/resource/keypair.go
+++ b/cmd/goplugin-aws/resource/keypair.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -18,6 +19,7 @@ type KeyPairHandler struct{}
 
 // Create a KeyPair
 func (h *KeyPairHandler) Create(desired *KeyPair) (*KeyPair, string, error) {
+	log := hclog.Default()
 	log.Debug("Creating KeyPair", "desired", desired)
 	client := newClient()
 	response, err := client.ImportKeyPair(
@@ -51,6 +53,7 @@ func (h *KeyPairHandler) Create(desired *KeyPair) (*KeyPair, string, error) {
 
 // Read a KeyPair
 func (h *KeyPairHandler) Read(externalID string) (*KeyPair, error) {
+	log := hclog.Default()
 	log.Debug("Reading KeyPair", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeKeyPairs(
@@ -80,6 +83,7 @@ func (h *KeyPairHandler) Read(externalID string) (*KeyPair, error) {
 
 // Delete a KeyPair
 func (h *KeyPairHandler) Delete(externalID string) error {
+	log := hclog.Default()
 	log.Debug("Deleting KeyPair", "externalID", externalID)
 	client := newClient()
 	_, err := client.DeleteKeyPair(

--- a/cmd/goplugin-aws/resource/route_table.go
+++ b/cmd/goplugin-aws/resource/route_table.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -53,6 +54,7 @@ type RouteTableHandler struct{}
 
 // Create a RouteTable
 func (h *RouteTableHandler) Create(desired *RouteTable) (*RouteTable, string, error) {
+	log := hclog.Default()
 	log.Debug("Creating RouteTable", "desired", desired)
 	client := newClient()
 	response, err := client.CreateRouteTable(
@@ -81,6 +83,7 @@ func (h *RouteTableHandler) Create(desired *RouteTable) (*RouteTable, string, er
 
 // Read a RouteTable
 func (h *RouteTableHandler) Read(externalID string) (*RouteTable, error) {
+	log := hclog.Default()
 	log.Debug("Reading RouteTable", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeRouteTables(
@@ -103,6 +106,7 @@ func (h *RouteTableHandler) Read(externalID string) (*RouteTable, error) {
 
 // Delete a RouteTable
 func (h *RouteTableHandler) Delete(externalID string) error {
+	log := hclog.Default()
 	log.Debug("Deleting RouteTable", "externalID", externalID)
 	client := newClient()
 
@@ -187,6 +191,7 @@ func convertRoutes(ec2Routes []*ec2.Route) []Route {
 }
 
 func waitForRouteTable(client *ec2.EC2, externalID string) error {
+	log := hclog.Default()
 	log.Debug("Polling for route table")
 	return poll(func() (bool, error) {
 		response, err := client.DescribeRouteTables(

--- a/cmd/goplugin-aws/resource/shared.go
+++ b/cmd/goplugin-aws/resource/shared.go
@@ -16,8 +16,6 @@ const (
 	logicalIDTag = "lyra-logical-id"
 )
 
-var log = hclog.Default()
-
 // newClient() creates a new ec2 client
 func newClient() *ec2.EC2 {
 	config := aws.NewConfig().
@@ -36,7 +34,7 @@ func newClient() *ec2.EC2 {
 
 func tagResource(client ec2.EC2, tags map[string]string, resourceIds ...*string) error {
 	if len(resourceIds) == 0 || tags == nil || len(tags) == 0 {
-		log.Debug("Nothing to tag", "resourceIds", resourceIds, "tags", tags)
+		hclog.Default().Debug("Nothing to tag", "resourceIds", resourceIds, "tags", tags)
 		return nil
 	}
 	awsTags := []*ec2.Tag{}
@@ -50,7 +48,7 @@ func tagResource(client ec2.EC2, tags map[string]string, resourceIds ...*string)
 			Tags:      awsTags,
 		})
 	if err != nil {
-		log.Debug("Error tagging", "error", err, "resourceIds", resourceIds, "tags", tags, "awsTags", awsTags)
+		hclog.Default().Debug("Error tagging", "error", err, "resourceIds", resourceIds, "tags", tags, "awsTags", awsTags)
 	}
 	return err
 }
@@ -74,7 +72,7 @@ func pollWithoutDefaults(backoff time.Duration, retries int32, fn func() (bool, 
 		}
 		jitter := time.Duration(rand.Int63n(int64(backoff)))
 		backoff = 2 * (backoff + jitter/2)
-		log.Debug("...waiting", "duration", backoff.String())
+		hclog.Default().Debug("...waiting", "duration", backoff.String())
 		time.Sleep(backoff)
 	}
 	return errors.New("polling exhausted retries")

--- a/cmd/goplugin-aws/resource/subnet.go
+++ b/cmd/goplugin-aws/resource/subnet.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/go-hclog"
 )
 
 // Subnet is the managed resource
@@ -25,6 +26,7 @@ type SubnetHandler struct{}
 
 // Create a Subnet
 func (h *SubnetHandler) Create(desired *Subnet) (*Subnet, string, error) {
+	log := hclog.Default()
 	log.Debug("Creating Subnet", "desired", desired)
 	client := newClient()
 	response, err := client.CreateSubnet(
@@ -57,6 +59,7 @@ func (h *SubnetHandler) Create(desired *Subnet) (*Subnet, string, error) {
 
 // Read a Subnet
 func (h *SubnetHandler) Read(externalID string) (*Subnet, error) {
+	log := hclog.Default()
 	log.Debug("Reading Subnet", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeSubnets(
@@ -79,6 +82,7 @@ func (h *SubnetHandler) Read(externalID string) (*Subnet, error) {
 
 // Delete a Subnet
 func (h *SubnetHandler) Delete(externalID string) error {
+	log := hclog.Default()
 	log.Debug("Deleting Subnet", "externalID", externalID)
 	client := newClient()
 	_, err := client.DeleteSubnet(

--- a/cmd/goplugin-aws/resource/vpc.go
+++ b/cmd/goplugin-aws/resource/vpc.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/go-hclog"
 )
 
 // Vpc is the managed resource
@@ -24,6 +25,7 @@ type VPCHandler struct{}
 
 // Create a VPC
 func (h *VPCHandler) Create(desired *Vpc) (*Vpc, string, error) {
+	log := hclog.Default()
 	log.Debug("Creating VPC", "desired", desired)
 	client := newClient()
 	response, err := client.CreateVpc(
@@ -57,6 +59,7 @@ func (h *VPCHandler) Create(desired *Vpc) (*Vpc, string, error) {
 
 // Read a VPC
 func (h *VPCHandler) Read(externalID string) (*Vpc, error) {
+	log := hclog.Default()
 	log.Debug("Reading VPC", "externalID", externalID)
 	client := newClient()
 	response, err := client.DescribeVpcs(
@@ -79,6 +82,7 @@ func (h *VPCHandler) Read(externalID string) (*Vpc, error) {
 
 // Delete a VPC
 func (h *VPCHandler) Delete(externalID string) error {
+	log := hclog.Default()
 	log.Debug("Deleting VPC", "externalID", externalID)
 	client := newClient()
 	_, err := client.DeleteVpc(

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -31,19 +31,19 @@ func Get() hclog.Logger {
 // Initialise the Logger
 func Initialise(spec Spec) hclog.Logger {
 	once.Do(func() {
-		loggerOptions := &hclog.LoggerOptions{
+		hclog.DefaultOptions = &hclog.LoggerOptions{
 			Name:            spec.Name,
 			Level:           hclog.Level(logsDisabled),
 			JSONFormat:      spec.JSON,
 			IncludeLocation: spec.IncludeLocation,
 		}
 		if len(spec.Level) > 0 {
-			loggerOptions.Level = hclog.LevelFromString(spec.Level)
+			hclog.DefaultOptions.Level = hclog.LevelFromString(spec.Level)
 		}
 		if spec.Output != nil {
-			loggerOptions.Output = spec.Output
+			hclog.DefaultOptions.Output = spec.Output
 		}
-		l := hclog.New(loggerOptions)
+		l := hclog.Default()
 		logger = l
 	})
 	return logger


### PR DESCRIPTION
This commit ensures that hclog.DefaultOptions is configured, both for
lyra and its embedded plug-ins.

The commit also removes a global `log` variable since initialization
of it causes a premature instantiation of the Default logger which in
turn makes impossible to subsequently configure it. Changing the
DefaultOptions has no effect once the Default logger has been retrieved.