### PR TITLE
(maint) Ensure that error from bolt DB is propagated correctly

### DIFF
--- a/cmd/goplugin-identity/identity/identity.go
+++ b/cmd/goplugin-identity/identity/identity.go
@@ -32,11 +32,10 @@ type tuple struct {
 }
 
 type storeMeta struct {
-	Version    string
-	Timestamp  time.Time
-	Era        int64
+	Version   string
+	Timestamp time.Time
+	Era       int64
 }
-
 
 // error used internally by the identity service
 type identityError string
@@ -411,7 +410,8 @@ func (i *Identity) withDb(df func(*bolt.DB) error) (err error) {
 			} else {
 				panic(e)
 			}
-		} else {
+		} else if err == nil {
+			// Propagate error from Close, if any
 			err = e2
 		}
 	}()


### PR DESCRIPTION
A mistake in the Identity.withDb function caused errors returned by
the provided function to disappear. This commit ensures that they are
propagated correctly.