### PR TITLE
Map incoming hiera data as dot-separated hierarchy

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -43,11 +43,11 @@ func (a *Applicator) ApplyWorkflowWithHieraData(workflowName string, hieraData m
 }
 
 func (a *Applicator) applyWithHieraData(workflowName string, hieraData map[string]string, intent wfapi.Operation) {
+	m := convertToDeepMap(hieraData)
+	hclog.Default().Debug("converted map to hiera data", "m", m)
+	v := eval.Wrap(nil, m).(eval.OrderedMap)
 	tp := func(ic lookup.ProviderContext, key string, _ map[string]eval.Value) (eval.Value, bool) {
-		m := convertToDeepMap(hieraData)
-		hclog.Default().Debug("converted map to hiera data", "m", m)
-		v := eval.Wrap(nil, m).(eval.OrderedMap)
-		return v, true
+		return v.Get4(key)
 	}
 	lookup.DoWithParent(context.Background(), tp, nil, applyWithContext(workflowName, intent))
 }

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -1,0 +1,30 @@
+package apply
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConvertToDeepMap(t *testing.T) {
+	m := make(map[string]string)
+	m["aws.tags.created_by"] = "person@company.com"
+	m["aws.tags.lifetime"] = "2hrs"
+	m["aws.hello"] = "hi"
+	actual := convertToDeepMap(m)
+	fmt.Println(actual)
+	require.Contains(t, actual, "aws")
+	aws := actual["aws"].(map[string]interface{})
+	require.NotNil(t, aws)
+	require.Contains(t, aws, "hello")
+	require.Equal(t, "hi", aws["hello"])
+	require.Contains(t, aws, "tags")
+	tags := aws["tags"].(map[string]interface{})
+	require.NotNil(t, tags)
+	require.Contains(t, tags, "created_by")
+	require.Contains(t, tags, "lifetime")
+	createdBy := tags["created_by"].(string)
+	require.Equal(t, "person@company.com", createdBy)
+	lifetime := tags["lifetime"].(string)
+	require.Equal(t, "2hrs", lifetime)
+}


### PR DESCRIPTION
Parse out keys like `aws.tags.created_by` to create a deep map, converts to eval.OrderedMap and passes them to hiera

Closes #76