### PR TITLE
Use hiera data for tags, and populate from k8s CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ The project requires [Go](https://golang.org/doc/install) 1.11 or higher, and [g
 1. Run the binary with the [sample Workflow](plugins/aws_vpc_yaml.yaml): ` $ ./build/lyra apply aws_vpc_yaml --debug`
 2. Delete the Workflow (i.e. its resources), run ` $ ./build/lyra delete aws_vpc_yaml --debug`.  
 
-This workflow is an AWS Workflow called `aws_vpc_yaml` in `plugins\aws_vpc_yaml.yaml`. This will use the default AWS credentials configured in your `~/.aws/credentials`. 
+This workflow is an AWS Workflow called `aws_vpc_yaml` in `plugins\aws_vpc_yaml.yaml`.  Tag data (loaded [here](plugins/aws_vpc_yaml.yaml#L6) by [hiera](https://github.com/lyraproj/hiera)) is specified in the [the data.yaml file](data.yaml) file.  This workflow will use the default AWS credentials configured in your `~/.aws/credentials`.
 
 For the examples using Terraform providers (e.g. `typespace=>'TerraformAws'`), region is currently hard-coded to `eu-west-1`. For non-Terraform providers (e.g. `typespace=>'aws'`), Lyra will use the default region supplied in your `~/.aws/config`. 
-
 
 ### Deploying Workflows with Kubernetes
 
@@ -49,6 +48,8 @@ For the examples using Terraform providers (e.g. `typespace=>'TerraformAws'`), r
 3. Create a Workflow resource: `$ kubectl apply -f k8s/aws_vpc.yaml`
 4. Inspect the resource: `$ kubectl get workflows` 
 5. Delete the Workflow (i.e. its resources): `$ kubectl delete workflow vpc-workflow`
+
+Tag data (loaded [here](plugins/aws_vpc_yaml.yaml#L6) by [hiera](https://github.com/lyraproj/hiera)) for kubernetes workflows is specified in [the data section of the k8s/aws_vpc.yaml file](k8s/vpc-workflow.yaml#L8-L12).
 
 ## Project Status
 Very much in early development. Lyra is just starting and things are a bit bumpy! Star this project above to stay tuned.

--- a/k8s/vpc-workflow.yaml
+++ b/k8s/vpc-workflow.yaml
@@ -3,5 +3,10 @@ kind: Workflow
 metadata:
   name: vpc-workflow
 spec:
-  workflowName: "aws_vpc_yaml"
+  workflowName: aws_vpc_yaml
   refreshTime: 65
+  data:
+    aws.tags.Name:       lyra-crd-sample
+    aws.tags.created_by: lyra-crd
+    aws.tags.project:    lyraproj
+    aws.tags.lifetime:   2h

--- a/plugins/aws_vpc_yaml.yaml
+++ b/plugins/aws_vpc_yaml.yaml
@@ -1,5 +1,9 @@
 aws_vpc_yaml:
   typespace: aws
+  input:
+    tags:
+      type: Hash[String,String]
+      lookup: aws.tags  
   output:
     vpc_id: String
     subnet_id: String
@@ -13,18 +17,14 @@ aws_vpc_yaml:
         enable_dns_support: false
         is_default: false
         state: available
-        tags:
-          name: lyra-sample-vpc
-          created_by: lyra
+        tags: $tags
     subnet:
       output: subnet_id
       state:
         vpc_id: $vpc_id
         cidr_block: 192.168.1.0/24
         ipv6_cidr_block: ''
-        tags: 
-          name: lyra-sample-vpc
-          created_by: lyra
+        tags: $tags
         assign_ipv6_address_on_creation: false
         map_public_ip_on_launch: false
         default_for_az: false


### PR DESCRIPTION
This commit uses hiera data for aws tags in plugins/aws_vpc_yaml.yaml and populates that hiera data in k8s/vpc-workflow.yaml