### PR TITLE
TF generation fixes for arrays/IDs

### DIFF
--- a/cmd/goplugin-tf-aws/generated/generated.go
+++ b/cmd/goplugin-tf-aws/generated/generated.go
@@ -956,8 +956,6 @@ func Initialize(sb *service.ServerBuilder, p *schema.Provider) {
 
 type Aws_acm_certificate_domain_validation_options_1 struct {
 
-    Aws_acm_certificate_domain_validation_options_1_id *string `lyra:"ignore"`
-
     Domain_name *string
 
     Resource_record_name *string
@@ -980,7 +978,7 @@ type Aws_acm_certificate struct {
 
     Domain_name *string
 
-    Domain_validation_options *Aws_acm_certificate_domain_validation_options_1
+    Domain_validation_options *[]Aws_acm_certificate_domain_validation_options_1
 
     Private_key *string
 
@@ -1080,8 +1078,6 @@ func (h *Aws_acm_certificate_validationHandler) Delete(externalID string) error 
 
 type Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3 struct {
 
-    Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3_id *string `lyra:"ignore"`
-
     Common_name *string
 
     Country *string
@@ -1112,19 +1108,15 @@ type Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subj
 
 type Aws_acmpca_certificate_authority_certificate_authority_configuration_2 struct {
 
-    Aws_acmpca_certificate_authority_certificate_authority_configuration_2_id *string `lyra:"ignore"`
-
     Key_algorithm string
 
     Signing_algorithm string
 
-    Subject Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3
+    Subject []Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3
 
 }
 
 type Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5 struct {
-
-    Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5_id *string `lyra:"ignore"`
 
     Custom_cname *string
 
@@ -1138,9 +1130,7 @@ type Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configurati
 
 type Aws_acmpca_certificate_authority_revocation_configuration_4 struct {
 
-    Aws_acmpca_certificate_authority_revocation_configuration_4_id *string `lyra:"ignore"`
-
-    Crl_configuration *Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5
+    Crl_configuration *[]Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5
 
 }
 
@@ -1152,7 +1142,7 @@ type Aws_acmpca_certificate_authority struct {
 
     Certificate *string
 
-    Certificate_authority_configuration Aws_acmpca_certificate_authority_certificate_authority_configuration_2
+    Certificate_authority_configuration []Aws_acmpca_certificate_authority_certificate_authority_configuration_2
 
     Certificate_chain *string
 
@@ -1164,7 +1154,7 @@ type Aws_acmpca_certificate_authority struct {
 
     Not_before *string
 
-    Revocation_configuration *Aws_acmpca_certificate_authority_revocation_configuration_4
+    Revocation_configuration *[]Aws_acmpca_certificate_authority_revocation_configuration_4
 
     Serial *string
 
@@ -1215,8 +1205,6 @@ func (h *Aws_acmpca_certificate_authorityHandler) Delete(externalID string) erro
 
 type Aws_alb_access_logs_6 struct {
 
-    Aws_alb_access_logs_6_id *string `lyra:"ignore"`
-
     Bucket string
 
     Enabled *bool
@@ -1226,8 +1214,6 @@ type Aws_alb_access_logs_6 struct {
 }
 
 type Aws_alb_subnet_mapping_7 struct {
-
-    Aws_alb_subnet_mapping_7_id *string `lyra:"ignore"`
 
     Allocation_id *string
 
@@ -1239,7 +1225,7 @@ type Aws_alb struct {
 
     Aws_alb_id *string `lyra:"ignore"`
 
-    Access_logs *Aws_alb_access_logs_6
+    Access_logs *[]Aws_alb_access_logs_6
 
     Arn *string
 
@@ -1318,8 +1304,6 @@ func (h *Aws_albHandler) Delete(externalID string) error {
 
 type Aws_alb_listener_default_action_8_authenticate_cognito_9 struct {
 
-    Aws_alb_listener_default_action_8_authenticate_cognito_9_id *string `lyra:"ignore"`
-
     Authentication_request_extra_params *map[string]string
 
     On_unauthenticated_request *string
@@ -1339,8 +1323,6 @@ type Aws_alb_listener_default_action_8_authenticate_cognito_9 struct {
 }
 
 type Aws_alb_listener_default_action_8_authenticate_oidc_10 struct {
-
-    Aws_alb_listener_default_action_8_authenticate_oidc_10_id *string `lyra:"ignore"`
 
     Authentication_request_extra_params *map[string]string
 
@@ -1368,8 +1350,6 @@ type Aws_alb_listener_default_action_8_authenticate_oidc_10 struct {
 
 type Aws_alb_listener_default_action_8_fixed_response_11 struct {
 
-    Aws_alb_listener_default_action_8_fixed_response_11_id *string `lyra:"ignore"`
-
     Content_type string
 
     Message_body *string
@@ -1379,8 +1359,6 @@ type Aws_alb_listener_default_action_8_fixed_response_11 struct {
 }
 
 type Aws_alb_listener_default_action_8_redirect_12 struct {
-
-    Aws_alb_listener_default_action_8_redirect_12_id *string `lyra:"ignore"`
 
     Host *string
 
@@ -1398,17 +1376,15 @@ type Aws_alb_listener_default_action_8_redirect_12 struct {
 
 type Aws_alb_listener_default_action_8 struct {
 
-    Aws_alb_listener_default_action_8_id *string `lyra:"ignore"`
+    Authenticate_cognito *[]Aws_alb_listener_default_action_8_authenticate_cognito_9
 
-    Authenticate_cognito *Aws_alb_listener_default_action_8_authenticate_cognito_9
+    Authenticate_oidc *[]Aws_alb_listener_default_action_8_authenticate_oidc_10
 
-    Authenticate_oidc *Aws_alb_listener_default_action_8_authenticate_oidc_10
-
-    Fixed_response *Aws_alb_listener_default_action_8_fixed_response_11
+    Fixed_response *[]Aws_alb_listener_default_action_8_fixed_response_11
 
     Order *int
 
-    Redirect *Aws_alb_listener_default_action_8_redirect_12
+    Redirect *[]Aws_alb_listener_default_action_8_redirect_12
 
     Target_group_arn *string
 
@@ -1424,7 +1400,7 @@ type Aws_alb_listener struct {
 
     Certificate_arn *string
 
-    Default_action Aws_alb_listener_default_action_8
+    Default_action []Aws_alb_listener_default_action_8
 
     Load_balancer_arn string
 
@@ -1522,8 +1498,6 @@ func (h *Aws_alb_listener_certificateHandler) Delete(externalID string) error {
 
 type Aws_alb_listener_rule_action_13_authenticate_cognito_14 struct {
 
-    Aws_alb_listener_rule_action_13_authenticate_cognito_14_id *string `lyra:"ignore"`
-
     Authentication_request_extra_params *map[string]string
 
     On_unauthenticated_request *string
@@ -1543,8 +1517,6 @@ type Aws_alb_listener_rule_action_13_authenticate_cognito_14 struct {
 }
 
 type Aws_alb_listener_rule_action_13_authenticate_oidc_15 struct {
-
-    Aws_alb_listener_rule_action_13_authenticate_oidc_15_id *string `lyra:"ignore"`
 
     Authentication_request_extra_params *map[string]string
 
@@ -1572,8 +1544,6 @@ type Aws_alb_listener_rule_action_13_authenticate_oidc_15 struct {
 
 type Aws_alb_listener_rule_action_13_fixed_response_16 struct {
 
-    Aws_alb_listener_rule_action_13_fixed_response_16_id *string `lyra:"ignore"`
-
     Content_type string
 
     Message_body *string
@@ -1583,8 +1553,6 @@ type Aws_alb_listener_rule_action_13_fixed_response_16 struct {
 }
 
 type Aws_alb_listener_rule_action_13_redirect_17 struct {
-
-    Aws_alb_listener_rule_action_13_redirect_17_id *string `lyra:"ignore"`
 
     Host *string
 
@@ -1602,17 +1570,15 @@ type Aws_alb_listener_rule_action_13_redirect_17 struct {
 
 type Aws_alb_listener_rule_action_13 struct {
 
-    Aws_alb_listener_rule_action_13_id *string `lyra:"ignore"`
+    Authenticate_cognito *[]Aws_alb_listener_rule_action_13_authenticate_cognito_14
 
-    Authenticate_cognito *Aws_alb_listener_rule_action_13_authenticate_cognito_14
+    Authenticate_oidc *[]Aws_alb_listener_rule_action_13_authenticate_oidc_15
 
-    Authenticate_oidc *Aws_alb_listener_rule_action_13_authenticate_oidc_15
-
-    Fixed_response *Aws_alb_listener_rule_action_13_fixed_response_16
+    Fixed_response *[]Aws_alb_listener_rule_action_13_fixed_response_16
 
     Order *int
 
-    Redirect *Aws_alb_listener_rule_action_13_redirect_17
+    Redirect *[]Aws_alb_listener_rule_action_13_redirect_17
 
     Target_group_arn *string
 
@@ -1621,8 +1587,6 @@ type Aws_alb_listener_rule_action_13 struct {
 }
 
 type Aws_alb_listener_rule_condition_18 struct {
-
-    Aws_alb_listener_rule_condition_18_id *string `lyra:"ignore"`
 
     Field *string
 
@@ -1634,7 +1598,7 @@ type Aws_alb_listener_rule struct {
 
     Aws_alb_listener_rule_id *string `lyra:"ignore"`
 
-    Action Aws_alb_listener_rule_action_13
+    Action []Aws_alb_listener_rule_action_13
 
     Arn *string
 
@@ -1685,8 +1649,6 @@ func (h *Aws_alb_listener_ruleHandler) Delete(externalID string) error {
 
 type Aws_alb_target_group_health_check_19 struct {
 
-    Aws_alb_target_group_health_check_19_id *string `lyra:"ignore"`
-
     Healthy_threshold *int
 
     Interval *int
@@ -1707,8 +1669,6 @@ type Aws_alb_target_group_health_check_19 struct {
 
 type Aws_alb_target_group_stickiness_20 struct {
 
-    Aws_alb_target_group_stickiness_20_id *string `lyra:"ignore"`
-
     Cookie_duration *int
 
     Enabled *bool
@@ -1727,7 +1687,7 @@ type Aws_alb_target_group struct {
 
     Deregistration_delay *int
 
-    Health_check *Aws_alb_target_group_health_check_19
+    Health_check *[]Aws_alb_target_group_health_check_19
 
     Name *string
 
@@ -1741,7 +1701,7 @@ type Aws_alb_target_group struct {
 
     Slow_start *int
 
-    Stickiness *Aws_alb_target_group_stickiness_20
+    Stickiness *[]Aws_alb_target_group_stickiness_20
 
     Tags *map[string]string
 
@@ -1841,8 +1801,6 @@ func (h *Aws_alb_target_group_attachmentHandler) Delete(externalID string) error
 
 type Aws_ami_ebs_block_device_21 struct {
 
-    Aws_ami_ebs_block_device_21_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_name string
@@ -1860,8 +1818,6 @@ type Aws_ami_ebs_block_device_21 struct {
 }
 
 type Aws_ami_ephemeral_block_device_22 struct {
-
-    Aws_ami_ephemeral_block_device_22_id *string `lyra:"ignore"`
 
     Device_name string
 
@@ -1944,8 +1900,6 @@ func (h *Aws_amiHandler) Delete(externalID string) error {
 
 type Aws_ami_copy_ebs_block_device_23 struct {
 
-    Aws_ami_copy_ebs_block_device_23_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_name *string
@@ -1963,8 +1917,6 @@ type Aws_ami_copy_ebs_block_device_23 struct {
 }
 
 type Aws_ami_copy_ephemeral_block_device_24 struct {
-
-    Aws_ami_copy_ephemeral_block_device_24_id *string `lyra:"ignore"`
 
     Device_name *string
 
@@ -2055,8 +2007,6 @@ func (h *Aws_ami_copyHandler) Delete(externalID string) error {
 
 type Aws_ami_from_instance_ebs_block_device_25 struct {
 
-    Aws_ami_from_instance_ebs_block_device_25_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_name *string
@@ -2074,8 +2024,6 @@ type Aws_ami_from_instance_ebs_block_device_25 struct {
 }
 
 type Aws_ami_from_instance_ephemeral_block_device_26 struct {
-
-    Aws_ami_from_instance_ephemeral_block_device_26_id *string `lyra:"ignore"`
 
     Device_name *string
 
@@ -2209,8 +2157,6 @@ func (h *Aws_ami_launch_permissionHandler) Delete(externalID string) error {
 
 type Aws_api_gateway_account_throttle_settings_27 struct {
 
-    Aws_api_gateway_account_throttle_settings_27_id *string `lyra:"ignore"`
-
     Burst_limit *int
 
     Rate_limit *float64
@@ -2223,7 +2169,7 @@ type Aws_api_gateway_account struct {
 
     Cloudwatch_role_arn *string
 
-    Throttle_settings *Aws_api_gateway_account_throttle_settings_27
+    Throttle_settings *[]Aws_api_gateway_account_throttle_settings_27
 
 }
 
@@ -2265,8 +2211,6 @@ func (h *Aws_api_gateway_accountHandler) Delete(externalID string) error {
 }
 
 type Aws_api_gateway_api_key_stage_key_28 struct {
-
-    Aws_api_gateway_api_key_stage_key_28_id *string `lyra:"ignore"`
 
     Rest_api_id string
 
@@ -2555,8 +2499,6 @@ func (h *Aws_api_gateway_deploymentHandler) Delete(externalID string) error {
 
 type Aws_api_gateway_documentation_part_location_29 struct {
 
-    Aws_api_gateway_documentation_part_location_29_id *string `lyra:"ignore"`
-
     Method *string
 
     Name *string
@@ -2573,7 +2515,7 @@ type Aws_api_gateway_documentation_part struct {
 
     Aws_api_gateway_documentation_part_id *string `lyra:"ignore"`
 
-    Location Aws_api_gateway_documentation_part_location_29
+    Location []Aws_api_gateway_documentation_part_location_29
 
     Properties string
 
@@ -2669,8 +2611,6 @@ func (h *Aws_api_gateway_documentation_versionHandler) Delete(externalID string)
 
 type Aws_api_gateway_domain_name_endpoint_configuration_30 struct {
 
-    Aws_api_gateway_domain_name_endpoint_configuration_30_id *string `lyra:"ignore"`
-
     Types []string
 
 }
@@ -2697,7 +2637,7 @@ type Aws_api_gateway_domain_name struct {
 
     Domain_name string
 
-    Endpoint_configuration *Aws_api_gateway_domain_name_endpoint_configuration_30
+    Endpoint_configuration *[]Aws_api_gateway_domain_name_endpoint_configuration_30
 
     Regional_certificate_arn *string
 
@@ -3061,8 +3001,6 @@ func (h *Aws_api_gateway_method_responseHandler) Delete(externalID string) error
 
 type Aws_api_gateway_method_settings_settings_31 struct {
 
-    Aws_api_gateway_method_settings_settings_31_id *string `lyra:"ignore"`
-
     Cache_data_encrypted *bool
 
     Cache_ttl_in_seconds *int
@@ -3093,7 +3031,7 @@ type Aws_api_gateway_method_settings struct {
 
     Rest_api_id string
 
-    Settings Aws_api_gateway_method_settings_settings_31
+    Settings []Aws_api_gateway_method_settings_settings_31
 
     Stage_name string
 
@@ -3293,8 +3231,6 @@ func (h *Aws_api_gateway_resourceHandler) Delete(externalID string) error {
 
 type Aws_api_gateway_rest_api_endpoint_configuration_32 struct {
 
-    Aws_api_gateway_rest_api_endpoint_configuration_32_id *string `lyra:"ignore"`
-
     Types []string
 
 }
@@ -3313,7 +3249,7 @@ type Aws_api_gateway_rest_api struct {
 
     Description *string
 
-    Endpoint_configuration *Aws_api_gateway_rest_api_endpoint_configuration_32
+    Endpoint_configuration *[]Aws_api_gateway_rest_api_endpoint_configuration_32
 
     Execution_arn *string
 
@@ -3366,8 +3302,6 @@ func (h *Aws_api_gateway_rest_apiHandler) Delete(externalID string) error {
 
 type Aws_api_gateway_stage_access_log_settings_33 struct {
 
-    Aws_api_gateway_stage_access_log_settings_33_id *string `lyra:"ignore"`
-
     Destination_arn string
 
     Format string
@@ -3378,7 +3312,7 @@ type Aws_api_gateway_stage struct {
 
     Aws_api_gateway_stage_id *string `lyra:"ignore"`
 
-    Access_log_settings *Aws_api_gateway_stage_access_log_settings_33
+    Access_log_settings *[]Aws_api_gateway_stage_access_log_settings_33
 
     Cache_cluster_enabled *bool
 
@@ -3447,8 +3381,6 @@ func (h *Aws_api_gateway_stageHandler) Delete(externalID string) error {
 
 type Aws_api_gateway_usage_plan_api_stages_34 struct {
 
-    Aws_api_gateway_usage_plan_api_stages_34_id *string `lyra:"ignore"`
-
     Api_id string
 
     Stage string
@@ -3456,8 +3388,6 @@ type Aws_api_gateway_usage_plan_api_stages_34 struct {
 }
 
 type Aws_api_gateway_usage_plan_quota_settings_35 struct {
-
-    Aws_api_gateway_usage_plan_quota_settings_35_id *string `lyra:"ignore"`
 
     Limit int
 
@@ -3469,8 +3399,6 @@ type Aws_api_gateway_usage_plan_quota_settings_35 struct {
 
 type Aws_api_gateway_usage_plan_throttle_settings_36 struct {
 
-    Aws_api_gateway_usage_plan_throttle_settings_36_id *string `lyra:"ignore"`
-
     Burst_limit *int
 
     Rate_limit *float64
@@ -3481,7 +3409,7 @@ type Aws_api_gateway_usage_plan struct {
 
     Aws_api_gateway_usage_plan_id *string `lyra:"ignore"`
 
-    Api_stages *Aws_api_gateway_usage_plan_api_stages_34
+    Api_stages *[]Aws_api_gateway_usage_plan_api_stages_34
 
     Description *string
 
@@ -3687,8 +3615,6 @@ func (h *Aws_app_cookie_stickiness_policyHandler) Delete(externalID string) erro
 
 type Aws_appautoscaling_policy_step_adjustment_37 struct {
 
-    Aws_appautoscaling_policy_step_adjustment_37_id *string `lyra:"ignore"`
-
     Metric_interval_lower_bound *string
 
     Metric_interval_upper_bound *string
@@ -3699,8 +3625,6 @@ type Aws_appautoscaling_policy_step_adjustment_37 struct {
 
 type Aws_appautoscaling_policy_step_scaling_policy_configuration_38_step_adjustment_39 struct {
 
-    Aws_appautoscaling_policy_step_scaling_policy_configuration_38_step_adjustment_39_id *string `lyra:"ignore"`
-
     Metric_interval_lower_bound *string
 
     Metric_interval_upper_bound *string
@@ -3710,8 +3634,6 @@ type Aws_appautoscaling_policy_step_scaling_policy_configuration_38_step_adjustm
 }
 
 type Aws_appautoscaling_policy_step_scaling_policy_configuration_38 struct {
-
-    Aws_appautoscaling_policy_step_scaling_policy_configuration_38_id *string `lyra:"ignore"`
 
     Adjustment_type *string
 
@@ -3727,8 +3649,6 @@ type Aws_appautoscaling_policy_step_scaling_policy_configuration_38 struct {
 
 type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_dimensions_42 struct {
 
-    Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_dimensions_42_id *string `lyra:"ignore"`
-
     Name string
 
     Value string
@@ -3736,8 +3656,6 @@ type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_c
 }
 
 type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41 struct {
-
-    Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_id *string `lyra:"ignore"`
 
     Dimensions *Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_dimensions_42
 
@@ -3753,8 +3671,6 @@ type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_c
 
 type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43 struct {
 
-    Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43_id *string `lyra:"ignore"`
-
     Predefined_metric_type string
 
     Resource_label *string
@@ -3763,13 +3679,11 @@ type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_p
 
 type Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40 struct {
 
-    Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_id *string `lyra:"ignore"`
-
-    Customized_metric_specification *Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41
+    Customized_metric_specification *[]Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41
 
     Disable_scale_in *bool
 
-    Predefined_metric_specification *Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43
+    Predefined_metric_specification *[]Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43
 
     Scale_in_cooldown *int
 
@@ -3807,9 +3721,9 @@ type Aws_appautoscaling_policy struct {
 
     Step_adjustment *Aws_appautoscaling_policy_step_adjustment_37
 
-    Step_scaling_policy_configuration *Aws_appautoscaling_policy_step_scaling_policy_configuration_38
+    Step_scaling_policy_configuration *[]Aws_appautoscaling_policy_step_scaling_policy_configuration_38
 
-    Target_tracking_scaling_policy_configuration *Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40
+    Target_tracking_scaling_policy_configuration *[]Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40
 
 }
 
@@ -3852,8 +3766,6 @@ func (h *Aws_appautoscaling_policyHandler) Delete(externalID string) error {
 
 type Aws_appautoscaling_scheduled_action_scalable_target_action_44 struct {
 
-    Aws_appautoscaling_scheduled_action_scalable_target_action_44_id *string `lyra:"ignore"`
-
     Max_capacity *int
 
     Min_capacity *int
@@ -3874,7 +3786,7 @@ type Aws_appautoscaling_scheduled_action struct {
 
     Scalable_dimension *string
 
-    Scalable_target_action *Aws_appautoscaling_scheduled_action_scalable_target_action_44
+    Scalable_target_action *[]Aws_appautoscaling_scheduled_action_scalable_target_action_44
 
     Schedule *string
 
@@ -4029,8 +3941,6 @@ func (h *Aws_appmesh_meshHandler) Delete(externalID string) error {
 
 type Aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48 struct {
 
-    Aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48_id *string `lyra:"ignore"`
-
     Virtual_node string
 
     Weight int
@@ -4039,15 +3949,11 @@ type Aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48 struct
 
 type Aws_appmesh_route_spec_45_http_route_46_action_47 struct {
 
-    Aws_appmesh_route_spec_45_http_route_46_action_47_id *string `lyra:"ignore"`
-
     Weighted_target Aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48
 
 }
 
 type Aws_appmesh_route_spec_45_http_route_46_match_49 struct {
-
-    Aws_appmesh_route_spec_45_http_route_46_match_49_id *string `lyra:"ignore"`
 
     Prefix string
 
@@ -4055,19 +3961,15 @@ type Aws_appmesh_route_spec_45_http_route_46_match_49 struct {
 
 type Aws_appmesh_route_spec_45_http_route_46 struct {
 
-    Aws_appmesh_route_spec_45_http_route_46_id *string `lyra:"ignore"`
+    Action []Aws_appmesh_route_spec_45_http_route_46_action_47
 
-    Action Aws_appmesh_route_spec_45_http_route_46_action_47
-
-    Match Aws_appmesh_route_spec_45_http_route_46_match_49
+    Match []Aws_appmesh_route_spec_45_http_route_46_match_49
 
 }
 
 type Aws_appmesh_route_spec_45 struct {
 
-    Aws_appmesh_route_spec_45_id *string `lyra:"ignore"`
-
-    Http_route *Aws_appmesh_route_spec_45_http_route_46
+    Http_route *[]Aws_appmesh_route_spec_45_http_route_46
 
 }
 
@@ -4085,7 +3987,7 @@ type Aws_appmesh_route struct {
 
     Name string
 
-    Spec Aws_appmesh_route_spec_45
+    Spec []Aws_appmesh_route_spec_45
 
     Virtual_router_name string
 
@@ -4130,8 +4032,6 @@ func (h *Aws_appmesh_routeHandler) Delete(externalID string) error {
 
 type Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52 struct {
 
-    Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52_id *string `lyra:"ignore"`
-
     Port int
 
     Protocol string
@@ -4140,15 +4040,11 @@ type Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52 struct {
 
 type Aws_appmesh_virtual_node_spec_50_listener_51 struct {
 
-    Aws_appmesh_virtual_node_spec_50_listener_51_id *string `lyra:"ignore"`
-
-    Port_mapping Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52
+    Port_mapping []Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52
 
 }
 
 type Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54 struct {
-
-    Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54_id *string `lyra:"ignore"`
 
     Service_name string
 
@@ -4156,21 +4052,17 @@ type Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54 struct {
 
 type Aws_appmesh_virtual_node_spec_50_service_discovery_53 struct {
 
-    Aws_appmesh_virtual_node_spec_50_service_discovery_53_id *string `lyra:"ignore"`
-
-    Dns Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54
+    Dns []Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54
 
 }
 
 type Aws_appmesh_virtual_node_spec_50 struct {
 
-    Aws_appmesh_virtual_node_spec_50_id *string `lyra:"ignore"`
-
     Backends *[]string
 
     Listener *Aws_appmesh_virtual_node_spec_50_listener_51
 
-    Service_discovery *Aws_appmesh_virtual_node_spec_50_service_discovery_53
+    Service_discovery *[]Aws_appmesh_virtual_node_spec_50_service_discovery_53
 
 }
 
@@ -4188,7 +4080,7 @@ type Aws_appmesh_virtual_node struct {
 
     Name string
 
-    Spec Aws_appmesh_virtual_node_spec_50
+    Spec []Aws_appmesh_virtual_node_spec_50
 
 }
 
@@ -4231,8 +4123,6 @@ func (h *Aws_appmesh_virtual_nodeHandler) Delete(externalID string) error {
 
 type Aws_appmesh_virtual_router_spec_55 struct {
 
-    Aws_appmesh_virtual_router_spec_55_id *string `lyra:"ignore"`
-
     Service_names []string
 
 }
@@ -4251,7 +4141,7 @@ type Aws_appmesh_virtual_router struct {
 
     Name string
 
-    Spec Aws_appmesh_virtual_router_spec_55
+    Spec []Aws_appmesh_virtual_router_spec_55
 
 }
 
@@ -4345,8 +4235,6 @@ func (h *Aws_appsync_api_keyHandler) Delete(externalID string) error {
 
 type Aws_appsync_datasource_dynamodb_config_56 struct {
 
-    Aws_appsync_datasource_dynamodb_config_56_id *string `lyra:"ignore"`
-
     Region *string
 
     Table_name string
@@ -4357,8 +4245,6 @@ type Aws_appsync_datasource_dynamodb_config_56 struct {
 
 type Aws_appsync_datasource_elasticsearch_config_57 struct {
 
-    Aws_appsync_datasource_elasticsearch_config_57_id *string `lyra:"ignore"`
-
     Endpoint string
 
     Region *string
@@ -4367,15 +4253,11 @@ type Aws_appsync_datasource_elasticsearch_config_57 struct {
 
 type Aws_appsync_datasource_http_config_58 struct {
 
-    Aws_appsync_datasource_http_config_58_id *string `lyra:"ignore"`
-
     Endpoint string
 
 }
 
 type Aws_appsync_datasource_lambda_config_59 struct {
-
-    Aws_appsync_datasource_lambda_config_59_id *string `lyra:"ignore"`
 
     Function_arn string
 
@@ -4391,13 +4273,13 @@ type Aws_appsync_datasource struct {
 
     Description *string
 
-    Dynamodb_config *Aws_appsync_datasource_dynamodb_config_56
+    Dynamodb_config *[]Aws_appsync_datasource_dynamodb_config_56
 
-    Elasticsearch_config *Aws_appsync_datasource_elasticsearch_config_57
+    Elasticsearch_config *[]Aws_appsync_datasource_elasticsearch_config_57
 
-    Http_config *Aws_appsync_datasource_http_config_58
+    Http_config *[]Aws_appsync_datasource_http_config_58
 
-    Lambda_config *Aws_appsync_datasource_lambda_config_59
+    Lambda_config *[]Aws_appsync_datasource_lambda_config_59
 
     Name string
 
@@ -4446,8 +4328,6 @@ func (h *Aws_appsync_datasourceHandler) Delete(externalID string) error {
 
 type Aws_appsync_graphql_api_log_config_60 struct {
 
-    Aws_appsync_graphql_api_log_config_60_id *string `lyra:"ignore"`
-
     Cloudwatch_logs_role_arn string
 
     Field_log_level string
@@ -4455,8 +4335,6 @@ type Aws_appsync_graphql_api_log_config_60 struct {
 }
 
 type Aws_appsync_graphql_api_openid_connect_config_61 struct {
-
-    Aws_appsync_graphql_api_openid_connect_config_61_id *string `lyra:"ignore"`
 
     Auth_ttl *int
 
@@ -4469,8 +4347,6 @@ type Aws_appsync_graphql_api_openid_connect_config_61 struct {
 }
 
 type Aws_appsync_graphql_api_user_pool_config_62 struct {
-
-    Aws_appsync_graphql_api_user_pool_config_62_id *string `lyra:"ignore"`
 
     App_id_client_regex *string
 
@@ -4490,15 +4366,15 @@ type Aws_appsync_graphql_api struct {
 
     Authentication_type string
 
-    Log_config *Aws_appsync_graphql_api_log_config_60
+    Log_config *[]Aws_appsync_graphql_api_log_config_60
 
     Name string
 
-    Openid_connect_config *Aws_appsync_graphql_api_openid_connect_config_61
+    Openid_connect_config *[]Aws_appsync_graphql_api_openid_connect_config_61
 
     Uris *map[string]string
 
-    User_pool_config *Aws_appsync_graphql_api_user_pool_config_62
+    User_pool_config *[]Aws_appsync_graphql_api_user_pool_config_62
 
 }
 
@@ -4541,8 +4417,6 @@ func (h *Aws_appsync_graphql_apiHandler) Delete(externalID string) error {
 
 type Aws_athena_database_encryption_configuration_63 struct {
 
-    Aws_athena_database_encryption_configuration_63_id *string `lyra:"ignore"`
-
     Encryption_option string
 
     Kms_key *string
@@ -4555,7 +4429,7 @@ type Aws_athena_database struct {
 
     Bucket string
 
-    Encryption_configuration *Aws_athena_database_encryption_configuration_63
+    Encryption_configuration *[]Aws_athena_database_encryption_configuration_63
 
     Force_destroy *bool
 
@@ -4702,8 +4576,6 @@ func (h *Aws_autoscaling_attachmentHandler) Delete(externalID string) error {
 
 type Aws_autoscaling_group_initial_lifecycle_hook_64 struct {
 
-    Aws_autoscaling_group_initial_lifecycle_hook_64_id *string `lyra:"ignore"`
-
     Default_result *string
 
     Heartbeat_timeout *int
@@ -4722,8 +4594,6 @@ type Aws_autoscaling_group_initial_lifecycle_hook_64 struct {
 
 type Aws_autoscaling_group_launch_template_65 struct {
 
-    Aws_autoscaling_group_launch_template_65_id *string `lyra:"ignore"`
-
     Id *string
 
     Name *string
@@ -4733,8 +4603,6 @@ type Aws_autoscaling_group_launch_template_65 struct {
 }
 
 type Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67 struct {
-
-    Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67_id *string `lyra:"ignore"`
 
     On_demand_allocation_strategy *string
 
@@ -4752,8 +4620,6 @@ type Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67 s
 
 type Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69 struct {
 
-    Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69_id *string `lyra:"ignore"`
-
     Launch_template_id *string
 
     Launch_template_name *string
@@ -4764,35 +4630,27 @@ type Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_t
 
 type Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70 struct {
 
-    Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70_id *string `lyra:"ignore"`
-
     Instance_type *string
 
 }
 
 type Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68 struct {
 
-    Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_id *string `lyra:"ignore"`
+    Launch_template_specification []Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69
 
-    Launch_template_specification Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69
-
-    Override *Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70
+    Override *[]Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70
 
 }
 
 type Aws_autoscaling_group_mixed_instances_policy_66 struct {
 
-    Aws_autoscaling_group_mixed_instances_policy_66_id *string `lyra:"ignore"`
+    Instances_distribution *[]Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67
 
-    Instances_distribution *Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67
-
-    Launch_template Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68
+    Launch_template []Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68
 
 }
 
 type Aws_autoscaling_group_tag_71 struct {
-
-    Aws_autoscaling_group_tag_71_id *string `lyra:"ignore"`
 
     Key string
 
@@ -4826,7 +4684,7 @@ type Aws_autoscaling_group struct {
 
     Launch_configuration *string
 
-    Launch_template *Aws_autoscaling_group_launch_template_65
+    Launch_template *[]Aws_autoscaling_group_launch_template_65
 
     Load_balancers *[]string
 
@@ -4838,7 +4696,7 @@ type Aws_autoscaling_group struct {
 
     Min_size int
 
-    Mixed_instances_policy *Aws_autoscaling_group_mixed_instances_policy_66
+    Mixed_instances_policy *[]Aws_autoscaling_group_mixed_instances_policy_66
 
     Name *string
 
@@ -5015,8 +4873,6 @@ func (h *Aws_autoscaling_notificationHandler) Delete(externalID string) error {
 
 type Aws_autoscaling_policy_step_adjustment_72 struct {
 
-    Aws_autoscaling_policy_step_adjustment_72_id *string `lyra:"ignore"`
-
     Metric_interval_lower_bound *string
 
     Metric_interval_upper_bound *string
@@ -5027,8 +4883,6 @@ type Aws_autoscaling_policy_step_adjustment_72 struct {
 
 type Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75 struct {
 
-    Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75_id *string `lyra:"ignore"`
-
     Name string
 
     Value string
@@ -5037,9 +4891,7 @@ type Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_s
 
 type Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74 struct {
 
-    Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_id *string `lyra:"ignore"`
-
-    Metric_dimension *Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75
+    Metric_dimension *[]Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75
 
     Metric_name string
 
@@ -5053,8 +4905,6 @@ type Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_s
 
 type Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76 struct {
 
-    Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76_id *string `lyra:"ignore"`
-
     Predefined_metric_type string
 
     Resource_label *string
@@ -5063,13 +4913,11 @@ type Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_s
 
 type Aws_autoscaling_policy_target_tracking_configuration_73 struct {
 
-    Aws_autoscaling_policy_target_tracking_configuration_73_id *string `lyra:"ignore"`
-
-    Customized_metric_specification *Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74
+    Customized_metric_specification *[]Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74
 
     Disable_scale_in *bool
 
-    Predefined_metric_specification *Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76
+    Predefined_metric_specification *[]Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76
 
     Target_value float64
 
@@ -5103,7 +4951,7 @@ type Aws_autoscaling_policy struct {
 
     Step_adjustment *Aws_autoscaling_policy_step_adjustment_72
 
-    Target_tracking_configuration *Aws_autoscaling_policy_target_tracking_configuration_73
+    Target_tracking_configuration *[]Aws_autoscaling_policy_target_tracking_configuration_73
 
 }
 
@@ -5207,8 +5055,6 @@ func (h *Aws_autoscaling_scheduleHandler) Delete(externalID string) error {
 
 type Aws_batch_compute_environment_compute_resources_77 struct {
 
-    Aws_batch_compute_environment_compute_resources_77_id *string `lyra:"ignore"`
-
     Bid_percentage *int
 
     Desired_vcpus *int
@@ -5245,7 +5091,7 @@ type Aws_batch_compute_environment struct {
 
     Compute_environment_name string
 
-    Compute_resources *Aws_batch_compute_environment_compute_resources_77
+    Compute_resources *[]Aws_batch_compute_environment_compute_resources_77
 
     Ecc_cluster_arn *string
 
@@ -5302,15 +5148,11 @@ func (h *Aws_batch_compute_environmentHandler) Delete(externalID string) error {
 
 type Aws_batch_job_definition_retry_strategy_78 struct {
 
-    Aws_batch_job_definition_retry_strategy_78_id *string `lyra:"ignore"`
-
     Attempts *int
 
 }
 
 type Aws_batch_job_definition_timeout_79 struct {
-
-    Aws_batch_job_definition_timeout_79_id *string `lyra:"ignore"`
 
     Attempt_duration_seconds *int
 
@@ -5328,11 +5170,11 @@ type Aws_batch_job_definition struct {
 
     Parameters *map[string]string
 
-    Retry_strategy *Aws_batch_job_definition_retry_strategy_78
+    Retry_strategy *[]Aws_batch_job_definition_retry_strategy_78
 
     Revision *int
 
-    Timeout *Aws_batch_job_definition_timeout_79
+    Timeout *[]Aws_batch_job_definition_timeout_79
 
     Type string
 
@@ -5430,8 +5272,6 @@ func (h *Aws_batch_job_queueHandler) Delete(externalID string) error {
 
 type Aws_budgets_budget_cost_types_80 struct {
 
-    Aws_budgets_budget_cost_types_80_id *string `lyra:"ignore"`
-
     Include_credit *bool
 
     Include_discount *bool
@@ -5466,7 +5306,7 @@ type Aws_budgets_budget struct {
 
     Cost_filters *map[string]string
 
-    Cost_types *Aws_budgets_budget_cost_types_80
+    Cost_types *[]Aws_budgets_budget_cost_types_80
 
     Limit_amount string
 
@@ -5653,8 +5493,6 @@ func (h *Aws_cloudformation_stackHandler) Delete(externalID string) error {
 
 type Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_83 struct {
 
-    Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_83_id *string `lyra:"ignore"`
-
     Forward string
 
     Whitelisted_names *[]string
@@ -5662,8 +5500,6 @@ type Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_8
 }
 
 type Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82 struct {
-
-    Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_id *string `lyra:"ignore"`
 
     Cookies Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_83
 
@@ -5677,8 +5513,6 @@ type Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82 struct {
 
 type Aws_cloudfront_distribution_cache_behavior_81_lambda_function_association_84 struct {
 
-    Aws_cloudfront_distribution_cache_behavior_81_lambda_function_association_84_id *string `lyra:"ignore"`
-
     Event_type string
 
     Include_body *bool
@@ -5688,8 +5522,6 @@ type Aws_cloudfront_distribution_cache_behavior_81_lambda_function_association_8
 }
 
 type Aws_cloudfront_distribution_cache_behavior_81 struct {
-
-    Aws_cloudfront_distribution_cache_behavior_81_id *string `lyra:"ignore"`
 
     Allowed_methods []string
 
@@ -5723,8 +5555,6 @@ type Aws_cloudfront_distribution_cache_behavior_81 struct {
 
 type Aws_cloudfront_distribution_custom_error_response_85 struct {
 
-    Aws_cloudfront_distribution_custom_error_response_85_id *string `lyra:"ignore"`
-
     Error_caching_min_ttl *int
 
     Error_code int
@@ -5737,8 +5567,6 @@ type Aws_cloudfront_distribution_custom_error_response_85 struct {
 
 type Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_cookies_88 struct {
 
-    Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_cookies_88_id *string `lyra:"ignore"`
-
     Forward string
 
     Whitelisted_names *[]string
@@ -5746,8 +5574,6 @@ type Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_c
 }
 
 type Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87 struct {
-
-    Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_id *string `lyra:"ignore"`
 
     Cookies Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_cookies_88
 
@@ -5761,8 +5587,6 @@ type Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87 s
 
 type Aws_cloudfront_distribution_default_cache_behavior_86_lambda_function_association_89 struct {
 
-    Aws_cloudfront_distribution_default_cache_behavior_86_lambda_function_association_89_id *string `lyra:"ignore"`
-
     Event_type string
 
     Include_body *bool
@@ -5772,8 +5596,6 @@ type Aws_cloudfront_distribution_default_cache_behavior_86_lambda_function_assoc
 }
 
 type Aws_cloudfront_distribution_default_cache_behavior_86 struct {
-
-    Aws_cloudfront_distribution_default_cache_behavior_86_id *string `lyra:"ignore"`
 
     Allowed_methods []string
 
@@ -5805,8 +5627,6 @@ type Aws_cloudfront_distribution_default_cache_behavior_86 struct {
 
 type Aws_cloudfront_distribution_logging_config_90 struct {
 
-    Aws_cloudfront_distribution_logging_config_90_id *string `lyra:"ignore"`
-
     Bucket string
 
     Include_cookies *bool
@@ -5817,8 +5637,6 @@ type Aws_cloudfront_distribution_logging_config_90 struct {
 
 type Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_cookies_93 struct {
 
-    Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_cookies_93_id *string `lyra:"ignore"`
-
     Forward string
 
     Whitelisted_names *[]string
@@ -5826,8 +5644,6 @@ type Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_c
 }
 
 type Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92 struct {
-
-    Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_id *string `lyra:"ignore"`
 
     Cookies Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_cookies_93
 
@@ -5841,8 +5657,6 @@ type Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92 s
 
 type Aws_cloudfront_distribution_ordered_cache_behavior_91_lambda_function_association_94 struct {
 
-    Aws_cloudfront_distribution_ordered_cache_behavior_91_lambda_function_association_94_id *string `lyra:"ignore"`
-
     Event_type string
 
     Include_body *bool
@@ -5852,8 +5666,6 @@ type Aws_cloudfront_distribution_ordered_cache_behavior_91_lambda_function_assoc
 }
 
 type Aws_cloudfront_distribution_ordered_cache_behavior_91 struct {
-
-    Aws_cloudfront_distribution_ordered_cache_behavior_91_id *string `lyra:"ignore"`
 
     Allowed_methods []string
 
@@ -5887,8 +5699,6 @@ type Aws_cloudfront_distribution_ordered_cache_behavior_91 struct {
 
 type Aws_cloudfront_distribution_origin_95_custom_header_96 struct {
 
-    Aws_cloudfront_distribution_origin_95_custom_header_96_id *string `lyra:"ignore"`
-
     Name string
 
     Value string
@@ -5896,8 +5706,6 @@ type Aws_cloudfront_distribution_origin_95_custom_header_96 struct {
 }
 
 type Aws_cloudfront_distribution_origin_95_custom_origin_config_97 struct {
-
-    Aws_cloudfront_distribution_origin_95_custom_origin_config_97_id *string `lyra:"ignore"`
 
     Http_port int
 
@@ -5915,15 +5723,11 @@ type Aws_cloudfront_distribution_origin_95_custom_origin_config_97 struct {
 
 type Aws_cloudfront_distribution_origin_95_s3_origin_config_98 struct {
 
-    Aws_cloudfront_distribution_origin_95_s3_origin_config_98_id *string `lyra:"ignore"`
-
     Origin_access_identity string
 
 }
 
 type Aws_cloudfront_distribution_origin_95 struct {
-
-    Aws_cloudfront_distribution_origin_95_id *string `lyra:"ignore"`
 
     Custom_header *Aws_cloudfront_distribution_origin_95_custom_header_96
 
@@ -5941,8 +5745,6 @@ type Aws_cloudfront_distribution_origin_95 struct {
 
 type Aws_cloudfront_distribution_restrictions_99_geo_restriction_100 struct {
 
-    Aws_cloudfront_distribution_restrictions_99_geo_restriction_100_id *string `lyra:"ignore"`
-
     Locations *[]string
 
     Restriction_type string
@@ -5951,15 +5753,11 @@ type Aws_cloudfront_distribution_restrictions_99_geo_restriction_100 struct {
 
 type Aws_cloudfront_distribution_restrictions_99 struct {
 
-    Aws_cloudfront_distribution_restrictions_99_id *string `lyra:"ignore"`
-
     Geo_restriction Aws_cloudfront_distribution_restrictions_99_geo_restriction_100
 
 }
 
 type Aws_cloudfront_distribution_viewer_certificate_101 struct {
-
-    Aws_cloudfront_distribution_viewer_certificate_101_id *string `lyra:"ignore"`
 
     Acm_certificate_arn *string
 
@@ -6013,7 +5811,7 @@ type Aws_cloudfront_distribution struct {
 
     Logging_config *Aws_cloudfront_distribution_logging_config_90
 
-    Ordered_cache_behavior *Aws_cloudfront_distribution_ordered_cache_behavior_91
+    Ordered_cache_behavior *[]Aws_cloudfront_distribution_ordered_cache_behavior_91
 
     Origin Aws_cloudfront_distribution_origin_95
 
@@ -6182,8 +5980,6 @@ func (h *Aws_cloudfront_public_keyHandler) Delete(externalID string) error {
 
 type Aws_cloudhsm_v2_cluster_cluster_certificates_102 struct {
 
-    Aws_cloudhsm_v2_cluster_cluster_certificates_102_id *string `lyra:"ignore"`
-
     Aws_hardware_certificate *string
 
     Cluster_certificate *string
@@ -6200,7 +5996,7 @@ type Aws_cloudhsm_v2_cluster struct {
 
     Aws_cloudhsm_v2_cluster_id *string `lyra:"ignore"`
 
-    Cluster_certificates *Aws_cloudhsm_v2_cluster_cluster_certificates_102
+    Cluster_certificates *[]Aws_cloudhsm_v2_cluster_cluster_certificates_102
 
     Cluster_id *string
 
@@ -6316,8 +6112,6 @@ func (h *Aws_cloudhsm_v2_hsmHandler) Delete(externalID string) error {
 
 type Aws_cloudtrail_event_selector_103_data_resource_104 struct {
 
-    Aws_cloudtrail_event_selector_103_data_resource_104_id *string `lyra:"ignore"`
-
     Type string
 
     Values []string
@@ -6326,9 +6120,7 @@ type Aws_cloudtrail_event_selector_103_data_resource_104 struct {
 
 type Aws_cloudtrail_event_selector_103 struct {
 
-    Aws_cloudtrail_event_selector_103_id *string `lyra:"ignore"`
-
-    Data_resource *Aws_cloudtrail_event_selector_103_data_resource_104
+    Data_resource *[]Aws_cloudtrail_event_selector_103_data_resource_104
 
     Include_management_events *bool
 
@@ -6350,7 +6142,7 @@ type Aws_cloudtrail struct {
 
     Enable_logging *bool
 
-    Event_selector *Aws_cloudtrail_event_selector_103
+    Event_selector *[]Aws_cloudtrail_event_selector_103
 
     Home_region *string
 
@@ -6462,8 +6254,6 @@ func (h *Aws_cloudwatch_dashboardHandler) Delete(externalID string) error {
 
 type Aws_cloudwatch_event_permission_condition_105 struct {
 
-    Aws_cloudwatch_event_permission_condition_105_id *string `lyra:"ignore"`
-
     Key string
 
     Type string
@@ -6478,7 +6268,7 @@ type Aws_cloudwatch_event_permission struct {
 
     Action *string
 
-    Condition *Aws_cloudwatch_event_permission_condition_105
+    Condition *[]Aws_cloudwatch_event_permission_condition_105
 
     Principal string
 
@@ -6584,8 +6374,6 @@ func (h *Aws_cloudwatch_event_ruleHandler) Delete(externalID string) error {
 
 type Aws_cloudwatch_event_target_batch_target_106 struct {
 
-    Aws_cloudwatch_event_target_batch_target_106_id *string `lyra:"ignore"`
-
     Array_size *int
 
     Job_attempts *int
@@ -6598,8 +6386,6 @@ type Aws_cloudwatch_event_target_batch_target_106 struct {
 
 type Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108 struct {
 
-    Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108_id *string `lyra:"ignore"`
-
     Assign_public_ip *bool
 
     Security_groups *[]string
@@ -6610,13 +6396,11 @@ type Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108 struct
 
 type Aws_cloudwatch_event_target_ecs_target_107 struct {
 
-    Aws_cloudwatch_event_target_ecs_target_107_id *string `lyra:"ignore"`
-
     Group *string
 
     Launch_type *string
 
-    Network_configuration *Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108
+    Network_configuration *[]Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108
 
     Platform_version *string
 
@@ -6628,8 +6412,6 @@ type Aws_cloudwatch_event_target_ecs_target_107 struct {
 
 type Aws_cloudwatch_event_target_input_transformer_109 struct {
 
-    Aws_cloudwatch_event_target_input_transformer_109_id *string `lyra:"ignore"`
-
     Input_paths *map[string]string
 
     Input_template string
@@ -6638,15 +6420,11 @@ type Aws_cloudwatch_event_target_input_transformer_109 struct {
 
 type Aws_cloudwatch_event_target_kinesis_target_110 struct {
 
-    Aws_cloudwatch_event_target_kinesis_target_110_id *string `lyra:"ignore"`
-
     Partition_key_path *string
 
 }
 
 type Aws_cloudwatch_event_target_run_command_targets_111 struct {
-
-    Aws_cloudwatch_event_target_run_command_targets_111_id *string `lyra:"ignore"`
 
     Key string
 
@@ -6655,8 +6433,6 @@ type Aws_cloudwatch_event_target_run_command_targets_111 struct {
 }
 
 type Aws_cloudwatch_event_target_sqs_target_112 struct {
-
-    Aws_cloudwatch_event_target_sqs_target_112_id *string `lyra:"ignore"`
 
     Message_group_id *string
 
@@ -6668,25 +6444,25 @@ type Aws_cloudwatch_event_target struct {
 
     Arn string
 
-    Batch_target *Aws_cloudwatch_event_target_batch_target_106
+    Batch_target *[]Aws_cloudwatch_event_target_batch_target_106
 
-    Ecs_target *Aws_cloudwatch_event_target_ecs_target_107
+    Ecs_target *[]Aws_cloudwatch_event_target_ecs_target_107
 
     Input *string
 
     Input_path *string
 
-    Input_transformer *Aws_cloudwatch_event_target_input_transformer_109
+    Input_transformer *[]Aws_cloudwatch_event_target_input_transformer_109
 
-    Kinesis_target *Aws_cloudwatch_event_target_kinesis_target_110
+    Kinesis_target *[]Aws_cloudwatch_event_target_kinesis_target_110
 
     Role_arn *string
 
     Rule string
 
-    Run_command_targets *Aws_cloudwatch_event_target_run_command_targets_111
+    Run_command_targets *[]Aws_cloudwatch_event_target_run_command_targets_111
 
-    Sqs_target *Aws_cloudwatch_event_target_sqs_target_112
+    Sqs_target *[]Aws_cloudwatch_event_target_sqs_target_112
 
     Target_id *string
 
@@ -6884,8 +6660,6 @@ func (h *Aws_cloudwatch_log_groupHandler) Delete(externalID string) error {
 
 type Aws_cloudwatch_log_metric_filter_metric_transformation_113 struct {
 
-    Aws_cloudwatch_log_metric_filter_metric_transformation_113_id *string `lyra:"ignore"`
-
     Default_value *string
 
     Name string
@@ -6902,7 +6676,7 @@ type Aws_cloudwatch_log_metric_filter struct {
 
     Log_group_name string
 
-    Metric_transformation Aws_cloudwatch_log_metric_filter_metric_transformation_113
+    Metric_transformation []Aws_cloudwatch_log_metric_filter_metric_transformation_113
 
     Name string
 
@@ -7183,8 +6957,6 @@ func (h *Aws_cloudwatch_metric_alarmHandler) Delete(externalID string) error {
 
 type Aws_codebuild_project_artifacts_114 struct {
 
-    Aws_codebuild_project_artifacts_114_id *string `lyra:"ignore"`
-
     Encryption_disabled *bool
 
     Location *string
@@ -7203,8 +6975,6 @@ type Aws_codebuild_project_artifacts_114 struct {
 
 type Aws_codebuild_project_cache_115 struct {
 
-    Aws_codebuild_project_cache_115_id *string `lyra:"ignore"`
-
     Location *string
 
     Type *string
@@ -7212,8 +6982,6 @@ type Aws_codebuild_project_cache_115 struct {
 }
 
 type Aws_codebuild_project_environment_116_environment_variable_117 struct {
-
-    Aws_codebuild_project_environment_116_environment_variable_117_id *string `lyra:"ignore"`
 
     Name string
 
@@ -7225,13 +6993,11 @@ type Aws_codebuild_project_environment_116_environment_variable_117 struct {
 
 type Aws_codebuild_project_environment_116 struct {
 
-    Aws_codebuild_project_environment_116_id *string `lyra:"ignore"`
-
     Certificate *string
 
     Compute_type string
 
-    Environment_variable *Aws_codebuild_project_environment_116_environment_variable_117
+    Environment_variable *[]Aws_codebuild_project_environment_116_environment_variable_117
 
     Image string
 
@@ -7242,8 +7008,6 @@ type Aws_codebuild_project_environment_116 struct {
 }
 
 type Aws_codebuild_project_secondary_artifacts_118 struct {
-
-    Aws_codebuild_project_secondary_artifacts_118_id *string `lyra:"ignore"`
 
     Artifact_identifier string
 
@@ -7265,8 +7029,6 @@ type Aws_codebuild_project_secondary_artifacts_118 struct {
 
 type Aws_codebuild_project_secondary_sources_119_auth_120 struct {
 
-    Aws_codebuild_project_secondary_sources_119_auth_120_id *string `lyra:"ignore"`
-
     Resource *string
 
     Type string
@@ -7274,8 +7036,6 @@ type Aws_codebuild_project_secondary_sources_119_auth_120 struct {
 }
 
 type Aws_codebuild_project_secondary_sources_119 struct {
-
-    Aws_codebuild_project_secondary_sources_119_id *string `lyra:"ignore"`
 
     Auth *Aws_codebuild_project_secondary_sources_119_auth_120
 
@@ -7297,8 +7057,6 @@ type Aws_codebuild_project_secondary_sources_119 struct {
 
 type Aws_codebuild_project_source_121_auth_122 struct {
 
-    Aws_codebuild_project_source_121_auth_122_id *string `lyra:"ignore"`
-
     Resource *string
 
     Type string
@@ -7306,8 +7064,6 @@ type Aws_codebuild_project_source_121_auth_122 struct {
 }
 
 type Aws_codebuild_project_source_121 struct {
-
-    Aws_codebuild_project_source_121_id *string `lyra:"ignore"`
 
     Auth *Aws_codebuild_project_source_121_auth_122
 
@@ -7326,8 +7082,6 @@ type Aws_codebuild_project_source_121 struct {
 }
 
 type Aws_codebuild_project_vpc_config_123 struct {
-
-    Aws_codebuild_project_vpc_config_123_id *string `lyra:"ignore"`
 
     Security_group_ids []string
 
@@ -7351,7 +7105,7 @@ type Aws_codebuild_project struct {
 
     Build_timeout *int
 
-    Cache *Aws_codebuild_project_cache_115
+    Cache *[]Aws_codebuild_project_cache_115
 
     Description *string
 
@@ -7373,7 +7127,7 @@ type Aws_codebuild_project struct {
 
     Timeout *int
 
-    Vpc_config *Aws_codebuild_project_vpc_config_123
+    Vpc_config *[]Aws_codebuild_project_vpc_config_123
 
 }
 
@@ -7526,8 +7280,6 @@ func (h *Aws_codecommit_repositoryHandler) Delete(externalID string) error {
 
 type Aws_codecommit_trigger_trigger_124 struct {
 
-    Aws_codecommit_trigger_trigger_124_id *string `lyra:"ignore"`
-
     Branches *[]string
 
     Custom_data *string
@@ -7640,8 +7392,6 @@ func (h *Aws_codedeploy_appHandler) Delete(externalID string) error {
 
 type Aws_codedeploy_deployment_config_minimum_healthy_hosts_125 struct {
 
-    Aws_codedeploy_deployment_config_minimum_healthy_hosts_125_id *string `lyra:"ignore"`
-
     Type *string
 
     Value *int
@@ -7649,8 +7399,6 @@ type Aws_codedeploy_deployment_config_minimum_healthy_hosts_125 struct {
 }
 
 type Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127 struct {
-
-    Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127_id *string `lyra:"ignore"`
 
     Interval *int
 
@@ -7660,8 +7408,6 @@ type Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_cana
 
 type Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128 struct {
 
-    Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128_id *string `lyra:"ignore"`
-
     Interval *int
 
     Percentage *int
@@ -7670,11 +7416,9 @@ type Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_line
 
 type Aws_codedeploy_deployment_config_traffic_routing_config_126 struct {
 
-    Aws_codedeploy_deployment_config_traffic_routing_config_126_id *string `lyra:"ignore"`
+    Time_based_canary *[]Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127
 
-    Time_based_canary *Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127
-
-    Time_based_linear *Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128
+    Time_based_linear *[]Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128
 
     Type *string
 
@@ -7690,9 +7434,9 @@ type Aws_codedeploy_deployment_config struct {
 
     Deployment_config_name string
 
-    Minimum_healthy_hosts *Aws_codedeploy_deployment_config_minimum_healthy_hosts_125
+    Minimum_healthy_hosts *[]Aws_codedeploy_deployment_config_minimum_healthy_hosts_125
 
-    Traffic_routing_config *Aws_codedeploy_deployment_config_traffic_routing_config_126
+    Traffic_routing_config *[]Aws_codedeploy_deployment_config_traffic_routing_config_126
 
 }
 
@@ -7735,8 +7479,6 @@ func (h *Aws_codedeploy_deployment_configHandler) Delete(externalID string) erro
 
 type Aws_codedeploy_deployment_group_alarm_configuration_129 struct {
 
-    Aws_codedeploy_deployment_group_alarm_configuration_129_id *string `lyra:"ignore"`
-
     Alarms *[]string
 
     Enabled *bool
@@ -7747,8 +7489,6 @@ type Aws_codedeploy_deployment_group_alarm_configuration_129 struct {
 
 type Aws_codedeploy_deployment_group_auto_rollback_configuration_130 struct {
 
-    Aws_codedeploy_deployment_group_auto_rollback_configuration_130_id *string `lyra:"ignore"`
-
     Enabled *bool
 
     Events *[]string
@@ -7756,8 +7496,6 @@ type Aws_codedeploy_deployment_group_auto_rollback_configuration_130 struct {
 }
 
 type Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132 struct {
-
-    Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132_id *string `lyra:"ignore"`
 
     Action_on_timeout *string
 
@@ -7767,15 +7505,11 @@ type Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment
 
 type Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133 struct {
 
-    Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133_id *string `lyra:"ignore"`
-
     Action *string
 
 }
 
 type Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134 struct {
-
-    Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134_id *string `lyra:"ignore"`
 
     Action *string
 
@@ -7785,19 +7519,15 @@ type Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_
 
 type Aws_codedeploy_deployment_group_blue_green_deployment_config_131 struct {
 
-    Aws_codedeploy_deployment_group_blue_green_deployment_config_131_id *string `lyra:"ignore"`
+    Deployment_ready_option *[]Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132
 
-    Deployment_ready_option *Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132
+    Green_fleet_provisioning_option *[]Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133
 
-    Green_fleet_provisioning_option *Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133
-
-    Terminate_blue_instances_on_deployment_success *Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134
+    Terminate_blue_instances_on_deployment_success *[]Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134
 
 }
 
 type Aws_codedeploy_deployment_group_deployment_style_135 struct {
-
-    Aws_codedeploy_deployment_group_deployment_style_135_id *string `lyra:"ignore"`
 
     Deployment_option *string
 
@@ -7806,8 +7536,6 @@ type Aws_codedeploy_deployment_group_deployment_style_135 struct {
 }
 
 type Aws_codedeploy_deployment_group_ec2_tag_filter_136 struct {
-
-    Aws_codedeploy_deployment_group_ec2_tag_filter_136_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -7819,8 +7547,6 @@ type Aws_codedeploy_deployment_group_ec2_tag_filter_136 struct {
 
 type Aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138 struct {
 
-    Aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138_id *string `lyra:"ignore"`
-
     Key *string
 
     Type *string
@@ -7831,15 +7557,11 @@ type Aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138 struct {
 
 type Aws_codedeploy_deployment_group_ec2_tag_set_137 struct {
 
-    Aws_codedeploy_deployment_group_ec2_tag_set_137_id *string `lyra:"ignore"`
-
     Ec2_tag_filter *Aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138
 
 }
 
 type Aws_codedeploy_deployment_group_ecs_service_139 struct {
-
-    Aws_codedeploy_deployment_group_ecs_service_139_id *string `lyra:"ignore"`
 
     Cluster_name string
 
@@ -7849,15 +7571,11 @@ type Aws_codedeploy_deployment_group_ecs_service_139 struct {
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140_elb_info_141 struct {
 
-    Aws_codedeploy_deployment_group_load_balancer_info_140_elb_info_141_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_info_142 struct {
-
-    Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_info_142_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -7865,15 +7583,11 @@ type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_info_14
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144 struct {
 
-    Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144_id *string `lyra:"ignore"`
-
     Listener_arns []string
 
 }
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145 struct {
-
-    Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145_id *string `lyra:"ignore"`
 
     Name string
 
@@ -7881,39 +7595,31 @@ type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_in
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146 struct {
 
-    Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146_id *string `lyra:"ignore"`
-
     Listener_arns []string
 
 }
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143 struct {
 
-    Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_id *string `lyra:"ignore"`
+    Prod_traffic_route []Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144
 
-    Prod_traffic_route Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144
+    Target_group []Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145
 
-    Target_group Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145
-
-    Test_traffic_route *Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146
+    Test_traffic_route *[]Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146
 
 }
 
 type Aws_codedeploy_deployment_group_load_balancer_info_140 struct {
 
-    Aws_codedeploy_deployment_group_load_balancer_info_140_id *string `lyra:"ignore"`
-
     Elb_info *Aws_codedeploy_deployment_group_load_balancer_info_140_elb_info_141
 
     Target_group_info *Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_info_142
 
-    Target_group_pair_info *Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143
+    Target_group_pair_info *[]Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143
 
 }
 
 type Aws_codedeploy_deployment_group_on_premises_instance_tag_filter_147 struct {
-
-    Aws_codedeploy_deployment_group_on_premises_instance_tag_filter_147_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -7924,8 +7630,6 @@ type Aws_codedeploy_deployment_group_on_premises_instance_tag_filter_147 struct 
 }
 
 type Aws_codedeploy_deployment_group_trigger_configuration_148 struct {
-
-    Aws_codedeploy_deployment_group_trigger_configuration_148_id *string `lyra:"ignore"`
 
     Trigger_events []string
 
@@ -7939,29 +7643,29 @@ type Aws_codedeploy_deployment_group struct {
 
     Aws_codedeploy_deployment_group_id *string `lyra:"ignore"`
 
-    Alarm_configuration *Aws_codedeploy_deployment_group_alarm_configuration_129
+    Alarm_configuration *[]Aws_codedeploy_deployment_group_alarm_configuration_129
 
     App_name string
 
-    Auto_rollback_configuration *Aws_codedeploy_deployment_group_auto_rollback_configuration_130
+    Auto_rollback_configuration *[]Aws_codedeploy_deployment_group_auto_rollback_configuration_130
 
     Autoscaling_groups *[]string
 
-    Blue_green_deployment_config *Aws_codedeploy_deployment_group_blue_green_deployment_config_131
+    Blue_green_deployment_config *[]Aws_codedeploy_deployment_group_blue_green_deployment_config_131
 
     Deployment_config_name *string
 
     Deployment_group_name string
 
-    Deployment_style *Aws_codedeploy_deployment_group_deployment_style_135
+    Deployment_style *[]Aws_codedeploy_deployment_group_deployment_style_135
 
     Ec2_tag_filter *Aws_codedeploy_deployment_group_ec2_tag_filter_136
 
     Ec2_tag_set *Aws_codedeploy_deployment_group_ec2_tag_set_137
 
-    Ecs_service *Aws_codedeploy_deployment_group_ecs_service_139
+    Ecs_service *[]Aws_codedeploy_deployment_group_ecs_service_139
 
-    Load_balancer_info *Aws_codedeploy_deployment_group_load_balancer_info_140
+    Load_balancer_info *[]Aws_codedeploy_deployment_group_load_balancer_info_140
 
     On_premises_instance_tag_filter *Aws_codedeploy_deployment_group_on_premises_instance_tag_filter_147
 
@@ -8010,8 +7714,6 @@ func (h *Aws_codedeploy_deployment_groupHandler) Delete(externalID string) error
 
 type Aws_codepipeline_artifact_store_149_encryption_key_150 struct {
 
-    Aws_codepipeline_artifact_store_149_encryption_key_150_id *string `lyra:"ignore"`
-
     Id string
 
     Type string
@@ -8020,9 +7722,7 @@ type Aws_codepipeline_artifact_store_149_encryption_key_150 struct {
 
 type Aws_codepipeline_artifact_store_149 struct {
 
-    Aws_codepipeline_artifact_store_149_id *string `lyra:"ignore"`
-
-    Encryption_key *Aws_codepipeline_artifact_store_149_encryption_key_150
+    Encryption_key *[]Aws_codepipeline_artifact_store_149_encryption_key_150
 
     Location string
 
@@ -8031,8 +7731,6 @@ type Aws_codepipeline_artifact_store_149 struct {
 }
 
 type Aws_codepipeline_stage_151_action_152 struct {
-
-    Aws_codepipeline_stage_151_action_152_id *string `lyra:"ignore"`
 
     Category string
 
@@ -8058,9 +7756,7 @@ type Aws_codepipeline_stage_151_action_152 struct {
 
 type Aws_codepipeline_stage_151 struct {
 
-    Aws_codepipeline_stage_151_id *string `lyra:"ignore"`
-
-    Action Aws_codepipeline_stage_151_action_152
+    Action []Aws_codepipeline_stage_151_action_152
 
     Name string
 
@@ -8072,13 +7768,13 @@ type Aws_codepipeline struct {
 
     Arn *string
 
-    Artifact_store Aws_codepipeline_artifact_store_149
+    Artifact_store []Aws_codepipeline_artifact_store_149
 
     Name string
 
     Role_arn string
 
-    Stage Aws_codepipeline_stage_151
+    Stage []Aws_codepipeline_stage_151
 
 }
 
@@ -8121,8 +7817,6 @@ func (h *Aws_codepipelineHandler) Delete(externalID string) error {
 
 type Aws_codepipeline_webhook_authentication_configuration_153 struct {
 
-    Aws_codepipeline_webhook_authentication_configuration_153_id *string `lyra:"ignore"`
-
     Allowed_ip_range *string
 
     Secret_token *string
@@ -8130,8 +7824,6 @@ type Aws_codepipeline_webhook_authentication_configuration_153 struct {
 }
 
 type Aws_codepipeline_webhook_filter_154 struct {
-
-    Aws_codepipeline_webhook_filter_154_id *string `lyra:"ignore"`
 
     Json_path string
 
@@ -8145,7 +7837,7 @@ type Aws_codepipeline_webhook struct {
 
     Authentication string
 
-    Authentication_configuration *Aws_codepipeline_webhook_authentication_configuration_153
+    Authentication_configuration *[]Aws_codepipeline_webhook_authentication_configuration_153
 
     Filter Aws_codepipeline_webhook_filter_154
 
@@ -8197,8 +7889,6 @@ func (h *Aws_codepipeline_webhookHandler) Delete(externalID string) error {
 }
 
 type Aws_cognito_identity_pool_cognito_identity_providers_155 struct {
-
-    Aws_cognito_identity_pool_cognito_identity_providers_155_id *string `lyra:"ignore"`
 
     Client_id *string
 
@@ -8269,8 +7959,6 @@ func (h *Aws_cognito_identity_poolHandler) Delete(externalID string) error {
 
 type Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157 struct {
 
-    Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157_id *string `lyra:"ignore"`
-
     Claim string
 
     Match_type string
@@ -8283,13 +7971,11 @@ type Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_15
 
 type Aws_cognito_identity_pool_roles_attachment_role_mapping_156 struct {
 
-    Aws_cognito_identity_pool_roles_attachment_role_mapping_156_id *string `lyra:"ignore"`
-
     Ambiguous_role_resolution *string
 
     Identity_provider string
 
-    Mapping_rule *Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157
+    Mapping_rule *[]Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157
 
     Type string
 
@@ -8400,8 +8086,6 @@ func (h *Aws_cognito_identity_providerHandler) Delete(externalID string) error {
 }
 
 type Aws_cognito_resource_server_scope_158 struct {
-
-    Aws_cognito_resource_server_scope_158_id *string `lyra:"ignore"`
 
     Scope_description string
 
@@ -8517,8 +8201,6 @@ func (h *Aws_cognito_user_groupHandler) Delete(externalID string) error {
 
 type Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160 struct {
 
-    Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160_id *string `lyra:"ignore"`
-
     Email_message *string
 
     Email_subject *string
@@ -8529,19 +8211,15 @@ type Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_
 
 type Aws_cognito_user_pool_admin_create_user_config_159 struct {
 
-    Aws_cognito_user_pool_admin_create_user_config_159_id *string `lyra:"ignore"`
-
     Allow_admin_create_user_only *bool
 
-    Invite_message_template *Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160
+    Invite_message_template *[]Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160
 
     Unused_account_validity_days *int
 
 }
 
 type Aws_cognito_user_pool_device_configuration_161 struct {
-
-    Aws_cognito_user_pool_device_configuration_161_id *string `lyra:"ignore"`
 
     Challenge_required_on_new_device *bool
 
@@ -8551,8 +8229,6 @@ type Aws_cognito_user_pool_device_configuration_161 struct {
 
 type Aws_cognito_user_pool_email_configuration_162 struct {
 
-    Aws_cognito_user_pool_email_configuration_162_id *string `lyra:"ignore"`
-
     Reply_to_email_address *string
 
     Source_arn *string
@@ -8560,8 +8236,6 @@ type Aws_cognito_user_pool_email_configuration_162 struct {
 }
 
 type Aws_cognito_user_pool_lambda_config_163 struct {
-
-    Aws_cognito_user_pool_lambda_config_163_id *string `lyra:"ignore"`
 
     Create_auth_challenge *string
 
@@ -8587,8 +8261,6 @@ type Aws_cognito_user_pool_lambda_config_163 struct {
 
 type Aws_cognito_user_pool_password_policy_164 struct {
 
-    Aws_cognito_user_pool_password_policy_164_id *string `lyra:"ignore"`
-
     Minimum_length *int
 
     Require_lowercase *bool
@@ -8603,8 +8275,6 @@ type Aws_cognito_user_pool_password_policy_164 struct {
 
 type Aws_cognito_user_pool_schema_165_number_attribute_constraints_166 struct {
 
-    Aws_cognito_user_pool_schema_165_number_attribute_constraints_166_id *string `lyra:"ignore"`
-
     Max_value *string
 
     Min_value *string
@@ -8612,8 +8282,6 @@ type Aws_cognito_user_pool_schema_165_number_attribute_constraints_166 struct {
 }
 
 type Aws_cognito_user_pool_schema_165_string_attribute_constraints_167 struct {
-
-    Aws_cognito_user_pool_schema_165_string_attribute_constraints_167_id *string `lyra:"ignore"`
 
     Max_length *string
 
@@ -8623,8 +8291,6 @@ type Aws_cognito_user_pool_schema_165_string_attribute_constraints_167 struct {
 
 type Aws_cognito_user_pool_schema_165 struct {
 
-    Aws_cognito_user_pool_schema_165_id *string `lyra:"ignore"`
-
     Attribute_data_type string
 
     Developer_only_attribute *bool
@@ -8633,17 +8299,15 @@ type Aws_cognito_user_pool_schema_165 struct {
 
     Name string
 
-    Number_attribute_constraints *Aws_cognito_user_pool_schema_165_number_attribute_constraints_166
+    Number_attribute_constraints *[]Aws_cognito_user_pool_schema_165_number_attribute_constraints_166
 
     Required *bool
 
-    String_attribute_constraints *Aws_cognito_user_pool_schema_165_string_attribute_constraints_167
+    String_attribute_constraints *[]Aws_cognito_user_pool_schema_165_string_attribute_constraints_167
 
 }
 
 type Aws_cognito_user_pool_sms_configuration_168 struct {
-
-    Aws_cognito_user_pool_sms_configuration_168_id *string `lyra:"ignore"`
 
     External_id string
 
@@ -8652,8 +8316,6 @@ type Aws_cognito_user_pool_sms_configuration_168 struct {
 }
 
 type Aws_cognito_user_pool_verification_message_template_169 struct {
-
-    Aws_cognito_user_pool_verification_message_template_169_id *string `lyra:"ignore"`
 
     Default_email_option *string
 
@@ -8673,7 +8335,7 @@ type Aws_cognito_user_pool struct {
 
     Aws_cognito_user_pool_id *string `lyra:"ignore"`
 
-    Admin_create_user_config *Aws_cognito_user_pool_admin_create_user_config_159
+    Admin_create_user_config *[]Aws_cognito_user_pool_admin_create_user_config_159
 
     Alias_attributes *[]string
 
@@ -8683,9 +8345,9 @@ type Aws_cognito_user_pool struct {
 
     Creation_date *string
 
-    Device_configuration *Aws_cognito_user_pool_device_configuration_161
+    Device_configuration *[]Aws_cognito_user_pool_device_configuration_161
 
-    Email_configuration *Aws_cognito_user_pool_email_configuration_162
+    Email_configuration *[]Aws_cognito_user_pool_email_configuration_162
 
     Email_verification_message *string
 
@@ -8693,7 +8355,7 @@ type Aws_cognito_user_pool struct {
 
     Endpoint *string
 
-    Lambda_config *Aws_cognito_user_pool_lambda_config_163
+    Lambda_config *[]Aws_cognito_user_pool_lambda_config_163
 
     Last_modified_date *string
 
@@ -8701,13 +8363,13 @@ type Aws_cognito_user_pool struct {
 
     Name string
 
-    Password_policy *Aws_cognito_user_pool_password_policy_164
+    Password_policy *[]Aws_cognito_user_pool_password_policy_164
 
     Schema *Aws_cognito_user_pool_schema_165
 
     Sms_authentication_message *string
 
-    Sms_configuration *Aws_cognito_user_pool_sms_configuration_168
+    Sms_configuration *[]Aws_cognito_user_pool_sms_configuration_168
 
     Sms_verification_message *string
 
@@ -8715,7 +8377,7 @@ type Aws_cognito_user_pool struct {
 
     Username_attributes *[]string
 
-    Verification_message_template *Aws_cognito_user_pool_verification_message_template_169
+    Verification_message_template *[]Aws_cognito_user_pool_verification_message_template_169
 
 }
 
@@ -8937,8 +8599,6 @@ func (h *Aws_config_aggregate_authorizationHandler) Delete(externalID string) er
 
 type Aws_config_config_rule_scope_170 struct {
 
-    Aws_config_config_rule_scope_170_id *string `lyra:"ignore"`
-
     Compliance_resource_id *string
 
     Compliance_resource_types *[]string
@@ -8951,8 +8611,6 @@ type Aws_config_config_rule_scope_170 struct {
 
 type Aws_config_config_rule_source_171_source_detail_172 struct {
 
-    Aws_config_config_rule_source_171_source_detail_172_id *string `lyra:"ignore"`
-
     Event_source *string
 
     Maximum_execution_frequency *string
@@ -8962,8 +8620,6 @@ type Aws_config_config_rule_source_171_source_detail_172 struct {
 }
 
 type Aws_config_config_rule_source_171 struct {
-
-    Aws_config_config_rule_source_171_id *string `lyra:"ignore"`
 
     Owner string
 
@@ -8989,9 +8645,9 @@ type Aws_config_config_rule struct {
 
     Rule_id *string
 
-    Scope *Aws_config_config_rule_scope_170
+    Scope *[]Aws_config_config_rule_scope_170
 
-    Source Aws_config_config_rule_source_171
+    Source []Aws_config_config_rule_source_171
 
 }
 
@@ -9034,8 +8690,6 @@ func (h *Aws_config_config_ruleHandler) Delete(externalID string) error {
 
 type Aws_config_configuration_aggregator_account_aggregation_source_173 struct {
 
-    Aws_config_configuration_aggregator_account_aggregation_source_173_id *string `lyra:"ignore"`
-
     Account_ids []string
 
     All_regions *bool
@@ -9045,8 +8699,6 @@ type Aws_config_configuration_aggregator_account_aggregation_source_173 struct {
 }
 
 type Aws_config_configuration_aggregator_organization_aggregation_source_174 struct {
-
-    Aws_config_configuration_aggregator_organization_aggregation_source_174_id *string `lyra:"ignore"`
 
     All_regions *bool
 
@@ -9060,13 +8712,13 @@ type Aws_config_configuration_aggregator struct {
 
     Aws_config_configuration_aggregator_id *string `lyra:"ignore"`
 
-    Account_aggregation_source *Aws_config_configuration_aggregator_account_aggregation_source_173
+    Account_aggregation_source *[]Aws_config_configuration_aggregator_account_aggregation_source_173
 
     Arn *string
 
     Name string
 
-    Organization_aggregation_source *Aws_config_configuration_aggregator_organization_aggregation_source_174
+    Organization_aggregation_source *[]Aws_config_configuration_aggregator_organization_aggregation_source_174
 
 }
 
@@ -9109,8 +8761,6 @@ func (h *Aws_config_configuration_aggregatorHandler) Delete(externalID string) e
 
 type Aws_config_configuration_recorder_recording_group_175 struct {
 
-    Aws_config_configuration_recorder_recording_group_175_id *string `lyra:"ignore"`
-
     All_supported *bool
 
     Include_global_resource_types *bool
@@ -9125,7 +8775,7 @@ type Aws_config_configuration_recorder struct {
 
     Name *string
 
-    Recording_group *Aws_config_configuration_recorder_recording_group_175
+    Recording_group *[]Aws_config_configuration_recorder_recording_group_175
 
     Role_arn string
 
@@ -9217,8 +8867,6 @@ func (h *Aws_config_configuration_recorder_statusHandler) Delete(externalID stri
 
 type Aws_config_delivery_channel_snapshot_delivery_properties_176 struct {
 
-    Aws_config_delivery_channel_snapshot_delivery_properties_176_id *string `lyra:"ignore"`
-
     Delivery_frequency *string
 
 }
@@ -9233,7 +8881,7 @@ type Aws_config_delivery_channel struct {
 
     S3_key_prefix *string
 
-    Snapshot_delivery_properties *Aws_config_delivery_channel_snapshot_delivery_properties_176
+    Snapshot_delivery_properties *[]Aws_config_delivery_channel_snapshot_delivery_properties_176
 
     Sns_topic_arn *string
 
@@ -9382,8 +9030,6 @@ func (h *Aws_datasync_agentHandler) Delete(externalID string) error {
 
 type Aws_datasync_location_efs_ec2_config_177 struct {
 
-    Aws_datasync_location_efs_ec2_config_177_id *string `lyra:"ignore"`
-
     Security_group_arns []string
 
     Subnet_arn string
@@ -9396,7 +9042,7 @@ type Aws_datasync_location_efs struct {
 
     Arn *string
 
-    Ec2_config Aws_datasync_location_efs_ec2_config_177
+    Ec2_config []Aws_datasync_location_efs_ec2_config_177
 
     Efs_file_system_arn string
 
@@ -9447,8 +9093,6 @@ func (h *Aws_datasync_location_efsHandler) Delete(externalID string) error {
 
 type Aws_datasync_location_nfs_on_prem_config_178 struct {
 
-    Aws_datasync_location_nfs_on_prem_config_178_id *string `lyra:"ignore"`
-
     Agent_arns []string
 
 }
@@ -9459,7 +9103,7 @@ type Aws_datasync_location_nfs struct {
 
     Arn *string
 
-    On_prem_config Aws_datasync_location_nfs_on_prem_config_178
+    On_prem_config []Aws_datasync_location_nfs_on_prem_config_178
 
     Server_hostname string
 
@@ -9510,8 +9154,6 @@ func (h *Aws_datasync_location_nfsHandler) Delete(externalID string) error {
 
 type Aws_datasync_location_s3_s3_config_179 struct {
 
-    Aws_datasync_location_s3_s3_config_179_id *string `lyra:"ignore"`
-
     Bucket_access_role_arn string
 
 }
@@ -9524,7 +9166,7 @@ type Aws_datasync_location_s3 struct {
 
     S3_bucket_arn string
 
-    S3_config Aws_datasync_location_s3_s3_config_179
+    S3_config []Aws_datasync_location_s3_s3_config_179
 
     Subdirectory string
 
@@ -9573,8 +9215,6 @@ func (h *Aws_datasync_location_s3Handler) Delete(externalID string) error {
 
 type Aws_datasync_task_options_180 struct {
 
-    Aws_datasync_task_options_180_id *string `lyra:"ignore"`
-
     Atime *string
 
     Bytes_per_second *int
@@ -9607,7 +9247,7 @@ type Aws_datasync_task struct {
 
     Name *string
 
-    Options *Aws_datasync_task_options_180
+    Options *[]Aws_datasync_task_options_180
 
     Source_location_arn string
 
@@ -9654,8 +9294,6 @@ func (h *Aws_datasync_taskHandler) Delete(externalID string) error {
 
 type Aws_dax_cluster_nodes_181 struct {
 
-    Aws_dax_cluster_nodes_181_id *string `lyra:"ignore"`
-
     Address *string
 
     Availability_zone *string
@@ -9667,8 +9305,6 @@ type Aws_dax_cluster_nodes_181 struct {
 }
 
 type Aws_dax_cluster_server_side_encryption_182 struct {
-
-    Aws_dax_cluster_server_side_encryption_182_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -9696,7 +9332,7 @@ type Aws_dax_cluster struct {
 
     Node_type string
 
-    Nodes *Aws_dax_cluster_nodes_181
+    Nodes *[]Aws_dax_cluster_nodes_181
 
     Notification_topic_arn *string
 
@@ -9708,7 +9344,7 @@ type Aws_dax_cluster struct {
 
     Security_group_ids *[]string
 
-    Server_side_encryption *Aws_dax_cluster_server_side_encryption_182
+    Server_side_encryption *[]Aws_dax_cluster_server_side_encryption_182
 
     Subnet_group_name *string
 
@@ -9754,8 +9390,6 @@ func (h *Aws_dax_clusterHandler) Delete(externalID string) error {
 }
 
 type Aws_dax_parameter_group_parameters_183 struct {
-
-    Aws_dax_parameter_group_parameters_183_id *string `lyra:"ignore"`
 
     Name string
 
@@ -10001,8 +9635,6 @@ func (h *Aws_db_event_subscriptionHandler) Delete(externalID string) error {
 
 type Aws_db_instance_s3_import_184 struct {
 
-    Aws_db_instance_s3_import_184_id *string `lyra:"ignore"`
-
     Bucket_name string
 
     Bucket_prefix *string
@@ -10103,7 +9735,7 @@ type Aws_db_instance struct {
 
     Resource_id *string
 
-    S3_import *Aws_db_instance_s3_import_184
+    S3_import *[]Aws_db_instance_s3_import_184
 
     Security_group_names *[]string
 
@@ -10166,8 +9798,6 @@ func (h *Aws_db_instanceHandler) Delete(externalID string) error {
 
 type Aws_db_option_group_option_185_option_settings_186 struct {
 
-    Aws_db_option_group_option_185_option_settings_186_id *string `lyra:"ignore"`
-
     Name string
 
     Value string
@@ -10175,8 +9805,6 @@ type Aws_db_option_group_option_185_option_settings_186 struct {
 }
 
 type Aws_db_option_group_option_185 struct {
-
-    Aws_db_option_group_option_185_id *string `lyra:"ignore"`
 
     Db_security_group_memberships *[]string
 
@@ -10253,8 +9881,6 @@ func (h *Aws_db_option_groupHandler) Delete(externalID string) error {
 
 type Aws_db_parameter_group_parameter_187 struct {
 
-    Aws_db_parameter_group_parameter_187_id *string `lyra:"ignore"`
-
     Apply_method *string
 
     Name string
@@ -10321,8 +9947,6 @@ func (h *Aws_db_parameter_groupHandler) Delete(externalID string) error {
 }
 
 type Aws_db_security_group_ingress_188 struct {
-
-    Aws_db_security_group_ingress_188_id *string `lyra:"ignore"`
 
     Cidr *string
 
@@ -10527,8 +10151,6 @@ func (h *Aws_db_subnet_groupHandler) Delete(externalID string) error {
 
 type Aws_default_network_acl_egress_189 struct {
 
-    Aws_default_network_acl_egress_189_id *string `lyra:"ignore"`
-
     Action string
 
     Cidr_block *string
@@ -10550,8 +10172,6 @@ type Aws_default_network_acl_egress_189 struct {
 }
 
 type Aws_default_network_acl_ingress_190 struct {
-
-    Aws_default_network_acl_ingress_190_id *string `lyra:"ignore"`
 
     Action string
 
@@ -10632,8 +10252,6 @@ func (h *Aws_default_network_aclHandler) Delete(externalID string) error {
 
 type Aws_default_route_table_route_191 struct {
 
-    Aws_default_route_table_route_191_id *string `lyra:"ignore"`
-
     Cidr_block *string
 
     Egress_only_gateway_id *string
@@ -10711,8 +10329,6 @@ func (h *Aws_default_route_tableHandler) Delete(externalID string) error {
 
 type Aws_default_security_group_egress_192 struct {
 
-    Aws_default_security_group_egress_192_id *string `lyra:"ignore"`
-
     Cidr_blocks *[]string
 
     Description *string
@@ -10734,8 +10350,6 @@ type Aws_default_security_group_egress_192 struct {
 }
 
 type Aws_default_security_group_ingress_193 struct {
-
-    Aws_default_security_group_ingress_193_id *string `lyra:"ignore"`
 
     Cidr_blocks *[]string
 
@@ -11113,8 +10727,6 @@ func (h *Aws_directory_service_conditional_forwarderHandler) Delete(externalID s
 
 type Aws_directory_service_directory_connect_settings_194 struct {
 
-    Aws_directory_service_directory_connect_settings_194_id *string `lyra:"ignore"`
-
     Customer_dns_ips []string
 
     Customer_username string
@@ -11126,8 +10738,6 @@ type Aws_directory_service_directory_connect_settings_194 struct {
 }
 
 type Aws_directory_service_directory_vpc_settings_195 struct {
-
-    Aws_directory_service_directory_vpc_settings_195_id *string `lyra:"ignore"`
 
     Subnet_ids []string
 
@@ -11143,7 +10753,7 @@ type Aws_directory_service_directory struct {
 
     Alias *string
 
-    Connect_settings *Aws_directory_service_directory_connect_settings_194
+    Connect_settings *[]Aws_directory_service_directory_connect_settings_194
 
     Description *string
 
@@ -11167,7 +10777,7 @@ type Aws_directory_service_directory struct {
 
     Type *string
 
-    Vpc_settings *Aws_directory_service_directory_vpc_settings_195
+    Vpc_settings *[]Aws_directory_service_directory_vpc_settings_195
 
 }
 
@@ -11210,8 +10820,6 @@ func (h *Aws_directory_service_directoryHandler) Delete(externalID string) error
 
 type Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198 struct {
 
-    Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198_id *string `lyra:"ignore"`
-
     Interval int
 
     Interval_unit *string
@@ -11222,23 +10830,19 @@ type Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198 st
 
 type Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199 struct {
 
-    Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199_id *string `lyra:"ignore"`
-
     Count int
 
 }
 
 type Aws_dlm_lifecycle_policy_policy_details_196_schedule_197 struct {
 
-    Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_id *string `lyra:"ignore"`
-
     Copy_tags *bool
 
-    Create_rule Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198
+    Create_rule []Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198
 
     Name string
 
-    Retain_rule Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199
+    Retain_rule []Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199
 
     Tags_to_add *map[string]string
 
@@ -11246,11 +10850,9 @@ type Aws_dlm_lifecycle_policy_policy_details_196_schedule_197 struct {
 
 type Aws_dlm_lifecycle_policy_policy_details_196 struct {
 
-    Aws_dlm_lifecycle_policy_policy_details_196_id *string `lyra:"ignore"`
-
     Resource_types []string
 
-    Schedule Aws_dlm_lifecycle_policy_policy_details_196_schedule_197
+    Schedule []Aws_dlm_lifecycle_policy_policy_details_196_schedule_197
 
     Target_tags map[string]string
 
@@ -11264,7 +10866,7 @@ type Aws_dlm_lifecycle_policy struct {
 
     Execution_role_arn string
 
-    Policy_details Aws_dlm_lifecycle_policy_policy_details_196
+    Policy_details []Aws_dlm_lifecycle_policy_policy_details_196
 
     State *string
 
@@ -11360,8 +10962,6 @@ func (h *Aws_dms_certificateHandler) Delete(externalID string) error {
 
 type Aws_dms_endpoint_mongodb_settings_200 struct {
 
-    Aws_dms_endpoint_mongodb_settings_200_id *string `lyra:"ignore"`
-
     Auth_mechanism *string
 
     Auth_source *string
@@ -11377,8 +10977,6 @@ type Aws_dms_endpoint_mongodb_settings_200 struct {
 }
 
 type Aws_dms_endpoint_s3_settings_201 struct {
-
-    Aws_dms_endpoint_s3_settings_201_id *string `lyra:"ignore"`
 
     Bucket_folder *string
 
@@ -11416,13 +11014,13 @@ type Aws_dms_endpoint struct {
 
     Kms_key_arn *string
 
-    Mongodb_settings *Aws_dms_endpoint_mongodb_settings_200
+    Mongodb_settings *[]Aws_dms_endpoint_mongodb_settings_200
 
     Password *string
 
     Port *int
 
-    S3_settings *Aws_dms_endpoint_s3_settings_201
+    S3_settings *[]Aws_dms_endpoint_s3_settings_201
 
     Server_name *string
 
@@ -11669,8 +11267,6 @@ func (h *Aws_dms_replication_taskHandler) Delete(externalID string) error {
 }
 
 type Aws_docdb_cluster_parameter_group_parameter_202 struct {
-
-    Aws_docdb_cluster_parameter_group_parameter_202_id *string `lyra:"ignore"`
 
     Apply_method *string
 
@@ -12474,8 +12070,6 @@ func (h *Aws_dx_public_virtual_interfaceHandler) Delete(externalID string) error
 
 type Aws_dynamodb_global_table_replica_203 struct {
 
-    Aws_dynamodb_global_table_replica_203_id *string `lyra:"ignore"`
-
     Region_name string
 
 }
@@ -12531,8 +12125,6 @@ func (h *Aws_dynamodb_global_tableHandler) Delete(externalID string) error {
 
 type Aws_dynamodb_table_attribute_204 struct {
 
-    Aws_dynamodb_table_attribute_204_id *string `lyra:"ignore"`
-
     Name string
 
     Type string
@@ -12540,8 +12132,6 @@ type Aws_dynamodb_table_attribute_204 struct {
 }
 
 type Aws_dynamodb_table_global_secondary_index_205 struct {
-
-    Aws_dynamodb_table_global_secondary_index_205_id *string `lyra:"ignore"`
 
     Hash_key string
 
@@ -12561,8 +12151,6 @@ type Aws_dynamodb_table_global_secondary_index_205 struct {
 
 type Aws_dynamodb_table_local_secondary_index_206 struct {
 
-    Aws_dynamodb_table_local_secondary_index_206_id *string `lyra:"ignore"`
-
     Name string
 
     Non_key_attributes *[]string
@@ -12575,23 +12163,17 @@ type Aws_dynamodb_table_local_secondary_index_206 struct {
 
 type Aws_dynamodb_table_point_in_time_recovery_207 struct {
 
-    Aws_dynamodb_table_point_in_time_recovery_207_id *string `lyra:"ignore"`
-
     Enabled bool
 
 }
 
 type Aws_dynamodb_table_server_side_encryption_208 struct {
 
-    Aws_dynamodb_table_server_side_encryption_208_id *string `lyra:"ignore"`
-
     Enabled bool
 
 }
 
 type Aws_dynamodb_table_ttl_209 struct {
-
-    Aws_dynamodb_table_ttl_209_id *string `lyra:"ignore"`
 
     Attribute_name string
 
@@ -12617,13 +12199,13 @@ type Aws_dynamodb_table struct {
 
     Name string
 
-    Point_in_time_recovery *Aws_dynamodb_table_point_in_time_recovery_207
+    Point_in_time_recovery *[]Aws_dynamodb_table_point_in_time_recovery_207
 
     Range_key *string
 
     Read_capacity *int
 
-    Server_side_encryption *Aws_dynamodb_table_server_side_encryption_208
+    Server_side_encryption *[]Aws_dynamodb_table_server_side_encryption_208
 
     Stream_arn *string
 
@@ -12983,8 +12565,6 @@ func (h *Aws_ec2_capacity_reservationHandler) Delete(externalID string) error {
 
 type Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211 struct {
 
-    Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211_id *string `lyra:"ignore"`
-
     Launch_template_id *string
 
     Launch_template_name *string
@@ -12994,8 +12574,6 @@ type Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211 
 }
 
 type Aws_ec2_fleet_launch_template_config_210_override_212 struct {
-
-    Aws_ec2_fleet_launch_template_config_210_override_212_id *string `lyra:"ignore"`
 
     Availability_zone *string
 
@@ -13013,25 +12591,19 @@ type Aws_ec2_fleet_launch_template_config_210_override_212 struct {
 
 type Aws_ec2_fleet_launch_template_config_210 struct {
 
-    Aws_ec2_fleet_launch_template_config_210_id *string `lyra:"ignore"`
+    Launch_template_specification []Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211
 
-    Launch_template_specification Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211
-
-    Override *Aws_ec2_fleet_launch_template_config_210_override_212
+    Override *[]Aws_ec2_fleet_launch_template_config_210_override_212
 
 }
 
 type Aws_ec2_fleet_on_demand_options_213 struct {
-
-    Aws_ec2_fleet_on_demand_options_213_id *string `lyra:"ignore"`
 
     Allocation_strategy *string
 
 }
 
 type Aws_ec2_fleet_spot_options_214 struct {
-
-    Aws_ec2_fleet_spot_options_214_id *string `lyra:"ignore"`
 
     Allocation_strategy *string
 
@@ -13042,8 +12614,6 @@ type Aws_ec2_fleet_spot_options_214 struct {
 }
 
 type Aws_ec2_fleet_target_capacity_specification_215 struct {
-
-    Aws_ec2_fleet_target_capacity_specification_215_id *string `lyra:"ignore"`
 
     Default_target_capacity_type string
 
@@ -13061,17 +12631,17 @@ type Aws_ec2_fleet struct {
 
     Excess_capacity_termination_policy *string
 
-    Launch_template_config Aws_ec2_fleet_launch_template_config_210
+    Launch_template_config []Aws_ec2_fleet_launch_template_config_210
 
-    On_demand_options *Aws_ec2_fleet_on_demand_options_213
+    On_demand_options *[]Aws_ec2_fleet_on_demand_options_213
 
     Replace_unhealthy_instances *bool
 
-    Spot_options *Aws_ec2_fleet_spot_options_214
+    Spot_options *[]Aws_ec2_fleet_spot_options_214
 
     Tags *map[string]string
 
-    Target_capacity_specification Aws_ec2_fleet_target_capacity_specification_215
+    Target_capacity_specification []Aws_ec2_fleet_target_capacity_specification_215
 
     Terminate_instances *bool
 
@@ -13650,15 +13220,11 @@ func (h *Aws_ecs_clusterHandler) Delete(externalID string) error {
 
 type Aws_ecs_service_deployment_controller_216 struct {
 
-    Aws_ecs_service_deployment_controller_216_id *string `lyra:"ignore"`
-
     Type *string
 
 }
 
 type Aws_ecs_service_load_balancer_217 struct {
-
-    Aws_ecs_service_load_balancer_217_id *string `lyra:"ignore"`
 
     Container_name string
 
@@ -13672,8 +13238,6 @@ type Aws_ecs_service_load_balancer_217 struct {
 
 type Aws_ecs_service_network_configuration_218 struct {
 
-    Aws_ecs_service_network_configuration_218_id *string `lyra:"ignore"`
-
     Assign_public_ip *bool
 
     Security_groups *[]string
@@ -13684,8 +13248,6 @@ type Aws_ecs_service_network_configuration_218 struct {
 
 type Aws_ecs_service_ordered_placement_strategy_219 struct {
 
-    Aws_ecs_service_ordered_placement_strategy_219_id *string `lyra:"ignore"`
-
     Field *string
 
     Type string
@@ -13693,8 +13255,6 @@ type Aws_ecs_service_ordered_placement_strategy_219 struct {
 }
 
 type Aws_ecs_service_placement_constraints_220 struct {
-
-    Aws_ecs_service_placement_constraints_220_id *string `lyra:"ignore"`
 
     Expression *string
 
@@ -13704,8 +13264,6 @@ type Aws_ecs_service_placement_constraints_220 struct {
 
 type Aws_ecs_service_placement_strategy_221 struct {
 
-    Aws_ecs_service_placement_strategy_221_id *string `lyra:"ignore"`
-
     Field *string
 
     Type string
@@ -13713,8 +13271,6 @@ type Aws_ecs_service_placement_strategy_221 struct {
 }
 
 type Aws_ecs_service_service_registries_222 struct {
-
-    Aws_ecs_service_service_registries_222_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -13732,7 +13288,7 @@ type Aws_ecs_service struct {
 
     Cluster *string
 
-    Deployment_controller *Aws_ecs_service_deployment_controller_216
+    Deployment_controller *[]Aws_ecs_service_deployment_controller_216
 
     Deployment_maximum_percent *int
 
@@ -13752,9 +13308,9 @@ type Aws_ecs_service struct {
 
     Name string
 
-    Network_configuration *Aws_ecs_service_network_configuration_218
+    Network_configuration *[]Aws_ecs_service_network_configuration_218
 
-    Ordered_placement_strategy *Aws_ecs_service_ordered_placement_strategy_219
+    Ordered_placement_strategy *[]Aws_ecs_service_ordered_placement_strategy_219
 
     Placement_constraints *Aws_ecs_service_placement_constraints_220
 
@@ -13813,8 +13369,6 @@ func (h *Aws_ecs_serviceHandler) Delete(externalID string) error {
 
 type Aws_ecs_task_definition_placement_constraints_223 struct {
 
-    Aws_ecs_task_definition_placement_constraints_223_id *string `lyra:"ignore"`
-
     Expression *string
 
     Type string
@@ -13822,8 +13376,6 @@ type Aws_ecs_task_definition_placement_constraints_223 struct {
 }
 
 type Aws_ecs_task_definition_volume_224_docker_volume_configuration_225 struct {
-
-    Aws_ecs_task_definition_volume_224_docker_volume_configuration_225_id *string `lyra:"ignore"`
 
     Autoprovision *bool
 
@@ -13839,9 +13391,7 @@ type Aws_ecs_task_definition_volume_224_docker_volume_configuration_225 struct {
 
 type Aws_ecs_task_definition_volume_224 struct {
 
-    Aws_ecs_task_definition_volume_224_id *string `lyra:"ignore"`
-
-    Docker_volume_configuration *Aws_ecs_task_definition_volume_224_docker_volume_configuration_225
+    Docker_volume_configuration *[]Aws_ecs_task_definition_volume_224_docker_volume_configuration_225
 
     Host_path *string
 
@@ -14209,15 +13759,11 @@ func (h *Aws_eip_associationHandler) Delete(externalID string) error {
 
 type Aws_eks_cluster_certificate_authority_226 struct {
 
-    Aws_eks_cluster_certificate_authority_226_id *string `lyra:"ignore"`
-
     Data *string
 
 }
 
 type Aws_eks_cluster_vpc_config_227 struct {
-
-    Aws_eks_cluster_vpc_config_227_id *string `lyra:"ignore"`
 
     Security_group_ids *[]string
 
@@ -14233,7 +13779,7 @@ type Aws_eks_cluster struct {
 
     Arn *string
 
-    Certificate_authority *Aws_eks_cluster_certificate_authority_226
+    Certificate_authority *[]Aws_eks_cluster_certificate_authority_226
 
     Created_at *string
 
@@ -14247,7 +13793,7 @@ type Aws_eks_cluster struct {
 
     Version *string
 
-    Vpc_config Aws_eks_cluster_vpc_config_227
+    Vpc_config []Aws_eks_cluster_vpc_config_227
 
 }
 
@@ -14290,8 +13836,6 @@ func (h *Aws_eks_clusterHandler) Delete(externalID string) error {
 
 type Aws_elastic_beanstalk_application_appversion_lifecycle_228 struct {
 
-    Aws_elastic_beanstalk_application_appversion_lifecycle_228_id *string `lyra:"ignore"`
-
     Delete_source_from_s3 *bool
 
     Max_age_in_days *int
@@ -14306,7 +13850,7 @@ type Aws_elastic_beanstalk_application struct {
 
     Aws_elastic_beanstalk_application_id *string `lyra:"ignore"`
 
-    Appversion_lifecycle *Aws_elastic_beanstalk_application_appversion_lifecycle_228
+    Appversion_lifecycle *[]Aws_elastic_beanstalk_application_appversion_lifecycle_228
 
     Description *string
 
@@ -14408,8 +13952,6 @@ func (h *Aws_elastic_beanstalk_application_versionHandler) Delete(externalID str
 
 type Aws_elastic_beanstalk_configuration_template_setting_229 struct {
 
-    Aws_elastic_beanstalk_configuration_template_setting_229_id *string `lyra:"ignore"`
-
     Name string
 
     Namespace string
@@ -14477,8 +14019,6 @@ func (h *Aws_elastic_beanstalk_configuration_templateHandler) Delete(externalID 
 
 type Aws_elastic_beanstalk_environment_all_settings_230 struct {
 
-    Aws_elastic_beanstalk_environment_all_settings_230_id *string `lyra:"ignore"`
-
     Name string
 
     Namespace string
@@ -14490,8 +14030,6 @@ type Aws_elastic_beanstalk_environment_all_settings_230 struct {
 }
 
 type Aws_elastic_beanstalk_environment_setting_231 struct {
-
-    Aws_elastic_beanstalk_environment_setting_231_id *string `lyra:"ignore"`
 
     Name string
 
@@ -14592,8 +14130,6 @@ func (h *Aws_elastic_beanstalk_environmentHandler) Delete(externalID string) err
 
 type Aws_elasticache_cluster_cache_nodes_232 struct {
 
-    Aws_elasticache_cluster_cache_nodes_232_id *string `lyra:"ignore"`
-
     Address *string
 
     Availability_zone *string
@@ -14616,7 +14152,7 @@ type Aws_elasticache_cluster struct {
 
     Az_mode *string
 
-    Cache_nodes *Aws_elasticache_cluster_cache_nodes_232
+    Cache_nodes *[]Aws_elasticache_cluster_cache_nodes_232
 
     Cluster_address *string
 
@@ -14701,8 +14237,6 @@ func (h *Aws_elasticache_clusterHandler) Delete(externalID string) error {
 
 type Aws_elasticache_parameter_group_parameter_233 struct {
 
-    Aws_elasticache_parameter_group_parameter_233_id *string `lyra:"ignore"`
-
     Name string
 
     Value string
@@ -14762,8 +14296,6 @@ func (h *Aws_elasticache_parameter_groupHandler) Delete(externalID string) error
 
 type Aws_elasticache_replication_group_cluster_mode_234 struct {
 
-    Aws_elasticache_replication_group_cluster_mode_234_id *string `lyra:"ignore"`
-
     Num_node_groups int
 
     Replicas_per_node_group int
@@ -14786,7 +14318,7 @@ type Aws_elasticache_replication_group struct {
 
     Availability_zones *[]string
 
-    Cluster_mode *Aws_elasticache_replication_group_cluster_mode_234
+    Cluster_mode *[]Aws_elasticache_replication_group_cluster_mode_234
 
     Configuration_endpoint_address *string
 
@@ -14971,8 +14503,6 @@ func (h *Aws_elasticache_subnet_groupHandler) Delete(externalID string) error {
 
 type Aws_elasticsearch_domain_cluster_config_235 struct {
 
-    Aws_elasticsearch_domain_cluster_config_235_id *string `lyra:"ignore"`
-
     Dedicated_master_count *int
 
     Dedicated_master_enabled *bool
@@ -14989,8 +14519,6 @@ type Aws_elasticsearch_domain_cluster_config_235 struct {
 
 type Aws_elasticsearch_domain_cognito_options_236 struct {
 
-    Aws_elasticsearch_domain_cognito_options_236_id *string `lyra:"ignore"`
-
     Enabled *bool
 
     Identity_pool_id string
@@ -15002,8 +14530,6 @@ type Aws_elasticsearch_domain_cognito_options_236 struct {
 }
 
 type Aws_elasticsearch_domain_ebs_options_237 struct {
-
-    Aws_elasticsearch_domain_ebs_options_237_id *string `lyra:"ignore"`
 
     Ebs_enabled bool
 
@@ -15017,8 +14543,6 @@ type Aws_elasticsearch_domain_ebs_options_237 struct {
 
 type Aws_elasticsearch_domain_encrypt_at_rest_238 struct {
 
-    Aws_elasticsearch_domain_encrypt_at_rest_238_id *string `lyra:"ignore"`
-
     Enabled bool
 
     Kms_key_id *string
@@ -15026,8 +14550,6 @@ type Aws_elasticsearch_domain_encrypt_at_rest_238 struct {
 }
 
 type Aws_elasticsearch_domain_log_publishing_options_239 struct {
-
-    Aws_elasticsearch_domain_log_publishing_options_239_id *string `lyra:"ignore"`
 
     Cloudwatch_log_group_arn string
 
@@ -15039,23 +14561,17 @@ type Aws_elasticsearch_domain_log_publishing_options_239 struct {
 
 type Aws_elasticsearch_domain_node_to_node_encryption_240 struct {
 
-    Aws_elasticsearch_domain_node_to_node_encryption_240_id *string `lyra:"ignore"`
-
     Enabled bool
 
 }
 
 type Aws_elasticsearch_domain_snapshot_options_241 struct {
 
-    Aws_elasticsearch_domain_snapshot_options_241_id *string `lyra:"ignore"`
-
     Automated_snapshot_start_hour int
 
 }
 
 type Aws_elasticsearch_domain_vpc_options_242 struct {
-
-    Aws_elasticsearch_domain_vpc_options_242_id *string `lyra:"ignore"`
 
     Availability_zones *[]string
 
@@ -15077,19 +14593,19 @@ type Aws_elasticsearch_domain struct {
 
     Arn *string
 
-    Cluster_config *Aws_elasticsearch_domain_cluster_config_235
+    Cluster_config *[]Aws_elasticsearch_domain_cluster_config_235
 
-    Cognito_options *Aws_elasticsearch_domain_cognito_options_236
+    Cognito_options *[]Aws_elasticsearch_domain_cognito_options_236
 
     Domain_id *string
 
     Domain_name string
 
-    Ebs_options *Aws_elasticsearch_domain_ebs_options_237
+    Ebs_options *[]Aws_elasticsearch_domain_ebs_options_237
 
     Elasticsearch_version *string
 
-    Encrypt_at_rest *Aws_elasticsearch_domain_encrypt_at_rest_238
+    Encrypt_at_rest *[]Aws_elasticsearch_domain_encrypt_at_rest_238
 
     Endpoint *string
 
@@ -15097,13 +14613,13 @@ type Aws_elasticsearch_domain struct {
 
     Log_publishing_options *Aws_elasticsearch_domain_log_publishing_options_239
 
-    Node_to_node_encryption *Aws_elasticsearch_domain_node_to_node_encryption_240
+    Node_to_node_encryption *[]Aws_elasticsearch_domain_node_to_node_encryption_240
 
-    Snapshot_options *Aws_elasticsearch_domain_snapshot_options_241
+    Snapshot_options *[]Aws_elasticsearch_domain_snapshot_options_241
 
     Tags *map[string]string
 
-    Vpc_options *Aws_elasticsearch_domain_vpc_options_242
+    Vpc_options *[]Aws_elasticsearch_domain_vpc_options_242
 
 }
 
@@ -15193,8 +14709,6 @@ func (h *Aws_elasticsearch_domain_policyHandler) Delete(externalID string) error
 
 type Aws_elastictranscoder_pipeline_content_config_243 struct {
 
-    Aws_elastictranscoder_pipeline_content_config_243_id *string `lyra:"ignore"`
-
     Bucket *string
 
     Storage_class *string
@@ -15202,8 +14716,6 @@ type Aws_elastictranscoder_pipeline_content_config_243 struct {
 }
 
 type Aws_elastictranscoder_pipeline_content_config_permissions_244 struct {
-
-    Aws_elastictranscoder_pipeline_content_config_permissions_244_id *string `lyra:"ignore"`
 
     Access *[]string
 
@@ -15214,8 +14726,6 @@ type Aws_elastictranscoder_pipeline_content_config_permissions_244 struct {
 }
 
 type Aws_elastictranscoder_pipeline_notifications_245 struct {
-
-    Aws_elastictranscoder_pipeline_notifications_245_id *string `lyra:"ignore"`
 
     Completed *string
 
@@ -15229,8 +14739,6 @@ type Aws_elastictranscoder_pipeline_notifications_245 struct {
 
 type Aws_elastictranscoder_pipeline_thumbnail_config_246 struct {
 
-    Aws_elastictranscoder_pipeline_thumbnail_config_246_id *string `lyra:"ignore"`
-
     Bucket *string
 
     Storage_class *string
@@ -15238,8 +14746,6 @@ type Aws_elastictranscoder_pipeline_thumbnail_config_246 struct {
 }
 
 type Aws_elastictranscoder_pipeline_thumbnail_config_permissions_247 struct {
-
-    Aws_elastictranscoder_pipeline_thumbnail_config_permissions_247_id *string `lyra:"ignore"`
 
     Access *[]string
 
@@ -15316,8 +14822,6 @@ func (h *Aws_elastictranscoder_pipelineHandler) Delete(externalID string) error 
 
 type Aws_elastictranscoder_preset_audio_248 struct {
 
-    Aws_elastictranscoder_preset_audio_248_id *string `lyra:"ignore"`
-
     Audio_packing_mode *string
 
     Bit_rate *string
@@ -15332,8 +14836,6 @@ type Aws_elastictranscoder_preset_audio_248 struct {
 
 type Aws_elastictranscoder_preset_audio_codec_options_249 struct {
 
-    Aws_elastictranscoder_preset_audio_codec_options_249_id *string `lyra:"ignore"`
-
     Bit_depth *string
 
     Bit_order *string
@@ -15345,8 +14847,6 @@ type Aws_elastictranscoder_preset_audio_codec_options_249 struct {
 }
 
 type Aws_elastictranscoder_preset_thumbnails_250 struct {
-
-    Aws_elastictranscoder_preset_thumbnails_250_id *string `lyra:"ignore"`
 
     Aspect_ratio *string
 
@@ -15367,8 +14867,6 @@ type Aws_elastictranscoder_preset_thumbnails_250 struct {
 }
 
 type Aws_elastictranscoder_preset_video_251 struct {
-
-    Aws_elastictranscoder_preset_video_251_id *string `lyra:"ignore"`
 
     Aspect_ratio *string
 
@@ -15399,8 +14897,6 @@ type Aws_elastictranscoder_preset_video_251 struct {
 }
 
 type Aws_elastictranscoder_preset_video_watermarks_252 struct {
-
-    Aws_elastictranscoder_preset_video_watermarks_252_id *string `lyra:"ignore"`
 
     Horizontal_align *string
 
@@ -15491,8 +14987,6 @@ func (h *Aws_elastictranscoder_presetHandler) Delete(externalID string) error {
 
 type Aws_elb_access_logs_253 struct {
 
-    Aws_elb_access_logs_253_id *string `lyra:"ignore"`
-
     Bucket string
 
     Bucket_prefix *string
@@ -15504,8 +14998,6 @@ type Aws_elb_access_logs_253 struct {
 }
 
 type Aws_elb_health_check_254 struct {
-
-    Aws_elb_health_check_254_id *string `lyra:"ignore"`
 
     Healthy_threshold int
 
@@ -15520,8 +15012,6 @@ type Aws_elb_health_check_254 struct {
 }
 
 type Aws_elb_listener_255 struct {
-
-    Aws_elb_listener_255_id *string `lyra:"ignore"`
 
     Instance_port int
 
@@ -15539,7 +15029,7 @@ type Aws_elb struct {
 
     Aws_elb_id *string `lyra:"ignore"`
 
-    Access_logs *Aws_elb_access_logs_253
+    Access_logs *[]Aws_elb_access_logs_253
 
     Arn *string
 
@@ -15553,7 +15043,7 @@ type Aws_elb struct {
 
     Dns_name *string
 
-    Health_check *Aws_elb_health_check_254
+    Health_check *[]Aws_elb_health_check_254
 
     Idle_timeout *int
 
@@ -15667,8 +15157,6 @@ func (h *Aws_elb_attachmentHandler) Delete(externalID string) error {
 
 type Aws_emr_cluster_bootstrap_action_256 struct {
 
-    Aws_emr_cluster_bootstrap_action_256_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Name string
@@ -15678,8 +15166,6 @@ type Aws_emr_cluster_bootstrap_action_256 struct {
 }
 
 type Aws_emr_cluster_ec2_attributes_257 struct {
-
-    Aws_emr_cluster_ec2_attributes_257_id *string `lyra:"ignore"`
 
     Additional_master_security_groups *string
 
@@ -15701,8 +15187,6 @@ type Aws_emr_cluster_ec2_attributes_257 struct {
 
 type Aws_emr_cluster_instance_group_258_ebs_config_259 struct {
 
-    Aws_emr_cluster_instance_group_258_ebs_config_259_id *string `lyra:"ignore"`
-
     Iops *int
 
     Size int
@@ -15714,8 +15198,6 @@ type Aws_emr_cluster_instance_group_258_ebs_config_259 struct {
 }
 
 type Aws_emr_cluster_instance_group_258 struct {
-
-    Aws_emr_cluster_instance_group_258_id *string `lyra:"ignore"`
 
     Autoscaling_policy *string
 
@@ -15737,8 +15219,6 @@ type Aws_emr_cluster_instance_group_258 struct {
 
 type Aws_emr_cluster_kerberos_attributes_260 struct {
 
-    Aws_emr_cluster_kerberos_attributes_260_id *string `lyra:"ignore"`
-
     Ad_domain_join_password *string
 
     Ad_domain_join_user *string
@@ -15753,8 +15233,6 @@ type Aws_emr_cluster_kerberos_attributes_260 struct {
 
 type Aws_emr_cluster_step_261_hadoop_jar_step_262 struct {
 
-    Aws_emr_cluster_step_261_hadoop_jar_step_262_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Jar string
@@ -15767,11 +15245,9 @@ type Aws_emr_cluster_step_261_hadoop_jar_step_262 struct {
 
 type Aws_emr_cluster_step_261 struct {
 
-    Aws_emr_cluster_step_261_id *string `lyra:"ignore"`
-
     Action_on_failure string
 
-    Hadoop_jar_step Aws_emr_cluster_step_261_hadoop_jar_step_262
+    Hadoop_jar_step []Aws_emr_cluster_step_261_hadoop_jar_step_262
 
     Name string
 
@@ -15803,13 +15279,13 @@ type Aws_emr_cluster struct {
 
     Ebs_root_volume_size *int
 
-    Ec2_attributes *Aws_emr_cluster_ec2_attributes_257
+    Ec2_attributes *[]Aws_emr_cluster_ec2_attributes_257
 
     Instance_group *Aws_emr_cluster_instance_group_258
 
     Keep_job_flow_alive_when_no_steps *bool
 
-    Kerberos_attributes *Aws_emr_cluster_kerberos_attributes_260
+    Kerberos_attributes *[]Aws_emr_cluster_kerberos_attributes_260
 
     Log_uri *string
 
@@ -15827,7 +15303,7 @@ type Aws_emr_cluster struct {
 
     Service_role string
 
-    Step *Aws_emr_cluster_step_261
+    Step *[]Aws_emr_cluster_step_261
 
     Tags *map[string]string
 
@@ -15875,8 +15351,6 @@ func (h *Aws_emr_clusterHandler) Delete(externalID string) error {
 }
 
 type Aws_emr_instance_group_ebs_config_263 struct {
-
-    Aws_emr_instance_group_ebs_config_263_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -16059,8 +15533,6 @@ func (h *Aws_flow_logHandler) Delete(externalID string) error {
 
 type Aws_gamelift_alias_routing_strategy_264 struct {
 
-    Aws_gamelift_alias_routing_strategy_264_id *string `lyra:"ignore"`
-
     Fleet_id *string
 
     Message *string
@@ -16079,7 +15551,7 @@ type Aws_gamelift_alias struct {
 
     Name string
 
-    Routing_strategy Aws_gamelift_alias_routing_strategy_264
+    Routing_strategy []Aws_gamelift_alias_routing_strategy_264
 
 }
 
@@ -16122,8 +15594,6 @@ func (h *Aws_gamelift_aliasHandler) Delete(externalID string) error {
 
 type Aws_gamelift_build_storage_location_265 struct {
 
-    Aws_gamelift_build_storage_location_265_id *string `lyra:"ignore"`
-
     Bucket string
 
     Key string
@@ -16140,7 +15610,7 @@ type Aws_gamelift_build struct {
 
     Operating_system string
 
-    Storage_location Aws_gamelift_build_storage_location_265
+    Storage_location []Aws_gamelift_build_storage_location_265
 
     Version *string
 
@@ -16185,8 +15655,6 @@ func (h *Aws_gamelift_buildHandler) Delete(externalID string) error {
 
 type Aws_gamelift_fleet_ec2_inbound_permission_266 struct {
 
-    Aws_gamelift_fleet_ec2_inbound_permission_266_id *string `lyra:"ignore"`
-
     From_port int
 
     Ip_range string
@@ -16199,8 +15667,6 @@ type Aws_gamelift_fleet_ec2_inbound_permission_266 struct {
 
 type Aws_gamelift_fleet_resource_creation_limit_policy_267 struct {
 
-    Aws_gamelift_fleet_resource_creation_limit_policy_267_id *string `lyra:"ignore"`
-
     New_game_sessions_per_creator *int
 
     Policy_period_in_minutes *int
@@ -16208,8 +15674,6 @@ type Aws_gamelift_fleet_resource_creation_limit_policy_267 struct {
 }
 
 type Aws_gamelift_fleet_runtime_configuration_268_server_process_269 struct {
-
-    Aws_gamelift_fleet_runtime_configuration_268_server_process_269_id *string `lyra:"ignore"`
 
     Concurrent_executions int
 
@@ -16221,13 +15685,11 @@ type Aws_gamelift_fleet_runtime_configuration_268_server_process_269 struct {
 
 type Aws_gamelift_fleet_runtime_configuration_268 struct {
 
-    Aws_gamelift_fleet_runtime_configuration_268_id *string `lyra:"ignore"`
-
     Game_session_activation_timeout_seconds *int
 
     Max_concurrent_game_session_activations *int
 
-    Server_process *Aws_gamelift_fleet_runtime_configuration_268_server_process_269
+    Server_process *[]Aws_gamelift_fleet_runtime_configuration_268_server_process_269
 
 }
 
@@ -16241,7 +15703,7 @@ type Aws_gamelift_fleet struct {
 
     Description *string
 
-    Ec2_inbound_permission *Aws_gamelift_fleet_ec2_inbound_permission_266
+    Ec2_inbound_permission *[]Aws_gamelift_fleet_ec2_inbound_permission_266
 
     Ec2_instance_type string
 
@@ -16255,9 +15717,9 @@ type Aws_gamelift_fleet struct {
 
     Operating_system *string
 
-    Resource_creation_limit_policy *Aws_gamelift_fleet_resource_creation_limit_policy_267
+    Resource_creation_limit_policy *[]Aws_gamelift_fleet_resource_creation_limit_policy_267
 
-    Runtime_configuration *Aws_gamelift_fleet_runtime_configuration_268
+    Runtime_configuration *[]Aws_gamelift_fleet_runtime_configuration_268
 
 }
 
@@ -16300,8 +15762,6 @@ func (h *Aws_gamelift_fleetHandler) Delete(externalID string) error {
 
 type Aws_gamelift_game_session_queue_player_latency_policy_270 struct {
 
-    Aws_gamelift_game_session_queue_player_latency_policy_270_id *string `lyra:"ignore"`
-
     Maximum_individual_player_latency_milliseconds int
 
     Policy_duration_seconds *int
@@ -16318,7 +15778,7 @@ type Aws_gamelift_game_session_queue struct {
 
     Name string
 
-    Player_latency_policy *Aws_gamelift_game_session_queue_player_latency_policy_270
+    Player_latency_policy *[]Aws_gamelift_game_session_queue_player_latency_policy_270
 
     Timeout_in_seconds *int
 
@@ -16363,8 +15823,6 @@ func (h *Aws_gamelift_game_session_queueHandler) Delete(externalID string) error
 
 type Aws_glacier_vault_notification_271 struct {
 
-    Aws_glacier_vault_notification_271_id *string `lyra:"ignore"`
-
     Events []string
 
     Sns_topic string
@@ -16383,7 +15841,7 @@ type Aws_glacier_vault struct {
 
     Name string
 
-    Notification *Aws_glacier_vault_notification_271
+    Notification *[]Aws_glacier_vault_notification_271
 
     Tags *map[string]string
 
@@ -16479,8 +15937,6 @@ func (h *Aws_glacier_vault_lockHandler) Delete(externalID string) error {
 
 type Aws_globalaccelerator_accelerator_attributes_272 struct {
 
-    Aws_globalaccelerator_accelerator_attributes_272_id *string `lyra:"ignore"`
-
     Flow_logs_enabled *bool
 
     Flow_logs_s3_bucket *string
@@ -16490,8 +15946,6 @@ type Aws_globalaccelerator_accelerator_attributes_272 struct {
 }
 
 type Aws_globalaccelerator_accelerator_ip_sets_273 struct {
-
-    Aws_globalaccelerator_accelerator_ip_sets_273_id *string `lyra:"ignore"`
 
     Ip_addresses *[]string
 
@@ -16503,13 +15957,13 @@ type Aws_globalaccelerator_accelerator struct {
 
     Aws_globalaccelerator_accelerator_id *string `lyra:"ignore"`
 
-    Attributes *Aws_globalaccelerator_accelerator_attributes_272
+    Attributes *[]Aws_globalaccelerator_accelerator_attributes_272
 
     Enabled *bool
 
     Ip_address_type *string
 
-    Ip_sets *Aws_globalaccelerator_accelerator_ip_sets_273
+    Ip_sets *[]Aws_globalaccelerator_accelerator_ip_sets_273
 
     Name string
 
@@ -16607,8 +16061,6 @@ func (h *Aws_glue_catalog_databaseHandler) Delete(externalID string) error {
 
 type Aws_glue_catalog_table_partition_keys_274 struct {
 
-    Aws_glue_catalog_table_partition_keys_274_id *string `lyra:"ignore"`
-
     Comment *string
 
     Name string
@@ -16618,8 +16070,6 @@ type Aws_glue_catalog_table_partition_keys_274 struct {
 }
 
 type Aws_glue_catalog_table_storage_descriptor_275_columns_276 struct {
-
-    Aws_glue_catalog_table_storage_descriptor_275_columns_276_id *string `lyra:"ignore"`
 
     Comment *string
 
@@ -16631,8 +16081,6 @@ type Aws_glue_catalog_table_storage_descriptor_275_columns_276 struct {
 
 type Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277 struct {
 
-    Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277_id *string `lyra:"ignore"`
-
     Name *string
 
     Parameters *map[string]string
@@ -16642,8 +16090,6 @@ type Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277 struct {
 }
 
 type Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278 struct {
-
-    Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278_id *string `lyra:"ignore"`
 
     Skewed_column_names *[]string
 
@@ -16655,8 +16101,6 @@ type Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278 struct {
 
 type Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279 struct {
 
-    Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279_id *string `lyra:"ignore"`
-
     Column string
 
     Sort_order int
@@ -16665,11 +16109,9 @@ type Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279 struct {
 
 type Aws_glue_catalog_table_storage_descriptor_275 struct {
 
-    Aws_glue_catalog_table_storage_descriptor_275_id *string `lyra:"ignore"`
-
     Bucket_columns *[]string
 
-    Columns *Aws_glue_catalog_table_storage_descriptor_275_columns_276
+    Columns *[]Aws_glue_catalog_table_storage_descriptor_275_columns_276
 
     Compressed *bool
 
@@ -16683,11 +16125,11 @@ type Aws_glue_catalog_table_storage_descriptor_275 struct {
 
     Parameters *map[string]string
 
-    Ser_de_info *Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277
+    Ser_de_info *[]Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277
 
-    Skewed_info *Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278
+    Skewed_info *[]Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278
 
-    Sort_columns *Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279
+    Sort_columns *[]Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279
 
     Stored_as_sub_directories *bool
 
@@ -16709,11 +16151,11 @@ type Aws_glue_catalog_table struct {
 
     Parameters *map[string]string
 
-    Partition_keys *Aws_glue_catalog_table_partition_keys_274
+    Partition_keys *[]Aws_glue_catalog_table_partition_keys_274
 
     Retention *int
 
-    Storage_descriptor *Aws_glue_catalog_table_storage_descriptor_275
+    Storage_descriptor *[]Aws_glue_catalog_table_storage_descriptor_275
 
     Table_type *string
 
@@ -16762,8 +16204,6 @@ func (h *Aws_glue_catalog_tableHandler) Delete(externalID string) error {
 
 type Aws_glue_classifier_grok_classifier_280 struct {
 
-    Aws_glue_classifier_grok_classifier_280_id *string `lyra:"ignore"`
-
     Classification string
 
     Custom_patterns *string
@@ -16774,15 +16214,11 @@ type Aws_glue_classifier_grok_classifier_280 struct {
 
 type Aws_glue_classifier_json_classifier_281 struct {
 
-    Aws_glue_classifier_json_classifier_281_id *string `lyra:"ignore"`
-
     Json_path string
 
 }
 
 type Aws_glue_classifier_xml_classifier_282 struct {
-
-    Aws_glue_classifier_xml_classifier_282_id *string `lyra:"ignore"`
 
     Classification string
 
@@ -16794,13 +16230,13 @@ type Aws_glue_classifier struct {
 
     Aws_glue_classifier_id *string `lyra:"ignore"`
 
-    Grok_classifier *Aws_glue_classifier_grok_classifier_280
+    Grok_classifier *[]Aws_glue_classifier_grok_classifier_280
 
-    Json_classifier *Aws_glue_classifier_json_classifier_281
+    Json_classifier *[]Aws_glue_classifier_json_classifier_281
 
     Name string
 
-    Xml_classifier *Aws_glue_classifier_xml_classifier_282
+    Xml_classifier *[]Aws_glue_classifier_xml_classifier_282
 
 }
 
@@ -16843,8 +16279,6 @@ func (h *Aws_glue_classifierHandler) Delete(externalID string) error {
 
 type Aws_glue_connection_physical_connection_requirements_283 struct {
 
-    Aws_glue_connection_physical_connection_requirements_283_id *string `lyra:"ignore"`
-
     Availability_zone *string
 
     Security_group_id_list *[]string
@@ -16869,7 +16303,7 @@ type Aws_glue_connection struct {
 
     Name string
 
-    Physical_connection_requirements *Aws_glue_connection_physical_connection_requirements_283
+    Physical_connection_requirements *[]Aws_glue_connection_physical_connection_requirements_283
 
 }
 
@@ -16912,15 +16346,11 @@ func (h *Aws_glue_connectionHandler) Delete(externalID string) error {
 
 type Aws_glue_crawler_dynamodb_target_284 struct {
 
-    Aws_glue_crawler_dynamodb_target_284_id *string `lyra:"ignore"`
-
     Path string
 
 }
 
 type Aws_glue_crawler_jdbc_target_285 struct {
-
-    Aws_glue_crawler_jdbc_target_285_id *string `lyra:"ignore"`
 
     Connection_name string
 
@@ -16932,8 +16362,6 @@ type Aws_glue_crawler_jdbc_target_285 struct {
 
 type Aws_glue_crawler_s3_target_286 struct {
 
-    Aws_glue_crawler_s3_target_286_id *string `lyra:"ignore"`
-
     Exclusions *[]string
 
     Path string
@@ -16941,8 +16369,6 @@ type Aws_glue_crawler_s3_target_286 struct {
 }
 
 type Aws_glue_crawler_schema_change_policy_287 struct {
-
-    Aws_glue_crawler_schema_change_policy_287_id *string `lyra:"ignore"`
 
     Delete_behavior *string
 
@@ -16962,19 +16388,19 @@ type Aws_glue_crawler struct {
 
     Description *string
 
-    Dynamodb_target *Aws_glue_crawler_dynamodb_target_284
+    Dynamodb_target *[]Aws_glue_crawler_dynamodb_target_284
 
-    Jdbc_target *Aws_glue_crawler_jdbc_target_285
+    Jdbc_target *[]Aws_glue_crawler_jdbc_target_285
 
     Name string
 
     Role string
 
-    S3_target *Aws_glue_crawler_s3_target_286
+    S3_target *[]Aws_glue_crawler_s3_target_286
 
     Schedule *string
 
-    Schema_change_policy *Aws_glue_crawler_schema_change_policy_287
+    Schema_change_policy *[]Aws_glue_crawler_schema_change_policy_287
 
     Security_configuration *string
 
@@ -17021,8 +16447,6 @@ func (h *Aws_glue_crawlerHandler) Delete(externalID string) error {
 
 type Aws_glue_job_command_288 struct {
 
-    Aws_glue_job_command_288_id *string `lyra:"ignore"`
-
     Name *string
 
     Script_location string
@@ -17030,8 +16454,6 @@ type Aws_glue_job_command_288 struct {
 }
 
 type Aws_glue_job_execution_property_289 struct {
-
-    Aws_glue_job_execution_property_289_id *string `lyra:"ignore"`
 
     Max_concurrent_runs *int
 
@@ -17043,7 +16465,7 @@ type Aws_glue_job struct {
 
     Allocated_capacity *int
 
-    Command Aws_glue_job_command_288
+    Command []Aws_glue_job_command_288
 
     Connections *[]string
 
@@ -17051,7 +16473,7 @@ type Aws_glue_job struct {
 
     Description *string
 
-    Execution_property *Aws_glue_job_execution_property_289
+    Execution_property *[]Aws_glue_job_execution_property_289
 
     Max_retries *int
 
@@ -17104,8 +16526,6 @@ func (h *Aws_glue_jobHandler) Delete(externalID string) error {
 
 type Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291 struct {
 
-    Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291_id *string `lyra:"ignore"`
-
     Cloudwatch_encryption_mode *string
 
     Kms_key_arn *string
@@ -17113,8 +16533,6 @@ type Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_enc
 }
 
 type Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292 struct {
-
-    Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292_id *string `lyra:"ignore"`
 
     Job_bookmarks_encryption_mode *string
 
@@ -17124,8 +16542,6 @@ type Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_
 
 type Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293 struct {
 
-    Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293_id *string `lyra:"ignore"`
-
     Kms_key_arn *string
 
     S3_encryption_mode *string
@@ -17134,13 +16550,11 @@ type Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_
 
 type Aws_glue_security_configuration_encryption_configuration_290 struct {
 
-    Aws_glue_security_configuration_encryption_configuration_290_id *string `lyra:"ignore"`
+    Cloudwatch_encryption []Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291
 
-    Cloudwatch_encryption Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291
+    Job_bookmarks_encryption []Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292
 
-    Job_bookmarks_encryption Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292
-
-    S3_encryption Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293
+    S3_encryption []Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293
 
 }
 
@@ -17148,7 +16562,7 @@ type Aws_glue_security_configuration struct {
 
     Aws_glue_security_configuration_id *string `lyra:"ignore"`
 
-    Encryption_configuration Aws_glue_security_configuration_encryption_configuration_290
+    Encryption_configuration []Aws_glue_security_configuration_encryption_configuration_290
 
     Name string
 
@@ -17193,8 +16607,6 @@ func (h *Aws_glue_security_configurationHandler) Delete(externalID string) error
 
 type Aws_glue_trigger_actions_294 struct {
 
-    Aws_glue_trigger_actions_294_id *string `lyra:"ignore"`
-
     Arguments *map[string]string
 
     Job_name string
@@ -17204,8 +16616,6 @@ type Aws_glue_trigger_actions_294 struct {
 }
 
 type Aws_glue_trigger_predicate_295_conditions_296 struct {
-
-    Aws_glue_trigger_predicate_295_conditions_296_id *string `lyra:"ignore"`
 
     Job_name string
 
@@ -17217,9 +16627,7 @@ type Aws_glue_trigger_predicate_295_conditions_296 struct {
 
 type Aws_glue_trigger_predicate_295 struct {
 
-    Aws_glue_trigger_predicate_295_id *string `lyra:"ignore"`
-
-    Conditions Aws_glue_trigger_predicate_295_conditions_296
+    Conditions []Aws_glue_trigger_predicate_295_conditions_296
 
     Logical *string
 
@@ -17229,7 +16637,7 @@ type Aws_glue_trigger struct {
 
     Aws_glue_trigger_id *string `lyra:"ignore"`
 
-    Actions Aws_glue_trigger_actions_294
+    Actions []Aws_glue_trigger_actions_294
 
     Description *string
 
@@ -17237,7 +16645,7 @@ type Aws_glue_trigger struct {
 
     Name string
 
-    Predicate *Aws_glue_trigger_predicate_295
+    Predicate *[]Aws_glue_trigger_predicate_295
 
     Schedule *string
 
@@ -18870,15 +18278,11 @@ func (h *Aws_inspector_resource_groupHandler) Delete(externalID string) error {
 
 type Aws_instance_credit_specification_297 struct {
 
-    Aws_instance_credit_specification_297_id *string `lyra:"ignore"`
-
     Cpu_credits *string
 
 }
 
 type Aws_instance_ebs_block_device_298 struct {
-
-    Aws_instance_ebs_block_device_298_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -18900,8 +18304,6 @@ type Aws_instance_ebs_block_device_298 struct {
 
 type Aws_instance_ephemeral_block_device_299 struct {
 
-    Aws_instance_ephemeral_block_device_299_id *string `lyra:"ignore"`
-
     Device_name string
 
     No_device *bool
@@ -18912,8 +18314,6 @@ type Aws_instance_ephemeral_block_device_299 struct {
 
 type Aws_instance_network_interface_300 struct {
 
-    Aws_instance_network_interface_300_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_index int
@@ -18923,8 +18323,6 @@ type Aws_instance_network_interface_300 struct {
 }
 
 type Aws_instance_root_block_device_301 struct {
-
-    Aws_instance_root_block_device_301_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -18956,7 +18354,7 @@ type Aws_instance struct {
 
     Cpu_threads_per_core *int
 
-    Credit_specification *Aws_instance_credit_specification_297
+    Credit_specification *[]Aws_instance_credit_specification_297
 
     Disable_api_termination *bool
 
@@ -19004,7 +18402,7 @@ type Aws_instance struct {
 
     Public_ip *string
 
-    Root_block_device *Aws_instance_root_block_device_301
+    Root_block_device *[]Aws_instance_root_block_device_301
 
     Security_groups *[]string
 
@@ -19363,8 +18761,6 @@ func (h *Aws_iot_thing_principal_attachmentHandler) Delete(externalID string) er
 
 type Aws_iot_thing_type_properties_302 struct {
 
-    Aws_iot_thing_type_properties_302_id *string `lyra:"ignore"`
-
     Description *string
 
     Searchable_attributes *[]string
@@ -19381,7 +18777,7 @@ type Aws_iot_thing_type struct {
 
     Name string
 
-    Properties *Aws_iot_thing_type_properties_302
+    Properties *[]Aws_iot_thing_type_properties_302
 
 }
 
@@ -19424,8 +18820,6 @@ func (h *Aws_iot_thing_typeHandler) Delete(externalID string) error {
 
 type Aws_iot_topic_rule_cloudwatch_alarm_303 struct {
 
-    Aws_iot_topic_rule_cloudwatch_alarm_303_id *string `lyra:"ignore"`
-
     Alarm_name string
 
     Role_arn string
@@ -19437,8 +18831,6 @@ type Aws_iot_topic_rule_cloudwatch_alarm_303 struct {
 }
 
 type Aws_iot_topic_rule_cloudwatch_metric_304 struct {
-
-    Aws_iot_topic_rule_cloudwatch_metric_304_id *string `lyra:"ignore"`
 
     Metric_name string
 
@@ -19455,8 +18847,6 @@ type Aws_iot_topic_rule_cloudwatch_metric_304 struct {
 }
 
 type Aws_iot_topic_rule_dynamodb_305 struct {
-
-    Aws_iot_topic_rule_dynamodb_305_id *string `lyra:"ignore"`
 
     Hash_key_field string
 
@@ -19480,8 +18870,6 @@ type Aws_iot_topic_rule_dynamodb_305 struct {
 
 type Aws_iot_topic_rule_elasticsearch_306 struct {
 
-    Aws_iot_topic_rule_elasticsearch_306_id *string `lyra:"ignore"`
-
     Endpoint string
 
     Id string
@@ -19496,8 +18884,6 @@ type Aws_iot_topic_rule_elasticsearch_306 struct {
 
 type Aws_iot_topic_rule_firehose_307 struct {
 
-    Aws_iot_topic_rule_firehose_307_id *string `lyra:"ignore"`
-
     Delivery_stream_name string
 
     Role_arn string
@@ -19507,8 +18893,6 @@ type Aws_iot_topic_rule_firehose_307 struct {
 }
 
 type Aws_iot_topic_rule_kinesis_308 struct {
-
-    Aws_iot_topic_rule_kinesis_308_id *string `lyra:"ignore"`
 
     Partition_key *string
 
@@ -19520,15 +18904,11 @@ type Aws_iot_topic_rule_kinesis_308 struct {
 
 type Aws_iot_topic_rule_lambda_309 struct {
 
-    Aws_iot_topic_rule_lambda_309_id *string `lyra:"ignore"`
-
     Function_arn string
 
 }
 
 type Aws_iot_topic_rule_republish_310 struct {
-
-    Aws_iot_topic_rule_republish_310_id *string `lyra:"ignore"`
 
     Role_arn string
 
@@ -19537,8 +18917,6 @@ type Aws_iot_topic_rule_republish_310 struct {
 }
 
 type Aws_iot_topic_rule_s3_311 struct {
-
-    Aws_iot_topic_rule_s3_311_id *string `lyra:"ignore"`
 
     Bucket_name string
 
@@ -19550,8 +18928,6 @@ type Aws_iot_topic_rule_s3_311 struct {
 
 type Aws_iot_topic_rule_sns_312 struct {
 
-    Aws_iot_topic_rule_sns_312_id *string `lyra:"ignore"`
-
     Message_format *string
 
     Role_arn string
@@ -19561,8 +18937,6 @@ type Aws_iot_topic_rule_sns_312 struct {
 }
 
 type Aws_iot_topic_rule_sqs_313 struct {
-
-    Aws_iot_topic_rule_sqs_313_id *string `lyra:"ignore"`
 
     Queue_url string
 
@@ -19702,8 +19076,6 @@ func (h *Aws_key_pairHandler) Delete(externalID string) error {
 
 type Aws_kinesis_analytics_application_cloudwatch_logging_options_314 struct {
 
-    Aws_kinesis_analytics_application_cloudwatch_logging_options_314_id *string `lyra:"ignore"`
-
     Id *string
 
     Log_stream_arn string
@@ -19714,8 +19086,6 @@ type Aws_kinesis_analytics_application_cloudwatch_logging_options_314 struct {
 
 type Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316_id *string `lyra:"ignore"`
-
     Resource_arn string
 
     Role_arn string
@@ -19723,8 +19093,6 @@ type Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316 struct {
 }
 
 type Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317 struct {
-
-    Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317_id *string `lyra:"ignore"`
 
     Resource_arn string
 
@@ -19734,15 +19102,11 @@ type Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317 struct {
 
 type Aws_kinesis_analytics_application_inputs_315_parallelism_318 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_parallelism_318_id *string `lyra:"ignore"`
-
     Count int
 
 }
 
 type Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320 struct {
-
-    Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320_id *string `lyra:"ignore"`
 
     Resource_arn string
 
@@ -19752,15 +19116,11 @@ type Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_l
 
 type Aws_kinesis_analytics_application_inputs_315_processing_configuration_319 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_id *string `lyra:"ignore"`
-
-    Lambda Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320
+    Lambda []Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320
 
 }
 
 type Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322 struct {
-
-    Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322_id *string `lyra:"ignore"`
 
     Mapping *string
 
@@ -19772,8 +19132,6 @@ type Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322 
 
 type Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325_id *string `lyra:"ignore"`
-
     Record_column_delimiter string
 
     Record_row_delimiter string
@@ -19782,27 +19140,21 @@ type Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_m
 
 type Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326_id *string `lyra:"ignore"`
-
     Record_row_path string
 
 }
 
 type Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_id *string `lyra:"ignore"`
+    Csv *[]Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325
 
-    Csv *Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325
-
-    Json *Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326
+    Json *[]Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326
 
 }
 
 type Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_id *string `lyra:"ignore"`
-
-    Mapping_parameters *Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324
+    Mapping_parameters *[]Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324
 
     Record_format_type *string
 
@@ -19810,19 +19162,15 @@ type Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323 s
 
 type Aws_kinesis_analytics_application_inputs_315_schema_321 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_schema_321_id *string `lyra:"ignore"`
-
-    Record_columns Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322
+    Record_columns []Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322
 
     Record_encoding *string
 
-    Record_format Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323
+    Record_format []Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323
 
 }
 
 type Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327 struct {
-
-    Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327_id *string `lyra:"ignore"`
 
     Starting_position *string
 
@@ -19830,31 +19178,27 @@ type Aws_kinesis_analytics_application_inputs_315_starting_position_configuratio
 
 type Aws_kinesis_analytics_application_inputs_315 struct {
 
-    Aws_kinesis_analytics_application_inputs_315_id *string `lyra:"ignore"`
-
     Id *string
 
-    Kinesis_firehose *Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316
+    Kinesis_firehose *[]Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316
 
-    Kinesis_stream *Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317
+    Kinesis_stream *[]Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317
 
     Name_prefix string
 
-    Parallelism *Aws_kinesis_analytics_application_inputs_315_parallelism_318
+    Parallelism *[]Aws_kinesis_analytics_application_inputs_315_parallelism_318
 
-    Processing_configuration *Aws_kinesis_analytics_application_inputs_315_processing_configuration_319
+    Processing_configuration *[]Aws_kinesis_analytics_application_inputs_315_processing_configuration_319
 
-    Schema Aws_kinesis_analytics_application_inputs_315_schema_321
+    Schema []Aws_kinesis_analytics_application_inputs_315_schema_321
 
-    Starting_position_configuration *Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327
+    Starting_position_configuration *[]Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327
 
     Stream_names *[]string
 
 }
 
 type Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329 struct {
-
-    Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329_id *string `lyra:"ignore"`
 
     Resource_arn string
 
@@ -19864,8 +19208,6 @@ type Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329 struct {
 
 type Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330 struct {
 
-    Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330_id *string `lyra:"ignore"`
-
     Resource_arn string
 
     Role_arn string
@@ -19873,8 +19215,6 @@ type Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330 struct {
 }
 
 type Aws_kinesis_analytics_application_outputs_328_lambda_331 struct {
-
-    Aws_kinesis_analytics_application_outputs_328_lambda_331_id *string `lyra:"ignore"`
 
     Resource_arn string
 
@@ -19884,33 +19224,27 @@ type Aws_kinesis_analytics_application_outputs_328_lambda_331 struct {
 
 type Aws_kinesis_analytics_application_outputs_328_schema_332 struct {
 
-    Aws_kinesis_analytics_application_outputs_328_schema_332_id *string `lyra:"ignore"`
-
     Record_format_type *string
 
 }
 
 type Aws_kinesis_analytics_application_outputs_328 struct {
 
-    Aws_kinesis_analytics_application_outputs_328_id *string `lyra:"ignore"`
-
     Id *string
 
-    Kinesis_firehose *Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329
+    Kinesis_firehose *[]Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329
 
-    Kinesis_stream *Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330
+    Kinesis_stream *[]Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330
 
-    Lambda *Aws_kinesis_analytics_application_outputs_328_lambda_331
+    Lambda *[]Aws_kinesis_analytics_application_outputs_328_lambda_331
 
     Name string
 
-    Schema Aws_kinesis_analytics_application_outputs_328_schema_332
+    Schema []Aws_kinesis_analytics_application_outputs_328_schema_332
 
 }
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_s3_334 struct {
-
-    Aws_kinesis_analytics_application_reference_data_sources_333_s3_334_id *string `lyra:"ignore"`
 
     Bucket_arn string
 
@@ -19922,8 +19256,6 @@ type Aws_kinesis_analytics_application_reference_data_sources_333_s3_334 struct 
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336_id *string `lyra:"ignore"`
-
     Mapping *string
 
     Name string
@@ -19934,8 +19266,6 @@ type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_rec
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339_id *string `lyra:"ignore"`
-
     Record_column_delimiter string
 
     Record_row_delimiter string
@@ -19944,27 +19274,21 @@ type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_rec
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340_id *string `lyra:"ignore"`
-
     Record_row_path string
 
 }
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_id *string `lyra:"ignore"`
+    Csv *[]Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339
 
-    Csv *Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339
-
-    Json *Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340
+    Json *[]Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340
 
 }
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_id *string `lyra:"ignore"`
-
-    Mapping_parameters *Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338
+    Mapping_parameters *[]Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338
 
     Record_format_type *string
 
@@ -19972,25 +19296,21 @@ type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_rec
 
 type Aws_kinesis_analytics_application_reference_data_sources_333_schema_335 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_id *string `lyra:"ignore"`
-
-    Record_columns Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336
+    Record_columns []Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336
 
     Record_encoding *string
 
-    Record_format Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337
+    Record_format []Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337
 
 }
 
 type Aws_kinesis_analytics_application_reference_data_sources_333 struct {
 
-    Aws_kinesis_analytics_application_reference_data_sources_333_id *string `lyra:"ignore"`
-
     Id *string
 
-    S3 Aws_kinesis_analytics_application_reference_data_sources_333_s3_334
+    S3 []Aws_kinesis_analytics_application_reference_data_sources_333_s3_334
 
-    Schema Aws_kinesis_analytics_application_reference_data_sources_333_schema_335
+    Schema []Aws_kinesis_analytics_application_reference_data_sources_333_schema_335
 
     Table_name string
 
@@ -20002,7 +19322,7 @@ type Aws_kinesis_analytics_application struct {
 
     Arn *string
 
-    Cloudwatch_logging_options *Aws_kinesis_analytics_application_cloudwatch_logging_options_314
+    Cloudwatch_logging_options *[]Aws_kinesis_analytics_application_cloudwatch_logging_options_314
 
     Code *string
 
@@ -20010,15 +19330,15 @@ type Aws_kinesis_analytics_application struct {
 
     Description *string
 
-    Inputs *Aws_kinesis_analytics_application_inputs_315
+    Inputs *[]Aws_kinesis_analytics_application_inputs_315
 
     Last_update_timestamp *string
 
     Name string
 
-    Outputs *Aws_kinesis_analytics_application_outputs_328
+    Outputs *[]Aws_kinesis_analytics_application_outputs_328
 
-    Reference_data_sources *Aws_kinesis_analytics_application_reference_data_sources_333
+    Reference_data_sources *[]Aws_kinesis_analytics_application_reference_data_sources_333
 
     Status *string
 
@@ -20065,8 +19385,6 @@ func (h *Aws_kinesis_analytics_applicationHandler) Delete(externalID string) err
 
 type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_cloudwatch_logging_options_342 struct {
 
-    Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_cloudwatch_logging_options_342_id *string `lyra:"ignore"`
-
     Enabled *bool
 
     Log_group_name *string
@@ -20077,8 +19395,6 @@ type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_cloudw
 
 type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345 struct {
 
-    Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345_id *string `lyra:"ignore"`
-
     Parameter_name string
 
     Parameter_value string
@@ -20087,9 +19403,7 @@ type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_proces
 
 type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344 struct {
 
-    Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_id *string `lyra:"ignore"`
-
-    Parameters *Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345
+    Parameters *[]Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345
 
     Type string
 
@@ -20097,17 +19411,13 @@ type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_proces
 
 type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343 struct {
 
-    Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_id *string `lyra:"ignore"`
-
     Enabled *bool
 
-    Processors *Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344
+    Processors *[]Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341 struct {
-
-    Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_id *string `lyra:"ignore"`
 
     Buffering_interval *int
 
@@ -20121,7 +19431,7 @@ type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341 struct
 
     Index_rotation_period *string
 
-    Processing_configuration *Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343
+    Processing_configuration *[]Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343
 
     Retry_duration *int
 
@@ -20135,8 +19445,6 @@ type Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341 struct
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_cloudwatch_logging_options_347 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_cloudwatch_logging_options_347_id *string `lyra:"ignore"`
-
     Enabled *bool
 
     Log_group_name *string
@@ -20147,15 +19455,11 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_cloudwat
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351_id *string `lyra:"ignore"`
-
     Timestamp_formats *[]string
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352 struct {
-
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352_id *string `lyra:"ignore"`
 
     Case_insensitive *bool
 
@@ -20167,25 +19471,19 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_for
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_id *string `lyra:"ignore"`
+    Hive_json_ser_de *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351
 
-    Hive_json_ser_de *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351
-
-    Open_x_json_ser_de *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352
+    Open_x_json_ser_de *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_id *string `lyra:"ignore"`
-
-    Deserializer Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350
+    Deserializer []Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355 struct {
-
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355_id *string `lyra:"ignore"`
 
     Block_size_bytes *int
 
@@ -20211,8 +19509,6 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_for
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356_id *string `lyra:"ignore"`
-
     Block_size_bytes *int
 
     Compression *string
@@ -20229,25 +19525,19 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_for
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_id *string `lyra:"ignore"`
+    Orc_ser_de *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355
 
-    Orc_ser_de *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355
-
-    Parquet_ser_de *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356
+    Parquet_ser_de *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_id *string `lyra:"ignore"`
-
-    Serializer Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354
+    Serializer []Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357 struct {
-
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357_id *string `lyra:"ignore"`
 
     Catalog_id *string
 
@@ -20265,21 +19555,17 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_for
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_id *string `lyra:"ignore"`
-
     Enabled *bool
 
-    Input_format_configuration Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349
+    Input_format_configuration []Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349
 
-    Output_format_configuration Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353
+    Output_format_configuration []Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353
 
-    Schema_configuration Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357
+    Schema_configuration []Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360 struct {
-
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360_id *string `lyra:"ignore"`
 
     Parameter_name string
 
@@ -20289,9 +19575,7 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processi
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_id *string `lyra:"ignore"`
-
-    Parameters *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360
+    Parameters *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360
 
     Type string
 
@@ -20299,17 +19583,13 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processi
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_id *string `lyra:"ignore"`
-
     Enabled *bool
 
-    Processors *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359
+    Processors *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361_cloudwatch_logging_options_362 struct {
-
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361_cloudwatch_logging_options_362_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -20320,8 +19600,6 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backu
 }
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361 struct {
-
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361_id *string `lyra:"ignore"`
 
     Bucket_arn string
 
@@ -20343,8 +19621,6 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backu
 
 type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346 struct {
 
-    Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_id *string `lyra:"ignore"`
-
     Bucket_arn string
 
     Buffer_interval *int
@@ -20355,7 +19631,7 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346 struct {
 
     Compression_format *string
 
-    Data_format_conversion_configuration *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348
+    Data_format_conversion_configuration *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348
 
     Error_output_prefix *string
 
@@ -20363,19 +19639,17 @@ type Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346 struct {
 
     Prefix *string
 
-    Processing_configuration *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358
+    Processing_configuration *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358
 
     Role_arn string
 
-    S3_backup_configuration *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361
+    S3_backup_configuration *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361
 
     S3_backup_mode *string
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363 struct {
-
-    Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363_id *string `lyra:"ignore"`
 
     Kinesis_stream_arn string
 
@@ -20384,8 +19658,6 @@ type Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363 struc
 }
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_logging_options_365 struct {
-
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_logging_options_365_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -20397,8 +19669,6 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368 struct {
 
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368_id *string `lyra:"ignore"`
-
     Parameter_name string
 
     Parameter_value string
@@ -20407,9 +19677,7 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367 struct {
 
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_id *string `lyra:"ignore"`
-
-    Parameters *Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368
+    Parameters *[]Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368
 
     Type string
 
@@ -20417,17 +19685,13 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366 struct {
 
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_id *string `lyra:"ignore"`
-
     Enabled *bool
 
-    Processors *Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367
+    Processors *[]Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369_cloudwatch_logging_options_370 struct {
-
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369_cloudwatch_logging_options_370_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -20438,8 +19702,6 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_c
 }
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369 struct {
-
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369_id *string `lyra:"ignore"`
 
     Bucket_arn string
 
@@ -20461,8 +19723,6 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_c
 
 type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364 struct {
 
-    Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_id *string `lyra:"ignore"`
-
     Cloudwatch_logging_options *Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_logging_options_365
 
     Cluster_jdbcurl string
@@ -20475,13 +19735,13 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364 struct {
 
     Password string
 
-    Processing_configuration *Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366
+    Processing_configuration *[]Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366
 
     Retry_duration *int
 
     Role_arn string
 
-    S3_backup_configuration *Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369
+    S3_backup_configuration *[]Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369
 
     S3_backup_mode *string
 
@@ -20490,8 +19750,6 @@ type Aws_kinesis_firehose_delivery_stream_redshift_configuration_364 struct {
 }
 
 type Aws_kinesis_firehose_delivery_stream_s3_configuration_371_cloudwatch_logging_options_372 struct {
-
-    Aws_kinesis_firehose_delivery_stream_s3_configuration_371_cloudwatch_logging_options_372_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -20502,8 +19760,6 @@ type Aws_kinesis_firehose_delivery_stream_s3_configuration_371_cloudwatch_loggin
 }
 
 type Aws_kinesis_firehose_delivery_stream_s3_configuration_371 struct {
-
-    Aws_kinesis_firehose_delivery_stream_s3_configuration_371_id *string `lyra:"ignore"`
 
     Bucket_arn string
 
@@ -20525,8 +19781,6 @@ type Aws_kinesis_firehose_delivery_stream_s3_configuration_371 struct {
 
 type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_logging_options_374 struct {
 
-    Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_logging_options_374_id *string `lyra:"ignore"`
-
     Enabled *bool
 
     Log_group_name *string
@@ -20537,8 +19791,6 @@ type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_lo
 
 type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377 struct {
 
-    Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377_id *string `lyra:"ignore"`
-
     Parameter_name string
 
     Parameter_value string
@@ -20547,9 +19799,7 @@ type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_co
 
 type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376 struct {
 
-    Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_id *string `lyra:"ignore"`
-
-    Parameters *Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377
+    Parameters *[]Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377
 
     Type string
 
@@ -20557,17 +19807,13 @@ type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_co
 
 type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375 struct {
 
-    Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_id *string `lyra:"ignore"`
-
     Enabled *bool
 
-    Processors *Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376
+    Processors *[]Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376
 
 }
 
 type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373 struct {
-
-    Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_id *string `lyra:"ignore"`
 
     Cloudwatch_logging_options *Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_logging_options_374
 
@@ -20579,7 +19825,7 @@ type Aws_kinesis_firehose_delivery_stream_splunk_configuration_373 struct {
 
     Hec_token string
 
-    Processing_configuration *Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375
+    Processing_configuration *[]Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375
 
     Retry_duration *int
 
@@ -20597,19 +19843,19 @@ type Aws_kinesis_firehose_delivery_stream struct {
 
     Destination_id *string
 
-    Elasticsearch_configuration *Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341
+    Elasticsearch_configuration *[]Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341
 
-    Extended_s3_configuration *Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346
+    Extended_s3_configuration *[]Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346
 
-    Kinesis_source_configuration *Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363
+    Kinesis_source_configuration *[]Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363
 
     Name string
 
-    Redshift_configuration *Aws_kinesis_firehose_delivery_stream_redshift_configuration_364
+    Redshift_configuration *[]Aws_kinesis_firehose_delivery_stream_redshift_configuration_364
 
-    S3_configuration *Aws_kinesis_firehose_delivery_stream_s3_configuration_371
+    S3_configuration *[]Aws_kinesis_firehose_delivery_stream_s3_configuration_371
 
-    Splunk_configuration *Aws_kinesis_firehose_delivery_stream_splunk_configuration_373
+    Splunk_configuration *[]Aws_kinesis_firehose_delivery_stream_splunk_configuration_373
 
     Tags *map[string]string
 
@@ -20768,8 +20014,6 @@ func (h *Aws_kms_aliasHandler) Delete(externalID string) error {
 
 type Aws_kms_grant_constraints_378 struct {
 
-    Aws_kms_grant_constraints_378_id *string `lyra:"ignore"`
-
     Encryption_context_equals *map[string]string
 
     Encryption_context_subset *map[string]string
@@ -20902,8 +20146,6 @@ func (h *Aws_kms_keyHandler) Delete(externalID string) error {
 
 type Aws_lambda_alias_routing_config_379 struct {
 
-    Aws_lambda_alias_routing_config_379_id *string `lyra:"ignore"`
-
     Additional_version_weights *map[string]string
 
 }
@@ -20924,7 +20166,7 @@ type Aws_lambda_alias struct {
 
     Name string
 
-    Routing_config *Aws_lambda_alias_routing_config_379
+    Routing_config *[]Aws_lambda_alias_routing_config_379
 
 }
 
@@ -21034,15 +20276,11 @@ func (h *Aws_lambda_event_source_mappingHandler) Delete(externalID string) error
 
 type Aws_lambda_function_dead_letter_config_380 struct {
 
-    Aws_lambda_function_dead_letter_config_380_id *string `lyra:"ignore"`
-
     Target_arn string
 
 }
 
 type Aws_lambda_function_environment_381 struct {
-
-    Aws_lambda_function_environment_381_id *string `lyra:"ignore"`
 
     Variables *map[string]string
 
@@ -21050,15 +20288,11 @@ type Aws_lambda_function_environment_381 struct {
 
 type Aws_lambda_function_tracing_config_382 struct {
 
-    Aws_lambda_function_tracing_config_382_id *string `lyra:"ignore"`
-
     Mode string
 
 }
 
 type Aws_lambda_function_vpc_config_383 struct {
-
-    Aws_lambda_function_vpc_config_383_id *string `lyra:"ignore"`
 
     Security_group_ids []string
 
@@ -21074,11 +20308,11 @@ type Aws_lambda_function struct {
 
     Arn *string
 
-    Dead_letter_config *Aws_lambda_function_dead_letter_config_380
+    Dead_letter_config *[]Aws_lambda_function_dead_letter_config_380
 
     Description *string
 
-    Environment *Aws_lambda_function_environment_381
+    Environment *[]Aws_lambda_function_environment_381
 
     Filename *string
 
@@ -21120,11 +20354,11 @@ type Aws_lambda_function struct {
 
     Timeout *int
 
-    Tracing_config *Aws_lambda_function_tracing_config_382
+    Tracing_config *[]Aws_lambda_function_tracing_config_382
 
     Version *string
 
-    Vpc_config *Aws_lambda_function_vpc_config_383
+    Vpc_config *[]Aws_lambda_function_vpc_config_383
 
 }
 
@@ -21299,8 +20533,6 @@ func (h *Aws_lambda_permissionHandler) Delete(externalID string) error {
 
 type Aws_launch_configuration_ebs_block_device_384 struct {
 
-    Aws_launch_configuration_ebs_block_device_384_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_name string
@@ -21321,8 +20553,6 @@ type Aws_launch_configuration_ebs_block_device_384 struct {
 
 type Aws_launch_configuration_ephemeral_block_device_385 struct {
 
-    Aws_launch_configuration_ephemeral_block_device_385_id *string `lyra:"ignore"`
-
     Device_name string
 
     Virtual_name string
@@ -21330,8 +20560,6 @@ type Aws_launch_configuration_ephemeral_block_device_385 struct {
 }
 
 type Aws_launch_configuration_root_block_device_386 struct {
-
-    Aws_launch_configuration_root_block_device_386_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -21371,7 +20599,7 @@ type Aws_launch_configuration struct {
 
     Placement_tenancy *string
 
-    Root_block_device *Aws_launch_configuration_root_block_device_386
+    Root_block_device *[]Aws_launch_configuration_root_block_device_386
 
     Security_groups *[]string
 
@@ -21426,8 +20654,6 @@ func (h *Aws_launch_configurationHandler) Delete(externalID string) error {
 
 type Aws_launch_template_block_device_mappings_387_ebs_388 struct {
 
-    Aws_launch_template_block_device_mappings_387_ebs_388_id *string `lyra:"ignore"`
-
     Delete_on_termination *string
 
     Encrypted *string
@@ -21446,11 +20672,9 @@ type Aws_launch_template_block_device_mappings_387_ebs_388 struct {
 
 type Aws_launch_template_block_device_mappings_387 struct {
 
-    Aws_launch_template_block_device_mappings_387_id *string `lyra:"ignore"`
-
     Device_name *string
 
-    Ebs *Aws_launch_template_block_device_mappings_387_ebs_388
+    Ebs *[]Aws_launch_template_block_device_mappings_387_ebs_388
 
     No_device *string
 
@@ -21460,25 +20684,19 @@ type Aws_launch_template_block_device_mappings_387 struct {
 
 type Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390 struct {
 
-    Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390_id *string `lyra:"ignore"`
-
     Capacity_reservation_id *string
 
 }
 
 type Aws_launch_template_capacity_reservation_specification_389 struct {
 
-    Aws_launch_template_capacity_reservation_specification_389_id *string `lyra:"ignore"`
-
     Capacity_reservation_preference *string
 
-    Capacity_reservation_target *Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390
+    Capacity_reservation_target *[]Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390
 
 }
 
 type Aws_launch_template_credit_specification_391 struct {
-
-    Aws_launch_template_credit_specification_391_id *string `lyra:"ignore"`
 
     Cpu_credits *string
 
@@ -21486,15 +20704,11 @@ type Aws_launch_template_credit_specification_391 struct {
 
 type Aws_launch_template_elastic_gpu_specifications_392 struct {
 
-    Aws_launch_template_elastic_gpu_specifications_392_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_launch_template_iam_instance_profile_393 struct {
-
-    Aws_launch_template_iam_instance_profile_393_id *string `lyra:"ignore"`
 
     Arn *string
 
@@ -21503,8 +20717,6 @@ type Aws_launch_template_iam_instance_profile_393 struct {
 }
 
 type Aws_launch_template_instance_market_options_394_spot_options_395 struct {
-
-    Aws_launch_template_instance_market_options_394_spot_options_395_id *string `lyra:"ignore"`
 
     Block_duration_minutes *int
 
@@ -21520,17 +20732,13 @@ type Aws_launch_template_instance_market_options_394_spot_options_395 struct {
 
 type Aws_launch_template_instance_market_options_394 struct {
 
-    Aws_launch_template_instance_market_options_394_id *string `lyra:"ignore"`
-
     Market_type *string
 
-    Spot_options *Aws_launch_template_instance_market_options_394_spot_options_395
+    Spot_options *[]Aws_launch_template_instance_market_options_394_spot_options_395
 
 }
 
 type Aws_launch_template_license_specification_396 struct {
-
-    Aws_launch_template_license_specification_396_id *string `lyra:"ignore"`
 
     License_configuration_arn string
 
@@ -21538,15 +20746,11 @@ type Aws_launch_template_license_specification_396 struct {
 
 type Aws_launch_template_monitoring_397 struct {
 
-    Aws_launch_template_monitoring_397_id *string `lyra:"ignore"`
-
     Enabled *bool
 
 }
 
 type Aws_launch_template_network_interfaces_398 struct {
-
-    Aws_launch_template_network_interfaces_398_id *string `lyra:"ignore"`
 
     Associate_public_ip_address *bool
 
@@ -21576,8 +20780,6 @@ type Aws_launch_template_network_interfaces_398 struct {
 
 type Aws_launch_template_placement_399 struct {
 
-    Aws_launch_template_placement_399_id *string `lyra:"ignore"`
-
     Affinity *string
 
     Availability_zone *string
@@ -21594,8 +20796,6 @@ type Aws_launch_template_placement_399 struct {
 
 type Aws_launch_template_tag_specifications_400 struct {
 
-    Aws_launch_template_tag_specifications_400_id *string `lyra:"ignore"`
-
     Resource_type *string
 
     Tags *map[string]string
@@ -21608,11 +20808,11 @@ type Aws_launch_template struct {
 
     Arn *string
 
-    Block_device_mappings *Aws_launch_template_block_device_mappings_387
+    Block_device_mappings *[]Aws_launch_template_block_device_mappings_387
 
-    Capacity_reservation_specification *Aws_launch_template_capacity_reservation_specification_389
+    Capacity_reservation_specification *[]Aws_launch_template_capacity_reservation_specification_389
 
-    Credit_specification *Aws_launch_template_credit_specification_391
+    Credit_specification *[]Aws_launch_template_credit_specification_391
 
     Default_version *int
 
@@ -21622,15 +20822,15 @@ type Aws_launch_template struct {
 
     Ebs_optimized *string
 
-    Elastic_gpu_specifications *Aws_launch_template_elastic_gpu_specifications_392
+    Elastic_gpu_specifications *[]Aws_launch_template_elastic_gpu_specifications_392
 
-    Iam_instance_profile *Aws_launch_template_iam_instance_profile_393
+    Iam_instance_profile *[]Aws_launch_template_iam_instance_profile_393
 
     Image_id *string
 
     Instance_initiated_shutdown_behavior *string
 
-    Instance_market_options *Aws_launch_template_instance_market_options_394
+    Instance_market_options *[]Aws_launch_template_instance_market_options_394
 
     Instance_type *string
 
@@ -21642,21 +20842,21 @@ type Aws_launch_template struct {
 
     License_specification *Aws_launch_template_license_specification_396
 
-    Monitoring *Aws_launch_template_monitoring_397
+    Monitoring *[]Aws_launch_template_monitoring_397
 
     Name *string
 
     Name_prefix *string
 
-    Network_interfaces *Aws_launch_template_network_interfaces_398
+    Network_interfaces *[]Aws_launch_template_network_interfaces_398
 
-    Placement *Aws_launch_template_placement_399
+    Placement *[]Aws_launch_template_placement_399
 
     Ram_disk_id *string
 
     Security_group_names *[]string
 
-    Tag_specifications *Aws_launch_template_tag_specifications_400
+    Tag_specifications *[]Aws_launch_template_tag_specifications_400
 
     Tags *map[string]string
 
@@ -21705,8 +20905,6 @@ func (h *Aws_launch_templateHandler) Delete(externalID string) error {
 
 type Aws_lb_access_logs_401 struct {
 
-    Aws_lb_access_logs_401_id *string `lyra:"ignore"`
-
     Bucket string
 
     Enabled *bool
@@ -21716,8 +20914,6 @@ type Aws_lb_access_logs_401 struct {
 }
 
 type Aws_lb_subnet_mapping_402 struct {
-
-    Aws_lb_subnet_mapping_402_id *string `lyra:"ignore"`
 
     Allocation_id *string
 
@@ -21729,7 +20925,7 @@ type Aws_lb struct {
 
     Aws_lb_id *string `lyra:"ignore"`
 
-    Access_logs *Aws_lb_access_logs_401
+    Access_logs *[]Aws_lb_access_logs_401
 
     Arn *string
 
@@ -21859,8 +21055,6 @@ func (h *Aws_lb_cookie_stickiness_policyHandler) Delete(externalID string) error
 
 type Aws_lb_listener_default_action_403_authenticate_cognito_404 struct {
 
-    Aws_lb_listener_default_action_403_authenticate_cognito_404_id *string `lyra:"ignore"`
-
     Authentication_request_extra_params *map[string]string
 
     On_unauthenticated_request *string
@@ -21880,8 +21074,6 @@ type Aws_lb_listener_default_action_403_authenticate_cognito_404 struct {
 }
 
 type Aws_lb_listener_default_action_403_authenticate_oidc_405 struct {
-
-    Aws_lb_listener_default_action_403_authenticate_oidc_405_id *string `lyra:"ignore"`
 
     Authentication_request_extra_params *map[string]string
 
@@ -21909,8 +21101,6 @@ type Aws_lb_listener_default_action_403_authenticate_oidc_405 struct {
 
 type Aws_lb_listener_default_action_403_fixed_response_406 struct {
 
-    Aws_lb_listener_default_action_403_fixed_response_406_id *string `lyra:"ignore"`
-
     Content_type string
 
     Message_body *string
@@ -21920,8 +21110,6 @@ type Aws_lb_listener_default_action_403_fixed_response_406 struct {
 }
 
 type Aws_lb_listener_default_action_403_redirect_407 struct {
-
-    Aws_lb_listener_default_action_403_redirect_407_id *string `lyra:"ignore"`
 
     Host *string
 
@@ -21939,17 +21127,15 @@ type Aws_lb_listener_default_action_403_redirect_407 struct {
 
 type Aws_lb_listener_default_action_403 struct {
 
-    Aws_lb_listener_default_action_403_id *string `lyra:"ignore"`
+    Authenticate_cognito *[]Aws_lb_listener_default_action_403_authenticate_cognito_404
 
-    Authenticate_cognito *Aws_lb_listener_default_action_403_authenticate_cognito_404
+    Authenticate_oidc *[]Aws_lb_listener_default_action_403_authenticate_oidc_405
 
-    Authenticate_oidc *Aws_lb_listener_default_action_403_authenticate_oidc_405
-
-    Fixed_response *Aws_lb_listener_default_action_403_fixed_response_406
+    Fixed_response *[]Aws_lb_listener_default_action_403_fixed_response_406
 
     Order *int
 
-    Redirect *Aws_lb_listener_default_action_403_redirect_407
+    Redirect *[]Aws_lb_listener_default_action_403_redirect_407
 
     Target_group_arn *string
 
@@ -21965,7 +21151,7 @@ type Aws_lb_listener struct {
 
     Certificate_arn *string
 
-    Default_action Aws_lb_listener_default_action_403
+    Default_action []Aws_lb_listener_default_action_403
 
     Load_balancer_arn string
 
@@ -22063,8 +21249,6 @@ func (h *Aws_lb_listener_certificateHandler) Delete(externalID string) error {
 
 type Aws_lb_listener_rule_action_408_authenticate_cognito_409 struct {
 
-    Aws_lb_listener_rule_action_408_authenticate_cognito_409_id *string `lyra:"ignore"`
-
     Authentication_request_extra_params *map[string]string
 
     On_unauthenticated_request *string
@@ -22084,8 +21268,6 @@ type Aws_lb_listener_rule_action_408_authenticate_cognito_409 struct {
 }
 
 type Aws_lb_listener_rule_action_408_authenticate_oidc_410 struct {
-
-    Aws_lb_listener_rule_action_408_authenticate_oidc_410_id *string `lyra:"ignore"`
 
     Authentication_request_extra_params *map[string]string
 
@@ -22113,8 +21295,6 @@ type Aws_lb_listener_rule_action_408_authenticate_oidc_410 struct {
 
 type Aws_lb_listener_rule_action_408_fixed_response_411 struct {
 
-    Aws_lb_listener_rule_action_408_fixed_response_411_id *string `lyra:"ignore"`
-
     Content_type string
 
     Message_body *string
@@ -22124,8 +21304,6 @@ type Aws_lb_listener_rule_action_408_fixed_response_411 struct {
 }
 
 type Aws_lb_listener_rule_action_408_redirect_412 struct {
-
-    Aws_lb_listener_rule_action_408_redirect_412_id *string `lyra:"ignore"`
 
     Host *string
 
@@ -22143,17 +21321,15 @@ type Aws_lb_listener_rule_action_408_redirect_412 struct {
 
 type Aws_lb_listener_rule_action_408 struct {
 
-    Aws_lb_listener_rule_action_408_id *string `lyra:"ignore"`
+    Authenticate_cognito *[]Aws_lb_listener_rule_action_408_authenticate_cognito_409
 
-    Authenticate_cognito *Aws_lb_listener_rule_action_408_authenticate_cognito_409
+    Authenticate_oidc *[]Aws_lb_listener_rule_action_408_authenticate_oidc_410
 
-    Authenticate_oidc *Aws_lb_listener_rule_action_408_authenticate_oidc_410
-
-    Fixed_response *Aws_lb_listener_rule_action_408_fixed_response_411
+    Fixed_response *[]Aws_lb_listener_rule_action_408_fixed_response_411
 
     Order *int
 
-    Redirect *Aws_lb_listener_rule_action_408_redirect_412
+    Redirect *[]Aws_lb_listener_rule_action_408_redirect_412
 
     Target_group_arn *string
 
@@ -22162,8 +21338,6 @@ type Aws_lb_listener_rule_action_408 struct {
 }
 
 type Aws_lb_listener_rule_condition_413 struct {
-
-    Aws_lb_listener_rule_condition_413_id *string `lyra:"ignore"`
 
     Field *string
 
@@ -22175,7 +21349,7 @@ type Aws_lb_listener_rule struct {
 
     Aws_lb_listener_rule_id *string `lyra:"ignore"`
 
-    Action Aws_lb_listener_rule_action_408
+    Action []Aws_lb_listener_rule_action_408
 
     Arn *string
 
@@ -22225,8 +21399,6 @@ func (h *Aws_lb_listener_ruleHandler) Delete(externalID string) error {
 }
 
 type Aws_lb_ssl_negotiation_policy_attribute_414 struct {
-
-    Aws_lb_ssl_negotiation_policy_attribute_414_id *string `lyra:"ignore"`
 
     Name string
 
@@ -22287,8 +21459,6 @@ func (h *Aws_lb_ssl_negotiation_policyHandler) Delete(externalID string) error {
 
 type Aws_lb_target_group_health_check_415 struct {
 
-    Aws_lb_target_group_health_check_415_id *string `lyra:"ignore"`
-
     Healthy_threshold *int
 
     Interval *int
@@ -22309,8 +21479,6 @@ type Aws_lb_target_group_health_check_415 struct {
 
 type Aws_lb_target_group_stickiness_416 struct {
 
-    Aws_lb_target_group_stickiness_416_id *string `lyra:"ignore"`
-
     Cookie_duration *int
 
     Enabled *bool
@@ -22329,7 +21497,7 @@ type Aws_lb_target_group struct {
 
     Deregistration_delay *int
 
-    Health_check *Aws_lb_target_group_health_check_415
+    Health_check *[]Aws_lb_target_group_health_check_415
 
     Name *string
 
@@ -22343,7 +21511,7 @@ type Aws_lb_target_group struct {
 
     Slow_start *int
 
-    Stickiness *Aws_lb_target_group_stickiness_416
+    Stickiness *[]Aws_lb_target_group_stickiness_416
 
     Tags *map[string]string
 
@@ -22924,8 +22092,6 @@ func (h *Aws_load_balancer_listener_policyHandler) Delete(externalID string) err
 
 type Aws_load_balancer_policy_policy_attribute_417 struct {
 
-    Aws_load_balancer_policy_policy_attribute_417_id *string `lyra:"ignore"`
-
     Name *string
 
     Value *string
@@ -23030,8 +22196,6 @@ func (h *Aws_macie_member_account_associationHandler) Delete(externalID string) 
 
 type Aws_macie_s3_bucket_association_classification_type_418 struct {
 
-    Aws_macie_s3_bucket_association_classification_type_418_id *string `lyra:"ignore"`
-
     Continuous *string
 
     One_time *string
@@ -23044,7 +22208,7 @@ type Aws_macie_s3_bucket_association struct {
 
     Bucket_name string
 
-    Classification_type *Aws_macie_s3_bucket_association_classification_type_418
+    Classification_type *[]Aws_macie_s3_bucket_association_classification_type_418
 
     Member_account_id *string
 
@@ -23140,8 +22304,6 @@ func (h *Aws_main_route_table_associationHandler) Delete(externalID string) erro
 
 type Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420 struct {
 
-    Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420_id *string `lyra:"ignore"`
-
     Password *string
 
     Url *string
@@ -23152,9 +22314,7 @@ type Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420 struct {
 
 type Aws_media_package_channel_hls_ingest_419 struct {
 
-    Aws_media_package_channel_hls_ingest_419_id *string `lyra:"ignore"`
-
-    Ingest_endpoints *Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420
+    Ingest_endpoints *[]Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420
 
 }
 
@@ -23168,7 +22328,7 @@ type Aws_media_package_channel struct {
 
     Description *string
 
-    Hls_ingest *Aws_media_package_channel_hls_ingest_419
+    Hls_ingest *[]Aws_media_package_channel_hls_ingest_419
 
 }
 
@@ -23307,8 +22467,6 @@ func (h *Aws_media_store_container_policyHandler) Delete(externalID string) erro
 
 type Aws_mq_broker_configuration_421 struct {
 
-    Aws_mq_broker_configuration_421_id *string `lyra:"ignore"`
-
     Id *string
 
     Revision *int
@@ -23316,8 +22474,6 @@ type Aws_mq_broker_configuration_421 struct {
 }
 
 type Aws_mq_broker_instances_422 struct {
-
-    Aws_mq_broker_instances_422_id *string `lyra:"ignore"`
 
     Console_url *string
 
@@ -23329,8 +22485,6 @@ type Aws_mq_broker_instances_422 struct {
 
 type Aws_mq_broker_logs_423 struct {
 
-    Aws_mq_broker_logs_423_id *string `lyra:"ignore"`
-
     Audit *bool
 
     General *bool
@@ -23338,8 +22492,6 @@ type Aws_mq_broker_logs_423 struct {
 }
 
 type Aws_mq_broker_maintenance_window_start_time_424 struct {
-
-    Aws_mq_broker_maintenance_window_start_time_424_id *string `lyra:"ignore"`
 
     Day_of_week string
 
@@ -23350,8 +22502,6 @@ type Aws_mq_broker_maintenance_window_start_time_424 struct {
 }
 
 type Aws_mq_broker_user_425 struct {
-
-    Aws_mq_broker_user_425_id *string `lyra:"ignore"`
 
     Console_access *bool
 
@@ -23375,7 +22525,7 @@ type Aws_mq_broker struct {
 
     Broker_name string
 
-    Configuration *Aws_mq_broker_configuration_421
+    Configuration *[]Aws_mq_broker_configuration_421
 
     Deployment_mode *string
 
@@ -23385,11 +22535,11 @@ type Aws_mq_broker struct {
 
     Host_instance_type string
 
-    Instances *Aws_mq_broker_instances_422
+    Instances *[]Aws_mq_broker_instances_422
 
-    Logs *Aws_mq_broker_logs_423
+    Logs *[]Aws_mq_broker_logs_423
 
-    Maintenance_window_start_time *Aws_mq_broker_maintenance_window_start_time_424
+    Maintenance_window_start_time *[]Aws_mq_broker_maintenance_window_start_time_424
 
     Publicly_accessible *bool
 
@@ -23746,8 +22896,6 @@ func (h *Aws_neptune_cluster_instanceHandler) Delete(externalID string) error {
 
 type Aws_neptune_cluster_parameter_group_parameter_426 struct {
 
-    Aws_neptune_cluster_parameter_group_parameter_426_id *string `lyra:"ignore"`
-
     Apply_method *string
 
     Name string
@@ -23951,8 +23099,6 @@ func (h *Aws_neptune_event_subscriptionHandler) Delete(externalID string) error 
 
 type Aws_neptune_parameter_group_parameter_427 struct {
 
-    Aws_neptune_parameter_group_parameter_427_id *string `lyra:"ignore"`
-
     Apply_method *string
 
     Name string
@@ -24073,8 +23219,6 @@ func (h *Aws_neptune_subnet_groupHandler) Delete(externalID string) error {
 
 type Aws_network_acl_egress_428 struct {
 
-    Aws_network_acl_egress_428_id *string `lyra:"ignore"`
-
     Action string
 
     Cidr_block *string
@@ -24096,8 +23240,6 @@ type Aws_network_acl_egress_428 struct {
 }
 
 type Aws_network_acl_ingress_429 struct {
-
-    Aws_network_acl_ingress_429_id *string `lyra:"ignore"`
 
     Action string
 
@@ -24242,8 +23384,6 @@ func (h *Aws_network_acl_ruleHandler) Delete(externalID string) error {
 }
 
 type Aws_network_interface_attachment_430 struct {
-
-    Aws_network_interface_attachment_430_id *string `lyra:"ignore"`
 
     Attachment_id *string
 
@@ -24418,8 +23558,6 @@ func (h *Aws_network_interface_sg_attachmentHandler) Delete(externalID string) e
 
 type Aws_opsworks_application_app_source_431 struct {
 
-    Aws_opsworks_application_app_source_431_id *string `lyra:"ignore"`
-
     Password *string
 
     Revision *string
@@ -24436,8 +23574,6 @@ type Aws_opsworks_application_app_source_431 struct {
 
 type Aws_opsworks_application_environment_432 struct {
 
-    Aws_opsworks_application_environment_432_id *string `lyra:"ignore"`
-
     Key string
 
     Secure *bool
@@ -24447,8 +23583,6 @@ type Aws_opsworks_application_environment_432 struct {
 }
 
 type Aws_opsworks_application_ssl_configuration_433 struct {
-
-    Aws_opsworks_application_ssl_configuration_433_id *string `lyra:"ignore"`
 
     Certificate string
 
@@ -24462,7 +23596,7 @@ type Aws_opsworks_application struct {
 
     Aws_opsworks_application_id *string `lyra:"ignore"`
 
-    App_source *Aws_opsworks_application_app_source_431
+    App_source *[]Aws_opsworks_application_app_source_431
 
     Auto_bundle_on_deploy *string
 
@@ -24490,7 +23624,7 @@ type Aws_opsworks_application struct {
 
     Short_name *string
 
-    Ssl_configuration *Aws_opsworks_application_ssl_configuration_433
+    Ssl_configuration *[]Aws_opsworks_application_ssl_configuration_433
 
     Stack_id string
 
@@ -24536,8 +23670,6 @@ func (h *Aws_opsworks_applicationHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_custom_layer_ebs_volume_434 struct {
-
-    Aws_opsworks_custom_layer_ebs_volume_434_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -24639,8 +23771,6 @@ func (h *Aws_opsworks_custom_layerHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_ganglia_layer_ebs_volume_435 struct {
-
-    Aws_opsworks_ganglia_layer_ebs_volume_435_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -24746,8 +23876,6 @@ func (h *Aws_opsworks_ganglia_layerHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_haproxy_layer_ebs_volume_436 struct {
-
-    Aws_opsworks_haproxy_layer_ebs_volume_436_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -24860,8 +23988,6 @@ func (h *Aws_opsworks_haproxy_layerHandler) Delete(externalID string) error {
 
 type Aws_opsworks_instance_ebs_block_device_437 struct {
 
-    Aws_opsworks_instance_ebs_block_device_437_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_name string
@@ -24878,8 +24004,6 @@ type Aws_opsworks_instance_ebs_block_device_437 struct {
 
 type Aws_opsworks_instance_ephemeral_block_device_438 struct {
 
-    Aws_opsworks_instance_ephemeral_block_device_438_id *string `lyra:"ignore"`
-
     Device_name string
 
     Virtual_name string
@@ -24887,8 +24011,6 @@ type Aws_opsworks_instance_ephemeral_block_device_438 struct {
 }
 
 type Aws_opsworks_instance_root_block_device_439 struct {
-
-    Aws_opsworks_instance_root_block_device_439_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -25035,8 +24157,6 @@ func (h *Aws_opsworks_instanceHandler) Delete(externalID string) error {
 
 type Aws_opsworks_java_app_layer_ebs_volume_440 struct {
 
-    Aws_opsworks_java_app_layer_ebs_volume_440_id *string `lyra:"ignore"`
-
     Iops *int
 
     Mount_point string
@@ -25146,8 +24266,6 @@ func (h *Aws_opsworks_java_app_layerHandler) Delete(externalID string) error {
 
 type Aws_opsworks_memcached_layer_ebs_volume_441 struct {
 
-    Aws_opsworks_memcached_layer_ebs_volume_441_id *string `lyra:"ignore"`
-
     Iops *int
 
     Mount_point string
@@ -25248,8 +24366,6 @@ func (h *Aws_opsworks_memcached_layerHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_mysql_layer_ebs_volume_442 struct {
-
-    Aws_opsworks_mysql_layer_ebs_volume_442_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -25353,8 +24469,6 @@ func (h *Aws_opsworks_mysql_layerHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_nodejs_app_layer_ebs_volume_443 struct {
-
-    Aws_opsworks_nodejs_app_layer_ebs_volume_443_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -25510,8 +24624,6 @@ func (h *Aws_opsworks_permissionHandler) Delete(externalID string) error {
 
 type Aws_opsworks_php_app_layer_ebs_volume_444 struct {
 
-    Aws_opsworks_php_app_layer_ebs_volume_444_id *string `lyra:"ignore"`
-
     Iops *int
 
     Mount_point string
@@ -25610,8 +24722,6 @@ func (h *Aws_opsworks_php_app_layerHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_rails_app_layer_ebs_volume_445 struct {
-
-    Aws_opsworks_rails_app_layer_ebs_volume_445_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -25775,8 +24885,6 @@ func (h *Aws_opsworks_rds_db_instanceHandler) Delete(externalID string) error {
 
 type Aws_opsworks_stack_custom_cookbooks_source_446 struct {
 
-    Aws_opsworks_stack_custom_cookbooks_source_446_id *string `lyra:"ignore"`
-
     Password *string
 
     Revision *string
@@ -25807,7 +24915,7 @@ type Aws_opsworks_stack struct {
 
     Configuration_manager_version *string
 
-    Custom_cookbooks_source *Aws_opsworks_stack_custom_cookbooks_source_446
+    Custom_cookbooks_source *[]Aws_opsworks_stack_custom_cookbooks_source_446
 
     Custom_json *string
 
@@ -25883,8 +24991,6 @@ func (h *Aws_opsworks_stackHandler) Delete(externalID string) error {
 }
 
 type Aws_opsworks_static_web_layer_ebs_volume_447 struct {
-
-    Aws_opsworks_static_web_layer_ebs_volume_447_id *string `lyra:"ignore"`
 
     Iops *int
 
@@ -26545,8 +25651,6 @@ func (h *Aws_pinpoint_apns_voip_sandbox_channelHandler) Delete(externalID string
 
 type Aws_pinpoint_app_campaign_hook_448 struct {
 
-    Aws_pinpoint_app_campaign_hook_448_id *string `lyra:"ignore"`
-
     Lambda_function_name *string
 
     Mode *string
@@ -26556,8 +25660,6 @@ type Aws_pinpoint_app_campaign_hook_448 struct {
 }
 
 type Aws_pinpoint_app_limits_449 struct {
-
-    Aws_pinpoint_app_limits_449_id *string `lyra:"ignore"`
 
     Daily *int
 
@@ -26571,8 +25673,6 @@ type Aws_pinpoint_app_limits_449 struct {
 
 type Aws_pinpoint_app_quiet_time_450 struct {
 
-    Aws_pinpoint_app_quiet_time_450_id *string `lyra:"ignore"`
-
     End *string
 
     Start *string
@@ -26585,15 +25685,15 @@ type Aws_pinpoint_app struct {
 
     Application_id *string
 
-    Campaign_hook *Aws_pinpoint_app_campaign_hook_448
+    Campaign_hook *[]Aws_pinpoint_app_campaign_hook_448
 
-    Limits *Aws_pinpoint_app_limits_449
+    Limits *[]Aws_pinpoint_app_limits_449
 
     Name *string
 
     Name_prefix *string
 
-    Quiet_time *Aws_pinpoint_app_quiet_time_450
+    Quiet_time *[]Aws_pinpoint_app_quiet_time_450
 
 }
 
@@ -27038,8 +26138,6 @@ func (h *Aws_ram_resource_shareHandler) Delete(externalID string) error {
 
 type Aws_rds_cluster_s3_import_451 struct {
 
-    Aws_rds_cluster_s3_import_451_id *string `lyra:"ignore"`
-
     Bucket_name string
 
     Bucket_prefix *string
@@ -27053,8 +26151,6 @@ type Aws_rds_cluster_s3_import_451 struct {
 }
 
 type Aws_rds_cluster_scaling_configuration_452 struct {
-
-    Aws_rds_cluster_scaling_configuration_452_id *string `lyra:"ignore"`
 
     Auto_pause *bool
 
@@ -27132,9 +26228,9 @@ type Aws_rds_cluster struct {
 
     Replication_source_identifier *string
 
-    S3_import *Aws_rds_cluster_s3_import_451
+    S3_import *[]Aws_rds_cluster_s3_import_451
 
-    Scaling_configuration *Aws_rds_cluster_scaling_configuration_452
+    Scaling_configuration *[]Aws_rds_cluster_scaling_configuration_452
 
     Skip_final_snapshot *bool
 
@@ -27345,8 +26441,6 @@ func (h *Aws_rds_cluster_instanceHandler) Delete(externalID string) error {
 
 type Aws_rds_cluster_parameter_group_parameter_453 struct {
 
-    Aws_rds_cluster_parameter_group_parameter_453_id *string `lyra:"ignore"`
-
     Apply_method *string
 
     Name string
@@ -27473,8 +26567,6 @@ func (h *Aws_rds_global_clusterHandler) Delete(externalID string) error {
 
 type Aws_redshift_cluster_logging_454 struct {
 
-    Aws_redshift_cluster_logging_454_id *string `lyra:"ignore"`
-
     Bucket_name *string
 
     Enable bool
@@ -27484,8 +26576,6 @@ type Aws_redshift_cluster_logging_454 struct {
 }
 
 type Aws_redshift_cluster_snapshot_copy_455 struct {
-
-    Aws_redshift_cluster_snapshot_copy_455_id *string `lyra:"ignore"`
 
     Destination_region string
 
@@ -27543,7 +26633,7 @@ type Aws_redshift_cluster struct {
 
     Kms_key_id *string
 
-    Logging *Aws_redshift_cluster_logging_454
+    Logging *[]Aws_redshift_cluster_logging_454
 
     Master_password *string
 
@@ -27567,7 +26657,7 @@ type Aws_redshift_cluster struct {
 
     Snapshot_cluster_identifier *string
 
-    Snapshot_copy *Aws_redshift_cluster_snapshot_copy_455
+    Snapshot_copy *[]Aws_redshift_cluster_snapshot_copy_455
 
     Snapshot_identifier *string
 
@@ -27679,8 +26769,6 @@ func (h *Aws_redshift_event_subscriptionHandler) Delete(externalID string) error
 
 type Aws_redshift_parameter_group_parameter_456 struct {
 
-    Aws_redshift_parameter_group_parameter_456_id *string `lyra:"ignore"`
-
     Name string
 
     Value string
@@ -27739,8 +26827,6 @@ func (h *Aws_redshift_parameter_groupHandler) Delete(externalID string) error {
 }
 
 type Aws_redshift_security_group_ingress_457 struct {
-
-    Aws_redshift_security_group_ingress_457_id *string `lyra:"ignore"`
 
     Cidr *string
 
@@ -27901,8 +26987,6 @@ func (h *Aws_redshift_subnet_groupHandler) Delete(externalID string) error {
 
 type Aws_resourcegroups_group_resource_query_458 struct {
 
-    Aws_resourcegroups_group_resource_query_458_id *string `lyra:"ignore"`
-
     Query string
 
     Type *string
@@ -27919,7 +27003,7 @@ type Aws_resourcegroups_group struct {
 
     Name string
 
-    Resource_query Aws_resourcegroups_group_resource_query_458
+    Resource_query []Aws_resourcegroups_group_resource_query_458
 
 }
 
@@ -28208,8 +27292,6 @@ func (h *Aws_route53_query_logHandler) Delete(externalID string) error {
 
 type Aws_route53_record_alias_459 struct {
 
-    Aws_route53_record_alias_459_id *string `lyra:"ignore"`
-
     Evaluate_target_health bool
 
     Name string
@@ -28220,15 +27302,11 @@ type Aws_route53_record_alias_459 struct {
 
 type Aws_route53_record_failover_routing_policy_460 struct {
 
-    Aws_route53_record_failover_routing_policy_460_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_route53_record_geolocation_routing_policy_461 struct {
-
-    Aws_route53_record_geolocation_routing_policy_461_id *string `lyra:"ignore"`
 
     Continent *string
 
@@ -28240,15 +27318,11 @@ type Aws_route53_record_geolocation_routing_policy_461 struct {
 
 type Aws_route53_record_latency_routing_policy_462 struct {
 
-    Aws_route53_record_latency_routing_policy_462_id *string `lyra:"ignore"`
-
     Region string
 
 }
 
 type Aws_route53_record_weighted_routing_policy_463 struct {
-
-    Aws_route53_record_weighted_routing_policy_463_id *string `lyra:"ignore"`
 
     Weight int
 
@@ -28264,15 +27338,15 @@ type Aws_route53_record struct {
 
     Failover *string
 
-    Failover_routing_policy *Aws_route53_record_failover_routing_policy_460
+    Failover_routing_policy *[]Aws_route53_record_failover_routing_policy_460
 
     Fqdn *string
 
-    Geolocation_routing_policy *Aws_route53_record_geolocation_routing_policy_461
+    Geolocation_routing_policy *[]Aws_route53_record_geolocation_routing_policy_461
 
     Health_check_id *string
 
-    Latency_routing_policy *Aws_route53_record_latency_routing_policy_462
+    Latency_routing_policy *[]Aws_route53_record_latency_routing_policy_462
 
     Multivalue_answer_routing_policy *bool
 
@@ -28288,7 +27362,7 @@ type Aws_route53_record struct {
 
     Weight *int
 
-    Weighted_routing_policy *Aws_route53_record_weighted_routing_policy_463
+    Weighted_routing_policy *[]Aws_route53_record_weighted_routing_policy_463
 
     Zone_id string
 
@@ -28332,8 +27406,6 @@ func (h *Aws_route53_recordHandler) Delete(externalID string) error {
 }
 
 type Aws_route53_zone_vpc_464 struct {
-
-    Aws_route53_zone_vpc_464_id *string `lyra:"ignore"`
 
     Vpc_id string
 
@@ -28454,8 +27526,6 @@ func (h *Aws_route53_zone_associationHandler) Delete(externalID string) error {
 }
 
 type Aws_route_table_route_465 struct {
-
-    Aws_route_table_route_465_id *string `lyra:"ignore"`
 
     Cidr_block *string
 
@@ -28632,8 +27702,6 @@ func (h *Aws_s3_account_public_access_blockHandler) Delete(externalID string) er
 
 type Aws_s3_bucket_cors_rule_466 struct {
 
-    Aws_s3_bucket_cors_rule_466_id *string `lyra:"ignore"`
-
     Allowed_headers *[]string
 
     Allowed_methods []string
@@ -28648,8 +27716,6 @@ type Aws_s3_bucket_cors_rule_466 struct {
 
 type Aws_s3_bucket_lifecycle_rule_467_expiration_468 struct {
 
-    Aws_s3_bucket_lifecycle_rule_467_expiration_468_id *string `lyra:"ignore"`
-
     Date *string
 
     Days *int
@@ -28660,15 +27726,11 @@ type Aws_s3_bucket_lifecycle_rule_467_expiration_468 struct {
 
 type Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_expiration_469 struct {
 
-    Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_expiration_469_id *string `lyra:"ignore"`
-
     Days *int
 
 }
 
 type Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_transition_470 struct {
-
-    Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_transition_470_id *string `lyra:"ignore"`
 
     Days *int
 
@@ -28677,8 +27739,6 @@ type Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_transition_470 struct {
 }
 
 type Aws_s3_bucket_lifecycle_rule_467_transition_471 struct {
-
-    Aws_s3_bucket_lifecycle_rule_467_transition_471_id *string `lyra:"ignore"`
 
     Date *string
 
@@ -28689,8 +27749,6 @@ type Aws_s3_bucket_lifecycle_rule_467_transition_471 struct {
 }
 
 type Aws_s3_bucket_lifecycle_rule_467 struct {
-
-    Aws_s3_bucket_lifecycle_rule_467_id *string `lyra:"ignore"`
 
     Abort_incomplete_multipart_upload_days *int
 
@@ -28714,8 +27772,6 @@ type Aws_s3_bucket_lifecycle_rule_467 struct {
 
 type Aws_s3_bucket_logging_472 struct {
 
-    Aws_s3_bucket_logging_472_id *string `lyra:"ignore"`
-
     Target_bucket string
 
     Target_prefix *string
@@ -28723,8 +27779,6 @@ type Aws_s3_bucket_logging_472 struct {
 }
 
 type Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475 struct {
-
-    Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475_id *string `lyra:"ignore"`
 
     Days *int
 
@@ -28736,25 +27790,19 @@ type Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475 
 
 type Aws_s3_bucket_object_lock_configuration_473_rule_474 struct {
 
-    Aws_s3_bucket_object_lock_configuration_473_rule_474_id *string `lyra:"ignore"`
-
-    Default_retention Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475
+    Default_retention []Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475
 
 }
 
 type Aws_s3_bucket_object_lock_configuration_473 struct {
 
-    Aws_s3_bucket_object_lock_configuration_473_id *string `lyra:"ignore"`
-
     Object_lock_enabled string
 
-    Rule *Aws_s3_bucket_object_lock_configuration_473_rule_474
+    Rule *[]Aws_s3_bucket_object_lock_configuration_473_rule_474
 
 }
 
 type Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479 struct {
-
-    Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479_id *string `lyra:"ignore"`
 
     Owner string
 
@@ -28762,9 +27810,7 @@ type Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_acces
 
 type Aws_s3_bucket_replication_configuration_476_rules_477_destination_478 struct {
 
-    Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_id *string `lyra:"ignore"`
-
-    Access_control_translation *Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479
+    Access_control_translation *[]Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479
 
     Account_id *string
 
@@ -28778,8 +27824,6 @@ type Aws_s3_bucket_replication_configuration_476_rules_477_destination_478 struc
 
 type Aws_s3_bucket_replication_configuration_476_rules_477_filter_480 struct {
 
-    Aws_s3_bucket_replication_configuration_476_rules_477_filter_480_id *string `lyra:"ignore"`
-
     Prefix *string
 
     Tags *map[string]string
@@ -28788,15 +27832,11 @@ type Aws_s3_bucket_replication_configuration_476_rules_477_filter_480 struct {
 
 type Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_sse_kms_encrypted_objects_482 struct {
 
-    Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_sse_kms_encrypted_objects_482_id *string `lyra:"ignore"`
-
     Enabled bool
 
 }
 
 type Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481 struct {
-
-    Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_id *string `lyra:"ignore"`
 
     Sse_kms_encrypted_objects *Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_sse_kms_encrypted_objects_482
 
@@ -28804,11 +27844,9 @@ type Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_crit
 
 type Aws_s3_bucket_replication_configuration_476_rules_477 struct {
 
-    Aws_s3_bucket_replication_configuration_476_rules_477_id *string `lyra:"ignore"`
-
     Destination Aws_s3_bucket_replication_configuration_476_rules_477_destination_478
 
-    Filter *Aws_s3_bucket_replication_configuration_476_rules_477_filter_480
+    Filter *[]Aws_s3_bucket_replication_configuration_476_rules_477_filter_480
 
     Id *string
 
@@ -28824,8 +27862,6 @@ type Aws_s3_bucket_replication_configuration_476_rules_477 struct {
 
 type Aws_s3_bucket_replication_configuration_476 struct {
 
-    Aws_s3_bucket_replication_configuration_476_id *string `lyra:"ignore"`
-
     Role string
 
     Rules Aws_s3_bucket_replication_configuration_476_rules_477
@@ -28833,8 +27869,6 @@ type Aws_s3_bucket_replication_configuration_476 struct {
 }
 
 type Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485 struct {
-
-    Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485_id *string `lyra:"ignore"`
 
     Kms_master_key_id *string
 
@@ -28844,23 +27878,17 @@ type Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_serve
 
 type Aws_s3_bucket_server_side_encryption_configuration_483_rule_484 struct {
 
-    Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_id *string `lyra:"ignore"`
-
-    Apply_server_side_encryption_by_default Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485
+    Apply_server_side_encryption_by_default []Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485
 
 }
 
 type Aws_s3_bucket_server_side_encryption_configuration_483 struct {
 
-    Aws_s3_bucket_server_side_encryption_configuration_483_id *string `lyra:"ignore"`
-
-    Rule Aws_s3_bucket_server_side_encryption_configuration_483_rule_484
+    Rule []Aws_s3_bucket_server_side_encryption_configuration_483_rule_484
 
 }
 
 type Aws_s3_bucket_versioning_486 struct {
-
-    Aws_s3_bucket_versioning_486_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -28869,8 +27897,6 @@ type Aws_s3_bucket_versioning_486 struct {
 }
 
 type Aws_s3_bucket_website_487 struct {
-
-    Aws_s3_bucket_website_487_id *string `lyra:"ignore"`
 
     Error_document *string
 
@@ -28900,33 +27926,33 @@ type Aws_s3_bucket struct {
 
     Bucket_regional_domain_name *string
 
-    Cors_rule *Aws_s3_bucket_cors_rule_466
+    Cors_rule *[]Aws_s3_bucket_cors_rule_466
 
     Force_destroy *bool
 
     Hosted_zone_id *string
 
-    Lifecycle_rule *Aws_s3_bucket_lifecycle_rule_467
+    Lifecycle_rule *[]Aws_s3_bucket_lifecycle_rule_467
 
     Logging *Aws_s3_bucket_logging_472
 
-    Object_lock_configuration *Aws_s3_bucket_object_lock_configuration_473
+    Object_lock_configuration *[]Aws_s3_bucket_object_lock_configuration_473
 
     Policy *string
 
     Region *string
 
-    Replication_configuration *Aws_s3_bucket_replication_configuration_476
+    Replication_configuration *[]Aws_s3_bucket_replication_configuration_476
 
     Request_payer *string
 
-    Server_side_encryption_configuration *Aws_s3_bucket_server_side_encryption_configuration_483
+    Server_side_encryption_configuration *[]Aws_s3_bucket_server_side_encryption_configuration_483
 
     Tags *map[string]string
 
-    Versioning *Aws_s3_bucket_versioning_486
+    Versioning *[]Aws_s3_bucket_versioning_486
 
-    Website *Aws_s3_bucket_website_487
+    Website *[]Aws_s3_bucket_website_487
 
     Website_domain *string
 
@@ -28973,37 +27999,29 @@ func (h *Aws_s3_bucketHandler) Delete(externalID string) error {
 
 type Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491 struct {
 
-    Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491_id *string `lyra:"ignore"`
-
     Key_id string
 
 }
 
 type Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492 struct {
 
-    Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492_id *string `lyra:"ignore"`
-
 }
 
 type Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490 struct {
 
-    Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_id *string `lyra:"ignore"`
+    Sse_kms *[]Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491
 
-    Sse_kms *Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491
-
-    Sse_s3 *Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492
+    Sse_s3 *[]Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492
 
 }
 
 type Aws_s3_bucket_inventory_destination_488_bucket_489 struct {
 
-    Aws_s3_bucket_inventory_destination_488_bucket_489_id *string `lyra:"ignore"`
-
     Account_id *string
 
     Bucket_arn string
 
-    Encryption *Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490
+    Encryption *[]Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490
 
     Format string
 
@@ -29013,23 +28031,17 @@ type Aws_s3_bucket_inventory_destination_488_bucket_489 struct {
 
 type Aws_s3_bucket_inventory_destination_488 struct {
 
-    Aws_s3_bucket_inventory_destination_488_id *string `lyra:"ignore"`
-
-    Bucket Aws_s3_bucket_inventory_destination_488_bucket_489
+    Bucket []Aws_s3_bucket_inventory_destination_488_bucket_489
 
 }
 
 type Aws_s3_bucket_inventory_filter_493 struct {
-
-    Aws_s3_bucket_inventory_filter_493_id *string `lyra:"ignore"`
 
     Prefix *string
 
 }
 
 type Aws_s3_bucket_inventory_schedule_494 struct {
-
-    Aws_s3_bucket_inventory_schedule_494_id *string `lyra:"ignore"`
 
     Frequency string
 
@@ -29041,11 +28053,11 @@ type Aws_s3_bucket_inventory struct {
 
     Bucket string
 
-    Destination Aws_s3_bucket_inventory_destination_488
+    Destination []Aws_s3_bucket_inventory_destination_488
 
     Enabled *bool
 
-    Filter *Aws_s3_bucket_inventory_filter_493
+    Filter *[]Aws_s3_bucket_inventory_filter_493
 
     Included_object_versions string
 
@@ -29053,7 +28065,7 @@ type Aws_s3_bucket_inventory struct {
 
     Optional_fields *[]string
 
-    Schedule Aws_s3_bucket_inventory_schedule_494
+    Schedule []Aws_s3_bucket_inventory_schedule_494
 
 }
 
@@ -29096,8 +28108,6 @@ func (h *Aws_s3_bucket_inventoryHandler) Delete(externalID string) error {
 
 type Aws_s3_bucket_metric_filter_495 struct {
 
-    Aws_s3_bucket_metric_filter_495_id *string `lyra:"ignore"`
-
     Prefix *string
 
     Tags *map[string]string
@@ -29110,7 +28120,7 @@ type Aws_s3_bucket_metric struct {
 
     Bucket string
 
-    Filter *Aws_s3_bucket_metric_filter_495
+    Filter *[]Aws_s3_bucket_metric_filter_495
 
     Name string
 
@@ -29155,8 +28165,6 @@ func (h *Aws_s3_bucket_metricHandler) Delete(externalID string) error {
 
 type Aws_s3_bucket_notification_lambda_function_496 struct {
 
-    Aws_s3_bucket_notification_lambda_function_496_id *string `lyra:"ignore"`
-
     Events []string
 
     Filter_prefix *string
@@ -29171,8 +28179,6 @@ type Aws_s3_bucket_notification_lambda_function_496 struct {
 
 type Aws_s3_bucket_notification_queue_497 struct {
 
-    Aws_s3_bucket_notification_queue_497_id *string `lyra:"ignore"`
-
     Events []string
 
     Filter_prefix *string
@@ -29186,8 +28192,6 @@ type Aws_s3_bucket_notification_queue_497 struct {
 }
 
 type Aws_s3_bucket_notification_topic_498 struct {
-
-    Aws_s3_bucket_notification_topic_498_id *string `lyra:"ignore"`
 
     Events []string
 
@@ -29207,11 +28211,11 @@ type Aws_s3_bucket_notification struct {
 
     Bucket string
 
-    Lambda_function *Aws_s3_bucket_notification_lambda_function_496
+    Lambda_function *[]Aws_s3_bucket_notification_lambda_function_496
 
-    Queue *Aws_s3_bucket_notification_queue_497
+    Queue *[]Aws_s3_bucket_notification_queue_497
 
-    Topic *Aws_s3_bucket_notification_topic_498
+    Topic *[]Aws_s3_bucket_notification_topic_498
 
 }
 
@@ -29492,8 +28496,6 @@ func (h *Aws_sagemaker_notebook_instanceHandler) Delete(externalID string) error
 
 type Aws_secretsmanager_secret_rotation_rules_499 struct {
 
-    Aws_secretsmanager_secret_rotation_rules_499_id *string `lyra:"ignore"`
-
     Automatically_after_days int
 
 }
@@ -29520,7 +28522,7 @@ type Aws_secretsmanager_secret struct {
 
     Rotation_lambda_arn *string
 
-    Rotation_rules *Aws_secretsmanager_secret_rotation_rules_499
+    Rotation_rules *[]Aws_secretsmanager_secret_rotation_rules_499
 
     Tags *map[string]string
 
@@ -29620,8 +28622,6 @@ func (h *Aws_secretsmanager_secret_versionHandler) Delete(externalID string) err
 
 type Aws_security_group_egress_500 struct {
 
-    Aws_security_group_egress_500_id *string `lyra:"ignore"`
-
     Cidr_blocks *[]string
 
     Description *string
@@ -29643,8 +28643,6 @@ type Aws_security_group_egress_500 struct {
 }
 
 type Aws_security_group_ingress_501 struct {
-
-    Aws_security_group_ingress_501_id *string `lyra:"ignore"`
 
     Cidr_blocks *[]string
 
@@ -30084,8 +29082,6 @@ func (h *Aws_service_discovery_public_dns_namespaceHandler) Delete(externalID st
 
 type Aws_service_discovery_service_dns_config_502_dns_records_503 struct {
 
-    Aws_service_discovery_service_dns_config_502_dns_records_503_id *string `lyra:"ignore"`
-
     Ttl int
 
     Type string
@@ -30094,9 +29090,7 @@ type Aws_service_discovery_service_dns_config_502_dns_records_503 struct {
 
 type Aws_service_discovery_service_dns_config_502 struct {
 
-    Aws_service_discovery_service_dns_config_502_id *string `lyra:"ignore"`
-
-    Dns_records Aws_service_discovery_service_dns_config_502_dns_records_503
+    Dns_records []Aws_service_discovery_service_dns_config_502_dns_records_503
 
     Namespace_id string
 
@@ -30105,8 +29099,6 @@ type Aws_service_discovery_service_dns_config_502 struct {
 }
 
 type Aws_service_discovery_service_health_check_config_504 struct {
-
-    Aws_service_discovery_service_health_check_config_504_id *string `lyra:"ignore"`
 
     Failure_threshold *int
 
@@ -30117,8 +29109,6 @@ type Aws_service_discovery_service_health_check_config_504 struct {
 }
 
 type Aws_service_discovery_service_health_check_custom_config_505 struct {
-
-    Aws_service_discovery_service_health_check_custom_config_505_id *string `lyra:"ignore"`
 
     Failure_threshold *int
 
@@ -30132,11 +29122,11 @@ type Aws_service_discovery_service struct {
 
     Description *string
 
-    Dns_config Aws_service_discovery_service_dns_config_502
+    Dns_config []Aws_service_discovery_service_dns_config_502
 
-    Health_check_config *Aws_service_discovery_service_health_check_config_504
+    Health_check_config *[]Aws_service_discovery_service_health_check_config_504
 
-    Health_check_custom_config *Aws_service_discovery_service_health_check_custom_config_505
+    Health_check_custom_config *[]Aws_service_discovery_service_health_check_custom_config_505
 
     Name string
 
@@ -30518,8 +29508,6 @@ func (h *Aws_ses_domain_mail_fromHandler) Delete(externalID string) error {
 
 type Aws_ses_event_destination_cloudwatch_destination_506 struct {
 
-    Aws_ses_event_destination_cloudwatch_destination_506_id *string `lyra:"ignore"`
-
     Default_value string
 
     Dimension_name string
@@ -30530,8 +29518,6 @@ type Aws_ses_event_destination_cloudwatch_destination_506 struct {
 
 type Aws_ses_event_destination_kinesis_destination_507 struct {
 
-    Aws_ses_event_destination_kinesis_destination_507_id *string `lyra:"ignore"`
-
     Role_arn string
 
     Stream_arn string
@@ -30539,8 +29525,6 @@ type Aws_ses_event_destination_kinesis_destination_507 struct {
 }
 
 type Aws_ses_event_destination_sns_destination_508 struct {
-
-    Aws_ses_event_destination_sns_destination_508_id *string `lyra:"ignore"`
 
     Topic_arn string
 
@@ -30703,8 +29687,6 @@ func (h *Aws_ses_receipt_filterHandler) Delete(externalID string) error {
 
 type Aws_ses_receipt_rule_add_header_action_509 struct {
 
-    Aws_ses_receipt_rule_add_header_action_509_id *string `lyra:"ignore"`
-
     Header_name string
 
     Header_value string
@@ -30714,8 +29696,6 @@ type Aws_ses_receipt_rule_add_header_action_509 struct {
 }
 
 type Aws_ses_receipt_rule_bounce_action_510 struct {
-
-    Aws_ses_receipt_rule_bounce_action_510_id *string `lyra:"ignore"`
 
     Message string
 
@@ -30733,8 +29713,6 @@ type Aws_ses_receipt_rule_bounce_action_510 struct {
 
 type Aws_ses_receipt_rule_lambda_action_511 struct {
 
-    Aws_ses_receipt_rule_lambda_action_511_id *string `lyra:"ignore"`
-
     Function_arn string
 
     Invocation_type *string
@@ -30746,8 +29724,6 @@ type Aws_ses_receipt_rule_lambda_action_511 struct {
 }
 
 type Aws_ses_receipt_rule_s3_action_512 struct {
-
-    Aws_ses_receipt_rule_s3_action_512_id *string `lyra:"ignore"`
 
     Bucket_name string
 
@@ -30763,8 +29739,6 @@ type Aws_ses_receipt_rule_s3_action_512 struct {
 
 type Aws_ses_receipt_rule_sns_action_513 struct {
 
-    Aws_ses_receipt_rule_sns_action_513_id *string `lyra:"ignore"`
-
     Position int
 
     Topic_arn string
@@ -30772,8 +29746,6 @@ type Aws_ses_receipt_rule_sns_action_513 struct {
 }
 
 type Aws_ses_receipt_rule_stop_action_514 struct {
-
-    Aws_ses_receipt_rule_stop_action_514_id *string `lyra:"ignore"`
 
     Position int
 
@@ -30784,8 +29756,6 @@ type Aws_ses_receipt_rule_stop_action_514 struct {
 }
 
 type Aws_ses_receipt_rule_workmail_action_515 struct {
-
-    Aws_ses_receipt_rule_workmail_action_515_id *string `lyra:"ignore"`
 
     Organization_arn string
 
@@ -31518,8 +30488,6 @@ func (h *Aws_spot_datafeed_subscriptionHandler) Delete(externalID string) error 
 
 type Aws_spot_fleet_request_launch_specification_516_ebs_block_device_517 struct {
 
-    Aws_spot_fleet_request_launch_specification_516_ebs_block_device_517_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_name string
@@ -31538,8 +30506,6 @@ type Aws_spot_fleet_request_launch_specification_516_ebs_block_device_517 struct
 
 type Aws_spot_fleet_request_launch_specification_516_ephemeral_block_device_518 struct {
 
-    Aws_spot_fleet_request_launch_specification_516_ephemeral_block_device_518_id *string `lyra:"ignore"`
-
     Device_name string
 
     Virtual_name string
@@ -31547,8 +30513,6 @@ type Aws_spot_fleet_request_launch_specification_516_ephemeral_block_device_518 
 }
 
 type Aws_spot_fleet_request_launch_specification_516_root_block_device_519 struct {
-
-    Aws_spot_fleet_request_launch_specification_516_root_block_device_519_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -31561,8 +30525,6 @@ type Aws_spot_fleet_request_launch_specification_516_root_block_device_519 struc
 }
 
 type Aws_spot_fleet_request_launch_specification_516 struct {
-
-    Aws_spot_fleet_request_launch_specification_516_id *string `lyra:"ignore"`
 
     Ami string
 
@@ -31687,15 +30649,11 @@ func (h *Aws_spot_fleet_requestHandler) Delete(externalID string) error {
 
 type Aws_spot_instance_request_credit_specification_520 struct {
 
-    Aws_spot_instance_request_credit_specification_520_id *string `lyra:"ignore"`
-
     Cpu_credits *string
 
 }
 
 type Aws_spot_instance_request_ebs_block_device_521 struct {
-
-    Aws_spot_instance_request_ebs_block_device_521_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -31717,8 +30675,6 @@ type Aws_spot_instance_request_ebs_block_device_521 struct {
 
 type Aws_spot_instance_request_ephemeral_block_device_522 struct {
 
-    Aws_spot_instance_request_ephemeral_block_device_522_id *string `lyra:"ignore"`
-
     Device_name string
 
     No_device *bool
@@ -31729,8 +30685,6 @@ type Aws_spot_instance_request_ephemeral_block_device_522 struct {
 
 type Aws_spot_instance_request_network_interface_523 struct {
 
-    Aws_spot_instance_request_network_interface_523_id *string `lyra:"ignore"`
-
     Delete_on_termination *bool
 
     Device_index int
@@ -31740,8 +30694,6 @@ type Aws_spot_instance_request_network_interface_523 struct {
 }
 
 type Aws_spot_instance_request_root_block_device_524 struct {
-
-    Aws_spot_instance_request_root_block_device_524_id *string `lyra:"ignore"`
 
     Delete_on_termination *bool
 
@@ -31775,7 +30727,7 @@ type Aws_spot_instance_request struct {
 
     Cpu_threads_per_core *int
 
-    Credit_specification *Aws_spot_instance_request_credit_specification_520
+    Credit_specification *[]Aws_spot_instance_request_credit_specification_520
 
     Disable_api_termination *bool
 
@@ -31827,7 +30779,7 @@ type Aws_spot_instance_request struct {
 
     Public_ip *string
 
-    Root_block_device *Aws_spot_instance_request_root_block_device_524
+    Root_block_device *[]Aws_spot_instance_request_root_block_device_524
 
     Security_groups *[]string
 
@@ -32083,8 +31035,6 @@ func (h *Aws_ssm_activationHandler) Delete(externalID string) error {
 
 type Aws_ssm_association_output_location_525 struct {
 
-    Aws_ssm_association_output_location_525_id *string `lyra:"ignore"`
-
     S3_bucket_name string
 
     S3_key_prefix *string
@@ -32092,8 +31042,6 @@ type Aws_ssm_association_output_location_525 struct {
 }
 
 type Aws_ssm_association_targets_526 struct {
-
-    Aws_ssm_association_targets_526_id *string `lyra:"ignore"`
 
     Key string
 
@@ -32115,13 +31063,13 @@ type Aws_ssm_association struct {
 
     Name string
 
-    Output_location *Aws_ssm_association_output_location_525
+    Output_location *[]Aws_ssm_association_output_location_525
 
     Parameters *map[string]string
 
     Schedule_expression *string
 
-    Targets *Aws_ssm_association_targets_526
+    Targets *[]Aws_ssm_association_targets_526
 
 }
 
@@ -32164,8 +31112,6 @@ func (h *Aws_ssm_associationHandler) Delete(externalID string) error {
 
 type Aws_ssm_document_parameter_527 struct {
 
-    Aws_ssm_document_parameter_527_id *string `lyra:"ignore"`
-
     Default_value *string
 
     Description *string
@@ -32204,7 +31150,7 @@ type Aws_ssm_document struct {
 
     Owner *string
 
-    Parameter *Aws_ssm_document_parameter_527
+    Parameter *[]Aws_ssm_document_parameter_527
 
     Permissions *map[string]string
 
@@ -32318,8 +31264,6 @@ func (h *Aws_ssm_maintenance_windowHandler) Delete(externalID string) error {
 
 type Aws_ssm_maintenance_window_target_targets_528 struct {
 
-    Aws_ssm_maintenance_window_target_targets_528_id *string `lyra:"ignore"`
-
     Key string
 
     Values []string
@@ -32334,7 +31278,7 @@ type Aws_ssm_maintenance_window_target struct {
 
     Resource_type string
 
-    Targets Aws_ssm_maintenance_window_target_targets_528
+    Targets []Aws_ssm_maintenance_window_target_targets_528
 
     Window_id string
 
@@ -32379,8 +31323,6 @@ func (h *Aws_ssm_maintenance_window_targetHandler) Delete(externalID string) err
 
 type Aws_ssm_maintenance_window_task_logging_info_529 struct {
 
-    Aws_ssm_maintenance_window_task_logging_info_529_id *string `lyra:"ignore"`
-
     S3_bucket_name string
 
     S3_bucket_prefix *string
@@ -32391,8 +31333,6 @@ type Aws_ssm_maintenance_window_task_logging_info_529 struct {
 
 type Aws_ssm_maintenance_window_task_targets_530 struct {
 
-    Aws_ssm_maintenance_window_task_targets_530_id *string `lyra:"ignore"`
-
     Key string
 
     Values []string
@@ -32400,8 +31340,6 @@ type Aws_ssm_maintenance_window_task_targets_530 struct {
 }
 
 type Aws_ssm_maintenance_window_task_task_parameters_531 struct {
-
-    Aws_ssm_maintenance_window_task_task_parameters_531_id *string `lyra:"ignore"`
 
     Name string
 
@@ -32415,7 +31353,7 @@ type Aws_ssm_maintenance_window_task struct {
 
     Description *string
 
-    Logging_info *Aws_ssm_maintenance_window_task_logging_info_529
+    Logging_info *[]Aws_ssm_maintenance_window_task_logging_info_529
 
     Max_concurrency string
 
@@ -32427,11 +31365,11 @@ type Aws_ssm_maintenance_window_task struct {
 
     Service_role_arn string
 
-    Targets Aws_ssm_maintenance_window_task_targets_530
+    Targets []Aws_ssm_maintenance_window_task_targets_530
 
     Task_arn string
 
-    Task_parameters *Aws_ssm_maintenance_window_task_task_parameters_531
+    Task_parameters *[]Aws_ssm_maintenance_window_task_task_parameters_531
 
     Task_type string
 
@@ -32539,8 +31477,6 @@ func (h *Aws_ssm_parameterHandler) Delete(externalID string) error {
 
 type Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533 struct {
 
-    Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533_id *string `lyra:"ignore"`
-
     Key string
 
     Values []string
@@ -32549,21 +31485,17 @@ type Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533 struct {
 
 type Aws_ssm_patch_baseline_approval_rule_532 struct {
 
-    Aws_ssm_patch_baseline_approval_rule_532_id *string `lyra:"ignore"`
-
     Approve_after_days int
 
     Compliance_level *string
 
     Enable_non_security *bool
 
-    Patch_filter Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533
+    Patch_filter []Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533
 
 }
 
 type Aws_ssm_patch_baseline_global_filter_534 struct {
-
-    Aws_ssm_patch_baseline_global_filter_534_id *string `lyra:"ignore"`
 
     Key string
 
@@ -32575,7 +31507,7 @@ type Aws_ssm_patch_baseline struct {
 
     Aws_ssm_patch_baseline_id *string `lyra:"ignore"`
 
-    Approval_rule *Aws_ssm_patch_baseline_approval_rule_532
+    Approval_rule *[]Aws_ssm_patch_baseline_approval_rule_532
 
     Approved_patches *[]string
 
@@ -32583,7 +31515,7 @@ type Aws_ssm_patch_baseline struct {
 
     Description *string
 
-    Global_filter *Aws_ssm_patch_baseline_global_filter_534
+    Global_filter *[]Aws_ssm_patch_baseline_global_filter_534
 
     Name string
 
@@ -32679,8 +31611,6 @@ func (h *Aws_ssm_patch_groupHandler) Delete(externalID string) error {
 
 type Aws_ssm_resource_data_sync_s3_destination_535 struct {
 
-    Aws_ssm_resource_data_sync_s3_destination_535_id *string `lyra:"ignore"`
-
     Bucket_name string
 
     Kms_key_arn *string
@@ -32699,7 +31629,7 @@ type Aws_ssm_resource_data_sync struct {
 
     Name string
 
-    S3_destination Aws_ssm_resource_data_sync_s3_destination_535
+    S3_destination []Aws_ssm_resource_data_sync_s3_destination_535
 
 }
 
@@ -32858,8 +31788,6 @@ func (h *Aws_storagegateway_cached_iscsi_volumeHandler) Delete(externalID string
 
 type Aws_storagegateway_gateway_smb_active_directory_settings_536 struct {
 
-    Aws_storagegateway_gateway_smb_active_directory_settings_536_id *string `lyra:"ignore"`
-
     Domain_name string
 
     Password string
@@ -32888,7 +31816,7 @@ type Aws_storagegateway_gateway struct {
 
     Medium_changer_type *string
 
-    Smb_active_directory_settings *Aws_storagegateway_gateway_smb_active_directory_settings_536
+    Smb_active_directory_settings *[]Aws_storagegateway_gateway_smb_active_directory_settings_536
 
     Smb_guest_password *string
 
@@ -32935,8 +31863,6 @@ func (h *Aws_storagegateway_gatewayHandler) Delete(externalID string) error {
 
 type Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537 struct {
 
-    Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537_id *string `lyra:"ignore"`
-
     Directory_mode *string
 
     File_mode *string
@@ -32969,7 +31895,7 @@ type Aws_storagegateway_nfs_file_share struct {
 
     Location_arn string
 
-    Nfs_file_share_defaults *Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537
+    Nfs_file_share_defaults *[]Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537
 
     Object_acl *string
 
@@ -33704,8 +32630,6 @@ func (h *Aws_vpc_dhcp_options_associationHandler) Delete(externalID string) erro
 
 type Aws_vpc_endpoint_dns_entry_538 struct {
 
-    Aws_vpc_endpoint_dns_entry_538_id *string `lyra:"ignore"`
-
     Dns_name *string
 
     Hosted_zone_id *string
@@ -33720,7 +32644,7 @@ type Aws_vpc_endpoint struct {
 
     Cidr_blocks *[]string
 
-    Dns_entry *Aws_vpc_endpoint_dns_entry_538
+    Dns_entry *[]Aws_vpc_endpoint_dns_entry_538
 
     Network_interface_ids *[]string
 
@@ -34089,8 +33013,6 @@ func (h *Aws_vpc_ipv4_cidr_block_associationHandler) Delete(externalID string) e
 
 type Aws_vpc_peering_connection_accepter_539 struct {
 
-    Aws_vpc_peering_connection_accepter_539_id *string `lyra:"ignore"`
-
     Allow_classic_link_to_remote_vpc *bool
 
     Allow_remote_vpc_dns_resolution *bool
@@ -34100,8 +33022,6 @@ type Aws_vpc_peering_connection_accepter_539 struct {
 }
 
 type Aws_vpc_peering_connection_requester_540 struct {
-
-    Aws_vpc_peering_connection_requester_540_id *string `lyra:"ignore"`
 
     Allow_classic_link_to_remote_vpc *bool
 
@@ -34174,8 +33094,6 @@ func (h *Aws_vpc_peering_connectionHandler) Delete(externalID string) error {
 
 type Aws_vpc_peering_connection_accepter_accepter_541 struct {
 
-    Aws_vpc_peering_connection_accepter_accepter_541_id *string `lyra:"ignore"`
-
     Allow_classic_link_to_remote_vpc *bool
 
     Allow_remote_vpc_dns_resolution *bool
@@ -34185,8 +33103,6 @@ type Aws_vpc_peering_connection_accepter_accepter_541 struct {
 }
 
 type Aws_vpc_peering_connection_accepter_requester_542 struct {
-
-    Aws_vpc_peering_connection_accepter_requester_542_id *string `lyra:"ignore"`
 
     Allow_classic_link_to_remote_vpc *bool
 
@@ -34261,8 +33177,6 @@ func (h *Aws_vpc_peering_connection_accepterHandler) Delete(externalID string) e
 
 type Aws_vpc_peering_connection_options_accepter_543 struct {
 
-    Aws_vpc_peering_connection_options_accepter_543_id *string `lyra:"ignore"`
-
     Allow_classic_link_to_remote_vpc *bool
 
     Allow_remote_vpc_dns_resolution *bool
@@ -34272,8 +33186,6 @@ type Aws_vpc_peering_connection_options_accepter_543 struct {
 }
 
 type Aws_vpc_peering_connection_options_requester_544 struct {
-
-    Aws_vpc_peering_connection_options_requester_544_id *string `lyra:"ignore"`
 
     Allow_classic_link_to_remote_vpc *bool
 
@@ -34334,8 +33246,6 @@ func (h *Aws_vpc_peering_connection_optionsHandler) Delete(externalID string) er
 
 type Aws_vpn_connection_routes_545 struct {
 
-    Aws_vpn_connection_routes_545_id *string `lyra:"ignore"`
-
     Destination_cidr_block *string
 
     Source *string
@@ -34345,8 +33255,6 @@ type Aws_vpn_connection_routes_545 struct {
 }
 
 type Aws_vpn_connection_vgw_telemetry_546 struct {
-
-    Aws_vpn_connection_vgw_telemetry_546_id *string `lyra:"ignore"`
 
     Accepted_route_count *int
 
@@ -34643,8 +33551,6 @@ func (h *Aws_vpn_gateway_route_propagationHandler) Delete(externalID string) err
 
 type Aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548 struct {
 
-    Aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -34652,8 +33558,6 @@ type Aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548 struct {
 }
 
 type Aws_waf_byte_match_set_byte_match_tuples_547 struct {
-
-    Aws_waf_byte_match_set_byte_match_tuples_547_id *string `lyra:"ignore"`
 
     Field_to_match Aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548
 
@@ -34714,8 +33618,6 @@ func (h *Aws_waf_byte_match_setHandler) Delete(externalID string) error {
 
 type Aws_waf_geo_match_set_geo_match_constraint_549 struct {
 
-    Aws_waf_geo_match_set_geo_match_constraint_549_id *string `lyra:"ignore"`
-
     Type string
 
     Value string
@@ -34770,8 +33672,6 @@ func (h *Aws_waf_geo_match_setHandler) Delete(externalID string) error {
 }
 
 type Aws_waf_ipset_ip_set_descriptors_550 struct {
-
-    Aws_waf_ipset_ip_set_descriptors_550_id *string `lyra:"ignore"`
 
     Type string
 
@@ -34829,8 +33729,6 @@ func (h *Aws_waf_ipsetHandler) Delete(externalID string) error {
 }
 
 type Aws_waf_rate_based_rule_predicates_551 struct {
-
-    Aws_waf_rate_based_rule_predicates_551_id *string `lyra:"ignore"`
 
     Data_id string
 
@@ -34895,8 +33793,6 @@ func (h *Aws_waf_rate_based_ruleHandler) Delete(externalID string) error {
 
 type Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553 struct {
 
-    Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -34905,9 +33801,7 @@ type Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553 struct {
 
 type Aws_waf_regex_match_set_regex_match_tuple_552 struct {
 
-    Aws_waf_regex_match_set_regex_match_tuple_552_id *string `lyra:"ignore"`
-
-    Field_to_match Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553
+    Field_to_match []Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553
 
     Regex_pattern_set_id string
 
@@ -35011,8 +33905,6 @@ func (h *Aws_waf_regex_pattern_setHandler) Delete(externalID string) error {
 
 type Aws_waf_rule_predicates_554 struct {
 
-    Aws_waf_rule_predicates_554_id *string `lyra:"ignore"`
-
     Data_id string
 
     Negated bool
@@ -35072,17 +33964,13 @@ func (h *Aws_waf_ruleHandler) Delete(externalID string) error {
 
 type Aws_waf_rule_group_activated_rule_555_action_556 struct {
 
-    Aws_waf_rule_group_activated_rule_555_action_556_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_waf_rule_group_activated_rule_555 struct {
 
-    Aws_waf_rule_group_activated_rule_555_id *string `lyra:"ignore"`
-
-    Action Aws_waf_rule_group_activated_rule_555_action_556
+    Action []Aws_waf_rule_group_activated_rule_555_action_556
 
     Priority int
 
@@ -35143,8 +34031,6 @@ func (h *Aws_waf_rule_groupHandler) Delete(externalID string) error {
 
 type Aws_waf_size_constraint_set_size_constraints_557_field_to_match_558 struct {
 
-    Aws_waf_size_constraint_set_size_constraints_557_field_to_match_558_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35152,8 +34038,6 @@ type Aws_waf_size_constraint_set_size_constraints_557_field_to_match_558 struct 
 }
 
 type Aws_waf_size_constraint_set_size_constraints_557 struct {
-
-    Aws_waf_size_constraint_set_size_constraints_557_id *string `lyra:"ignore"`
 
     Comparison_operator string
 
@@ -35214,8 +34098,6 @@ func (h *Aws_waf_size_constraint_setHandler) Delete(externalID string) error {
 
 type Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_match_560 struct {
 
-    Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_match_560_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35223,8 +34105,6 @@ type Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_mat
 }
 
 type Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559 struct {
-
-    Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_id *string `lyra:"ignore"`
 
     Field_to_match Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_match_560
 
@@ -35281,15 +34161,11 @@ func (h *Aws_waf_sql_injection_match_setHandler) Delete(externalID string) error
 
 type Aws_waf_web_acl_default_action_561 struct {
 
-    Aws_waf_web_acl_default_action_561_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_waf_web_acl_rules_562_action_563 struct {
-
-    Aws_waf_web_acl_rules_562_action_563_id *string `lyra:"ignore"`
 
     Type string
 
@@ -35297,19 +34173,15 @@ type Aws_waf_web_acl_rules_562_action_563 struct {
 
 type Aws_waf_web_acl_rules_562_override_action_564 struct {
 
-    Aws_waf_web_acl_rules_562_override_action_564_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_waf_web_acl_rules_562 struct {
 
-    Aws_waf_web_acl_rules_562_id *string `lyra:"ignore"`
+    Action *[]Aws_waf_web_acl_rules_562_action_563
 
-    Action *Aws_waf_web_acl_rules_562_action_563
-
-    Override_action *Aws_waf_web_acl_rules_562_override_action_564
+    Override_action *[]Aws_waf_web_acl_rules_562_override_action_564
 
     Priority int
 
@@ -35372,8 +34244,6 @@ func (h *Aws_waf_web_aclHandler) Delete(externalID string) error {
 
 type Aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566 struct {
 
-    Aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35381,8 +34251,6 @@ type Aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566 struct {
 }
 
 type Aws_waf_xss_match_set_xss_match_tuples_565 struct {
-
-    Aws_waf_xss_match_set_xss_match_tuples_565_id *string `lyra:"ignore"`
 
     Field_to_match Aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566
 
@@ -35439,8 +34307,6 @@ func (h *Aws_waf_xss_match_setHandler) Delete(externalID string) error {
 
 type Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568 struct {
 
-    Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35449,9 +34315,7 @@ type Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568 stru
 
 type Aws_wafregional_byte_match_set_byte_match_tuple_567 struct {
 
-    Aws_wafregional_byte_match_set_byte_match_tuple_567_id *string `lyra:"ignore"`
-
-    Field_to_match Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568
+    Field_to_match []Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568
 
     Positional_constraint string
 
@@ -35463,8 +34327,6 @@ type Aws_wafregional_byte_match_set_byte_match_tuple_567 struct {
 
 type Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570 struct {
 
-    Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35473,9 +34335,7 @@ type Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570 str
 
 type Aws_wafregional_byte_match_set_byte_match_tuples_569 struct {
 
-    Aws_wafregional_byte_match_set_byte_match_tuples_569_id *string `lyra:"ignore"`
-
-    Field_to_match Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570
+    Field_to_match []Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570
 
     Positional_constraint string
 
@@ -35536,8 +34396,6 @@ func (h *Aws_wafregional_byte_match_setHandler) Delete(externalID string) error 
 
 type Aws_wafregional_geo_match_set_geo_match_constraint_571 struct {
 
-    Aws_wafregional_geo_match_set_geo_match_constraint_571_id *string `lyra:"ignore"`
-
     Type string
 
     Value string
@@ -35592,8 +34450,6 @@ func (h *Aws_wafregional_geo_match_setHandler) Delete(externalID string) error {
 }
 
 type Aws_wafregional_ipset_ip_set_descriptor_572 struct {
-
-    Aws_wafregional_ipset_ip_set_descriptor_572_id *string `lyra:"ignore"`
 
     Type string
 
@@ -35651,8 +34507,6 @@ func (h *Aws_wafregional_ipsetHandler) Delete(externalID string) error {
 }
 
 type Aws_wafregional_rate_based_rule_predicate_573 struct {
-
-    Aws_wafregional_rate_based_rule_predicate_573_id *string `lyra:"ignore"`
 
     Data_id string
 
@@ -35717,8 +34571,6 @@ func (h *Aws_wafregional_rate_based_ruleHandler) Delete(externalID string) error
 
 type Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575 struct {
 
-    Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35727,9 +34579,7 @@ type Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575 st
 
 type Aws_wafregional_regex_match_set_regex_match_tuple_574 struct {
 
-    Aws_wafregional_regex_match_set_regex_match_tuple_574_id *string `lyra:"ignore"`
-
-    Field_to_match Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575
+    Field_to_match []Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575
 
     Regex_pattern_set_id string
 
@@ -35833,8 +34683,6 @@ func (h *Aws_wafregional_regex_pattern_setHandler) Delete(externalID string) err
 
 type Aws_wafregional_rule_predicate_576 struct {
 
-    Aws_wafregional_rule_predicate_576_id *string `lyra:"ignore"`
-
     Data_id string
 
     Negated bool
@@ -35894,17 +34742,13 @@ func (h *Aws_wafregional_ruleHandler) Delete(externalID string) error {
 
 type Aws_wafregional_rule_group_activated_rule_577_action_578 struct {
 
-    Aws_wafregional_rule_group_activated_rule_577_action_578_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_wafregional_rule_group_activated_rule_577 struct {
 
-    Aws_wafregional_rule_group_activated_rule_577_id *string `lyra:"ignore"`
-
-    Action Aws_wafregional_rule_group_activated_rule_577_action_578
+    Action []Aws_wafregional_rule_group_activated_rule_577_action_578
 
     Priority int
 
@@ -35965,8 +34809,6 @@ func (h *Aws_wafregional_rule_groupHandler) Delete(externalID string) error {
 
 type Aws_wafregional_size_constraint_set_size_constraints_579_field_to_match_580 struct {
 
-    Aws_wafregional_size_constraint_set_size_constraints_579_field_to_match_580_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -35974,8 +34816,6 @@ type Aws_wafregional_size_constraint_set_size_constraints_579_field_to_match_580
 }
 
 type Aws_wafregional_size_constraint_set_size_constraints_579 struct {
-
-    Aws_wafregional_size_constraint_set_size_constraints_579_id *string `lyra:"ignore"`
 
     Comparison_operator string
 
@@ -36036,8 +34876,6 @@ func (h *Aws_wafregional_size_constraint_setHandler) Delete(externalID string) e
 
 type Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582 struct {
 
-    Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -36046,9 +34884,7 @@ type Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field
 
 type Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581 struct {
 
-    Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_id *string `lyra:"ignore"`
-
-    Field_to_match Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582
+    Field_to_match []Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582
 
     Text_transformation string
 
@@ -36103,15 +34939,11 @@ func (h *Aws_wafregional_sql_injection_match_setHandler) Delete(externalID strin
 
 type Aws_wafregional_web_acl_default_action_583 struct {
 
-    Aws_wafregional_web_acl_default_action_583_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_wafregional_web_acl_rule_584_action_585 struct {
-
-    Aws_wafregional_web_acl_rule_584_action_585_id *string `lyra:"ignore"`
 
     Type string
 
@@ -36119,19 +34951,15 @@ type Aws_wafregional_web_acl_rule_584_action_585 struct {
 
 type Aws_wafregional_web_acl_rule_584_override_action_586 struct {
 
-    Aws_wafregional_web_acl_rule_584_override_action_586_id *string `lyra:"ignore"`
-
     Type string
 
 }
 
 type Aws_wafregional_web_acl_rule_584 struct {
 
-    Aws_wafregional_web_acl_rule_584_id *string `lyra:"ignore"`
+    Action *[]Aws_wafregional_web_acl_rule_584_action_585
 
-    Action *Aws_wafregional_web_acl_rule_584_action_585
-
-    Override_action *Aws_wafregional_web_acl_rule_584_override_action_586
+    Override_action *[]Aws_wafregional_web_acl_rule_584_override_action_586
 
     Priority int
 
@@ -36145,7 +34973,7 @@ type Aws_wafregional_web_acl struct {
 
     Aws_wafregional_web_acl_id *string `lyra:"ignore"`
 
-    Default_action Aws_wafregional_web_acl_default_action_583
+    Default_action []Aws_wafregional_web_acl_default_action_583
 
     Metric_name string
 
@@ -36241,8 +35069,6 @@ func (h *Aws_wafregional_web_acl_associationHandler) Delete(externalID string) e
 
 type Aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588 struct {
 
-    Aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588_id *string `lyra:"ignore"`
-
     Data *string
 
     Type string
@@ -36250,8 +35076,6 @@ type Aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588 struct
 }
 
 type Aws_wafregional_xss_match_set_xss_match_tuple_587 struct {
-
-    Aws_wafregional_xss_match_set_xss_match_tuple_587_id *string `lyra:"ignore"`
 
     Field_to_match Aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588
 

--- a/cmd/goplugin-tf-azurerm/generated/generated.go
+++ b/cmd/goplugin-tf-azurerm/generated/generated.go
@@ -392,8 +392,6 @@ func Initialize(sb *service.ServerBuilder, p *schema.Provider) {
 
 type Azurerm_api_management_additional_location_1269 struct {
 
-    Azurerm_api_management_additional_location_1269_id *string `lyra:"ignore"`
-
     Gateway_regional_url *string
 
     Location string
@@ -404,8 +402,6 @@ type Azurerm_api_management_additional_location_1269 struct {
 
 type Azurerm_api_management_certificate_1270 struct {
 
-    Azurerm_api_management_certificate_1270_id *string `lyra:"ignore"`
-
     Certificate_password string
 
     Encoded_certificate string
@@ -415,8 +411,6 @@ type Azurerm_api_management_certificate_1270 struct {
 }
 
 type Azurerm_api_management_hostname_configuration_1271_management_1272 struct {
-
-    Azurerm_api_management_hostname_configuration_1271_management_1272_id *string `lyra:"ignore"`
 
     Certificate *string
 
@@ -432,8 +426,6 @@ type Azurerm_api_management_hostname_configuration_1271_management_1272 struct {
 
 type Azurerm_api_management_hostname_configuration_1271_portal_1273 struct {
 
-    Azurerm_api_management_hostname_configuration_1271_portal_1273_id *string `lyra:"ignore"`
-
     Certificate *string
 
     Certificate_password *string
@@ -447,8 +439,6 @@ type Azurerm_api_management_hostname_configuration_1271_portal_1273 struct {
 }
 
 type Azurerm_api_management_hostname_configuration_1271_proxy_1274 struct {
-
-    Azurerm_api_management_hostname_configuration_1271_proxy_1274_id *string `lyra:"ignore"`
 
     Certificate *string
 
@@ -466,8 +456,6 @@ type Azurerm_api_management_hostname_configuration_1271_proxy_1274 struct {
 
 type Azurerm_api_management_hostname_configuration_1271_scm_1275 struct {
 
-    Azurerm_api_management_hostname_configuration_1271_scm_1275_id *string `lyra:"ignore"`
-
     Certificate *string
 
     Certificate_password *string
@@ -482,21 +470,17 @@ type Azurerm_api_management_hostname_configuration_1271_scm_1275 struct {
 
 type Azurerm_api_management_hostname_configuration_1271 struct {
 
-    Azurerm_api_management_hostname_configuration_1271_id *string `lyra:"ignore"`
+    Management *[]Azurerm_api_management_hostname_configuration_1271_management_1272
 
-    Management *Azurerm_api_management_hostname_configuration_1271_management_1272
+    Portal *[]Azurerm_api_management_hostname_configuration_1271_portal_1273
 
-    Portal *Azurerm_api_management_hostname_configuration_1271_portal_1273
+    Proxy *[]Azurerm_api_management_hostname_configuration_1271_proxy_1274
 
-    Proxy *Azurerm_api_management_hostname_configuration_1271_proxy_1274
-
-    Scm *Azurerm_api_management_hostname_configuration_1271_scm_1275
+    Scm *[]Azurerm_api_management_hostname_configuration_1271_scm_1275
 
 }
 
 type Azurerm_api_management_identity_1276 struct {
-
-    Azurerm_api_management_identity_1276_id *string `lyra:"ignore"`
 
     Principal_id *string
 
@@ -507,8 +491,6 @@ type Azurerm_api_management_identity_1276 struct {
 }
 
 type Azurerm_api_management_security_1277 struct {
-
-    Azurerm_api_management_security_1277_id *string `lyra:"ignore"`
 
     Disable_backend_ssl30 *bool
 
@@ -528,8 +510,6 @@ type Azurerm_api_management_security_1277 struct {
 
 type Azurerm_api_management_sku_1278 struct {
 
-    Azurerm_api_management_sku_1278_id *string `lyra:"ignore"`
-
     Capacity int
 
     Name string
@@ -540,17 +520,17 @@ type Azurerm_api_management struct {
 
     Azurerm_api_management_id *string `lyra:"ignore"`
 
-    Additional_location *Azurerm_api_management_additional_location_1269
+    Additional_location *[]Azurerm_api_management_additional_location_1269
 
-    Certificate *Azurerm_api_management_certificate_1270
+    Certificate *[]Azurerm_api_management_certificate_1270
 
     Gateway_regional_url *string
 
     Gateway_url *string
 
-    Hostname_configuration *Azurerm_api_management_hostname_configuration_1271
+    Hostname_configuration *[]Azurerm_api_management_hostname_configuration_1271
 
-    Identity *Azurerm_api_management_identity_1276
+    Identity *[]Azurerm_api_management_identity_1276
 
     Location string
 
@@ -572,9 +552,9 @@ type Azurerm_api_management struct {
 
     Scm_url *string
 
-    Security *Azurerm_api_management_security_1277
+    Security *[]Azurerm_api_management_security_1277
 
-    Sku Azurerm_api_management_sku_1278
+    Sku []Azurerm_api_management_sku_1278
 
     Tags *map[string]string
 
@@ -619,8 +599,6 @@ func (h *Azurerm_api_managementHandler) Delete(externalID string) error {
 
 type Azurerm_app_service_connection_string_1279 struct {
 
-    Azurerm_app_service_connection_string_1279_id *string `lyra:"ignore"`
-
     Name string
 
     Type string
@@ -630,8 +608,6 @@ type Azurerm_app_service_connection_string_1279 struct {
 }
 
 type Azurerm_app_service_identity_1280 struct {
-
-    Azurerm_app_service_identity_1280_id *string `lyra:"ignore"`
 
     Principal_id *string
 
@@ -643,8 +619,6 @@ type Azurerm_app_service_identity_1280 struct {
 
 type Azurerm_app_service_site_config_1281_ip_restriction_1282 struct {
 
-    Azurerm_app_service_site_config_1281_ip_restriction_1282_id *string `lyra:"ignore"`
-
     Ip_address string
 
     Subnet_mask *string
@@ -652,8 +626,6 @@ type Azurerm_app_service_site_config_1281_ip_restriction_1282 struct {
 }
 
 type Azurerm_app_service_site_config_1281 struct {
-
-    Azurerm_app_service_site_config_1281_id *string `lyra:"ignore"`
 
     Always_on *bool
 
@@ -667,7 +639,7 @@ type Azurerm_app_service_site_config_1281 struct {
 
     Http2_enabled *bool
 
-    Ip_restriction *Azurerm_app_service_site_config_1281_ip_restriction_1282
+    Ip_restriction *[]Azurerm_app_service_site_config_1281_ip_restriction_1282
 
     Java_container *string
 
@@ -703,8 +675,6 @@ type Azurerm_app_service_site_config_1281 struct {
 
 type Azurerm_app_service_site_credential_1283 struct {
 
-    Azurerm_app_service_site_credential_1283_id *string `lyra:"ignore"`
-
     Password *string
 
     Username *string
@@ -712,8 +682,6 @@ type Azurerm_app_service_site_credential_1283 struct {
 }
 
 type Azurerm_app_service_source_control_1284 struct {
-
-    Azurerm_app_service_source_control_1284_id *string `lyra:"ignore"`
 
     Branch *string
 
@@ -739,7 +707,7 @@ type Azurerm_app_service struct {
 
     Https_only *bool
 
-    Identity *Azurerm_app_service_identity_1280
+    Identity *[]Azurerm_app_service_identity_1280
 
     Location string
 
@@ -751,11 +719,11 @@ type Azurerm_app_service struct {
 
     Resource_group_name string
 
-    Site_config *Azurerm_app_service_site_config_1281
+    Site_config *[]Azurerm_app_service_site_config_1281
 
-    Site_credential *Azurerm_app_service_site_credential_1283
+    Site_credential *[]Azurerm_app_service_site_credential_1283
 
-    Source_control *Azurerm_app_service_source_control_1284
+    Source_control *[]Azurerm_app_service_source_control_1284
 
     Tags *map[string]string
 
@@ -898,8 +866,6 @@ func (h *Azurerm_app_service_custom_hostname_bindingHandler) Delete(externalID s
 
 type Azurerm_app_service_plan_properties_1285 struct {
 
-    Azurerm_app_service_plan_properties_1285_id *string `lyra:"ignore"`
-
     App_service_environment_id *string
 
     Per_site_scaling *bool
@@ -909,8 +875,6 @@ type Azurerm_app_service_plan_properties_1285 struct {
 }
 
 type Azurerm_app_service_plan_sku_1286 struct {
-
-    Azurerm_app_service_plan_sku_1286_id *string `lyra:"ignore"`
 
     Capacity *int
 
@@ -936,13 +900,13 @@ type Azurerm_app_service_plan struct {
 
     Per_site_scaling *bool
 
-    Properties *Azurerm_app_service_plan_properties_1285
+    Properties *[]Azurerm_app_service_plan_properties_1285
 
     Reserved *bool
 
     Resource_group_name string
 
-    Sku Azurerm_app_service_plan_sku_1286
+    Sku []Azurerm_app_service_plan_sku_1286
 
     Tags *map[string]string
 
@@ -987,8 +951,6 @@ func (h *Azurerm_app_service_planHandler) Delete(externalID string) error {
 
 type Azurerm_app_service_slot_connection_string_1287 struct {
 
-    Azurerm_app_service_slot_connection_string_1287_id *string `lyra:"ignore"`
-
     Name string
 
     Type string
@@ -998,8 +960,6 @@ type Azurerm_app_service_slot_connection_string_1287 struct {
 }
 
 type Azurerm_app_service_slot_identity_1288 struct {
-
-    Azurerm_app_service_slot_identity_1288_id *string `lyra:"ignore"`
 
     Principal_id *string
 
@@ -1011,8 +971,6 @@ type Azurerm_app_service_slot_identity_1288 struct {
 
 type Azurerm_app_service_slot_site_config_1289_ip_restriction_1290 struct {
 
-    Azurerm_app_service_slot_site_config_1289_ip_restriction_1290_id *string `lyra:"ignore"`
-
     Ip_address string
 
     Subnet_mask *string
@@ -1020,8 +978,6 @@ type Azurerm_app_service_slot_site_config_1289_ip_restriction_1290 struct {
 }
 
 type Azurerm_app_service_slot_site_config_1289 struct {
-
-    Azurerm_app_service_slot_site_config_1289_id *string `lyra:"ignore"`
 
     Always_on *bool
 
@@ -1035,7 +991,7 @@ type Azurerm_app_service_slot_site_config_1289 struct {
 
     Http2_enabled *bool
 
-    Ip_restriction *Azurerm_app_service_slot_site_config_1289_ip_restriction_1290
+    Ip_restriction *[]Azurerm_app_service_slot_site_config_1289_ip_restriction_1290
 
     Java_container *string
 
@@ -1089,7 +1045,7 @@ type Azurerm_app_service_slot struct {
 
     Https_only *bool
 
-    Identity *Azurerm_app_service_slot_identity_1288
+    Identity *[]Azurerm_app_service_slot_identity_1288
 
     Location string
 
@@ -1097,7 +1053,7 @@ type Azurerm_app_service_slot struct {
 
     Resource_group_name string
 
-    Site_config *Azurerm_app_service_slot_site_config_1289
+    Site_config *[]Azurerm_app_service_slot_site_config_1289
 
     Tags *map[string]string
 
@@ -1142,8 +1098,6 @@ func (h *Azurerm_app_service_slotHandler) Delete(externalID string) error {
 
 type Azurerm_application_gateway_authentication_certificate_1291 struct {
 
-    Azurerm_application_gateway_authentication_certificate_1291_id *string `lyra:"ignore"`
-
     Data string
 
     Id *string
@@ -1153,8 +1107,6 @@ type Azurerm_application_gateway_authentication_certificate_1291 struct {
 }
 
 type Azurerm_application_gateway_backend_address_pool_1292 struct {
-
-    Azurerm_application_gateway_backend_address_pool_1292_id *string `lyra:"ignore"`
 
     Fqdn_list *[]string
 
@@ -1168,8 +1120,6 @@ type Azurerm_application_gateway_backend_address_pool_1292 struct {
 
 type Azurerm_application_gateway_backend_http_settings_1293_authentication_certificate_1294 struct {
 
-    Azurerm_application_gateway_backend_http_settings_1293_authentication_certificate_1294_id *string `lyra:"ignore"`
-
     Id *string
 
     Name string
@@ -1178,9 +1128,7 @@ type Azurerm_application_gateway_backend_http_settings_1293_authentication_certi
 
 type Azurerm_application_gateway_backend_http_settings_1293 struct {
 
-    Azurerm_application_gateway_backend_http_settings_1293_id *string `lyra:"ignore"`
-
-    Authentication_certificate *Azurerm_application_gateway_backend_http_settings_1293_authentication_certificate_1294
+    Authentication_certificate *[]Azurerm_application_gateway_backend_http_settings_1293_authentication_certificate_1294
 
     Cookie_based_affinity string
 
@@ -1202,8 +1150,6 @@ type Azurerm_application_gateway_backend_http_settings_1293 struct {
 
 type Azurerm_application_gateway_frontend_ip_configuration_1295 struct {
 
-    Azurerm_application_gateway_frontend_ip_configuration_1295_id *string `lyra:"ignore"`
-
     Id *string
 
     Name string
@@ -1220,8 +1166,6 @@ type Azurerm_application_gateway_frontend_ip_configuration_1295 struct {
 
 type Azurerm_application_gateway_frontend_port_1296 struct {
 
-    Azurerm_application_gateway_frontend_port_1296_id *string `lyra:"ignore"`
-
     Id *string
 
     Name string
@@ -1232,8 +1176,6 @@ type Azurerm_application_gateway_frontend_port_1296 struct {
 
 type Azurerm_application_gateway_gateway_ip_configuration_1297 struct {
 
-    Azurerm_application_gateway_gateway_ip_configuration_1297_id *string `lyra:"ignore"`
-
     Id *string
 
     Name string
@@ -1243,8 +1185,6 @@ type Azurerm_application_gateway_gateway_ip_configuration_1297 struct {
 }
 
 type Azurerm_application_gateway_http_listener_1298 struct {
-
-    Azurerm_application_gateway_http_listener_1298_id *string `lyra:"ignore"`
 
     Frontend_ip_configuration_id *string
 
@@ -1272,8 +1212,6 @@ type Azurerm_application_gateway_http_listener_1298 struct {
 
 type Azurerm_application_gateway_probe_1299_match_1300 struct {
 
-    Azurerm_application_gateway_probe_1299_match_1300_id *string `lyra:"ignore"`
-
     Body *string
 
     Status_code *[]string
@@ -1282,15 +1220,13 @@ type Azurerm_application_gateway_probe_1299_match_1300 struct {
 
 type Azurerm_application_gateway_probe_1299 struct {
 
-    Azurerm_application_gateway_probe_1299_id *string `lyra:"ignore"`
-
     Host string
 
     Id *string
 
     Interval int
 
-    Match *Azurerm_application_gateway_probe_1299_match_1300
+    Match *[]Azurerm_application_gateway_probe_1299_match_1300
 
     Minimum_servers *int
 
@@ -1307,8 +1243,6 @@ type Azurerm_application_gateway_probe_1299 struct {
 }
 
 type Azurerm_application_gateway_request_routing_rule_1301 struct {
-
-    Azurerm_application_gateway_request_routing_rule_1301_id *string `lyra:"ignore"`
 
     Backend_address_pool_id *string
 
@@ -1336,8 +1270,6 @@ type Azurerm_application_gateway_request_routing_rule_1301 struct {
 
 type Azurerm_application_gateway_sku_1302 struct {
 
-    Azurerm_application_gateway_sku_1302_id *string `lyra:"ignore"`
-
     Capacity int
 
     Name string
@@ -1347,8 +1279,6 @@ type Azurerm_application_gateway_sku_1302 struct {
 }
 
 type Azurerm_application_gateway_ssl_certificate_1303 struct {
-
-    Azurerm_application_gateway_ssl_certificate_1303_id *string `lyra:"ignore"`
 
     Data string
 
@@ -1363,8 +1293,6 @@ type Azurerm_application_gateway_ssl_certificate_1303 struct {
 }
 
 type Azurerm_application_gateway_url_path_map_1304_path_rule_1305 struct {
-
-    Azurerm_application_gateway_url_path_map_1304_path_rule_1305_id *string `lyra:"ignore"`
 
     Backend_address_pool_id *string
 
@@ -1384,8 +1312,6 @@ type Azurerm_application_gateway_url_path_map_1304_path_rule_1305 struct {
 
 type Azurerm_application_gateway_url_path_map_1304 struct {
 
-    Azurerm_application_gateway_url_path_map_1304_id *string `lyra:"ignore"`
-
     Default_backend_address_pool_id *string
 
     Default_backend_address_pool_name string
@@ -1398,13 +1324,11 @@ type Azurerm_application_gateway_url_path_map_1304 struct {
 
     Name string
 
-    Path_rule Azurerm_application_gateway_url_path_map_1304_path_rule_1305
+    Path_rule []Azurerm_application_gateway_url_path_map_1304_path_rule_1305
 
 }
 
 type Azurerm_application_gateway_waf_configuration_1306 struct {
-
-    Azurerm_application_gateway_waf_configuration_1306_id *string `lyra:"ignore"`
 
     Enabled bool
 
@@ -1420,41 +1344,41 @@ type Azurerm_application_gateway struct {
 
     Azurerm_application_gateway_id *string `lyra:"ignore"`
 
-    Authentication_certificate *Azurerm_application_gateway_authentication_certificate_1291
+    Authentication_certificate *[]Azurerm_application_gateway_authentication_certificate_1291
 
-    Backend_address_pool Azurerm_application_gateway_backend_address_pool_1292
+    Backend_address_pool []Azurerm_application_gateway_backend_address_pool_1292
 
-    Backend_http_settings Azurerm_application_gateway_backend_http_settings_1293
+    Backend_http_settings []Azurerm_application_gateway_backend_http_settings_1293
 
     Disabled_ssl_protocols *[]string
 
-    Frontend_ip_configuration Azurerm_application_gateway_frontend_ip_configuration_1295
+    Frontend_ip_configuration []Azurerm_application_gateway_frontend_ip_configuration_1295
 
-    Frontend_port Azurerm_application_gateway_frontend_port_1296
+    Frontend_port []Azurerm_application_gateway_frontend_port_1296
 
-    Gateway_ip_configuration Azurerm_application_gateway_gateway_ip_configuration_1297
+    Gateway_ip_configuration []Azurerm_application_gateway_gateway_ip_configuration_1297
 
-    Http_listener Azurerm_application_gateway_http_listener_1298
+    Http_listener []Azurerm_application_gateway_http_listener_1298
 
     Location string
 
     Name string
 
-    Probe *Azurerm_application_gateway_probe_1299
+    Probe *[]Azurerm_application_gateway_probe_1299
 
-    Request_routing_rule Azurerm_application_gateway_request_routing_rule_1301
+    Request_routing_rule []Azurerm_application_gateway_request_routing_rule_1301
 
     Resource_group_name string
 
-    Sku Azurerm_application_gateway_sku_1302
+    Sku []Azurerm_application_gateway_sku_1302
 
-    Ssl_certificate *Azurerm_application_gateway_ssl_certificate_1303
+    Ssl_certificate *[]Azurerm_application_gateway_ssl_certificate_1303
 
     Tags *map[string]string
 
-    Url_path_map *Azurerm_application_gateway_url_path_map_1304
+    Url_path_map *[]Azurerm_application_gateway_url_path_map_1304
 
-    Waf_configuration *Azurerm_application_gateway_waf_configuration_1306
+    Waf_configuration *[]Azurerm_application_gateway_waf_configuration_1306
 
 }
 
@@ -1658,8 +1582,6 @@ func (h *Azurerm_application_security_groupHandler) Delete(externalID string) er
 
 type Azurerm_automation_account_sku_1307 struct {
 
-    Azurerm_automation_account_sku_1307_id *string `lyra:"ignore"`
-
     Name *string
 
 }
@@ -1680,7 +1602,7 @@ type Azurerm_automation_account struct {
 
     Resource_group_name string
 
-    Sku Azurerm_automation_account_sku_1307
+    Sku []Azurerm_automation_account_sku_1307
 
     Tags *map[string]string
 
@@ -1892,8 +1814,6 @@ func (h *Azurerm_automation_dsc_nodeconfigurationHandler) Delete(externalID stri
 
 type Azurerm_automation_module_module_link_1308_hash_1309 struct {
 
-    Azurerm_automation_module_module_link_1308_hash_1309_id *string `lyra:"ignore"`
-
     Algorithm string
 
     Value string
@@ -1902,9 +1822,7 @@ type Azurerm_automation_module_module_link_1308_hash_1309 struct {
 
 type Azurerm_automation_module_module_link_1308 struct {
 
-    Azurerm_automation_module_module_link_1308_id *string `lyra:"ignore"`
-
-    Hash *Azurerm_automation_module_module_link_1308_hash_1309
+    Hash *[]Azurerm_automation_module_module_link_1308_hash_1309
 
     Uri string
 
@@ -1916,7 +1834,7 @@ type Azurerm_automation_module struct {
 
     Automation_account_name string
 
-    Module_link Azurerm_automation_module_module_link_1308
+    Module_link []Azurerm_automation_module_module_link_1308
 
     Name string
 
@@ -1963,8 +1881,6 @@ func (h *Azurerm_automation_moduleHandler) Delete(externalID string) error {
 
 type Azurerm_automation_runbook_publish_content_link_1310_hash_1311 struct {
 
-    Azurerm_automation_runbook_publish_content_link_1310_hash_1311_id *string `lyra:"ignore"`
-
     Algorithm string
 
     Value string
@@ -1973,9 +1889,7 @@ type Azurerm_automation_runbook_publish_content_link_1310_hash_1311 struct {
 
 type Azurerm_automation_runbook_publish_content_link_1310 struct {
 
-    Azurerm_automation_runbook_publish_content_link_1310_id *string `lyra:"ignore"`
-
-    Hash *Azurerm_automation_runbook_publish_content_link_1310_hash_1311
+    Hash *[]Azurerm_automation_runbook_publish_content_link_1310_hash_1311
 
     Uri string
 
@@ -2001,7 +1915,7 @@ type Azurerm_automation_runbook struct {
 
     Name string
 
-    Publish_content_link Azurerm_automation_runbook_publish_content_link_1310
+    Publish_content_link []Azurerm_automation_runbook_publish_content_link_1310
 
     Resource_group_name string
 
@@ -2050,8 +1964,6 @@ func (h *Azurerm_automation_runbookHandler) Delete(externalID string) error {
 
 type Azurerm_automation_schedule_monthly_occurrence_1312 struct {
 
-    Azurerm_automation_schedule_monthly_occurrence_1312_id *string `lyra:"ignore"`
-
     Day string
 
     Occurrence int
@@ -2076,7 +1988,7 @@ type Azurerm_automation_schedule struct {
 
     Month_days *[]int
 
-    Monthly_occurrence *Azurerm_automation_schedule_monthly_occurrence_1312
+    Monthly_occurrence *[]Azurerm_automation_schedule_monthly_occurrence_1312
 
     Name string
 
@@ -2129,8 +2041,6 @@ func (h *Azurerm_automation_scheduleHandler) Delete(externalID string) error {
 
 type Azurerm_autoscale_setting_notification_1313_email_1314 struct {
 
-    Azurerm_autoscale_setting_notification_1313_email_1314_id *string `lyra:"ignore"`
-
     Custom_emails *[]string
 
     Send_to_subscription_administrator *bool
@@ -2141,8 +2051,6 @@ type Azurerm_autoscale_setting_notification_1313_email_1314 struct {
 
 type Azurerm_autoscale_setting_notification_1313_webhook_1315 struct {
 
-    Azurerm_autoscale_setting_notification_1313_webhook_1315_id *string `lyra:"ignore"`
-
     Properties *map[string]string
 
     Service_uri string
@@ -2151,17 +2059,13 @@ type Azurerm_autoscale_setting_notification_1313_webhook_1315 struct {
 
 type Azurerm_autoscale_setting_notification_1313 struct {
 
-    Azurerm_autoscale_setting_notification_1313_id *string `lyra:"ignore"`
+    Email *[]Azurerm_autoscale_setting_notification_1313_email_1314
 
-    Email *Azurerm_autoscale_setting_notification_1313_email_1314
-
-    Webhook *Azurerm_autoscale_setting_notification_1313_webhook_1315
+    Webhook *[]Azurerm_autoscale_setting_notification_1313_webhook_1315
 
 }
 
 type Azurerm_autoscale_setting_profile_1316_capacity_1317 struct {
-
-    Azurerm_autoscale_setting_profile_1316_capacity_1317_id *string `lyra:"ignore"`
 
     Default int
 
@@ -2173,8 +2077,6 @@ type Azurerm_autoscale_setting_profile_1316_capacity_1317 struct {
 
 type Azurerm_autoscale_setting_profile_1316_fixed_date_1318 struct {
 
-    Azurerm_autoscale_setting_profile_1316_fixed_date_1318_id *string `lyra:"ignore"`
-
     End string
 
     Start string
@@ -2184,8 +2086,6 @@ type Azurerm_autoscale_setting_profile_1316_fixed_date_1318 struct {
 }
 
 type Azurerm_autoscale_setting_profile_1316_recurrence_1319 struct {
-
-    Azurerm_autoscale_setting_profile_1316_recurrence_1319_id *string `lyra:"ignore"`
 
     Days []string
 
@@ -2198,8 +2098,6 @@ type Azurerm_autoscale_setting_profile_1316_recurrence_1319 struct {
 }
 
 type Azurerm_autoscale_setting_profile_1316_rule_1320_metric_trigger_1321 struct {
-
-    Azurerm_autoscale_setting_profile_1316_rule_1320_metric_trigger_1321_id *string `lyra:"ignore"`
 
     Metric_name string
 
@@ -2221,8 +2119,6 @@ type Azurerm_autoscale_setting_profile_1316_rule_1320_metric_trigger_1321 struct
 
 type Azurerm_autoscale_setting_profile_1316_rule_1320_scale_action_1322 struct {
 
-    Azurerm_autoscale_setting_profile_1316_rule_1320_scale_action_1322_id *string `lyra:"ignore"`
-
     Cooldown string
 
     Direction string
@@ -2235,27 +2131,23 @@ type Azurerm_autoscale_setting_profile_1316_rule_1320_scale_action_1322 struct {
 
 type Azurerm_autoscale_setting_profile_1316_rule_1320 struct {
 
-    Azurerm_autoscale_setting_profile_1316_rule_1320_id *string `lyra:"ignore"`
+    Metric_trigger []Azurerm_autoscale_setting_profile_1316_rule_1320_metric_trigger_1321
 
-    Metric_trigger Azurerm_autoscale_setting_profile_1316_rule_1320_metric_trigger_1321
-
-    Scale_action Azurerm_autoscale_setting_profile_1316_rule_1320_scale_action_1322
+    Scale_action []Azurerm_autoscale_setting_profile_1316_rule_1320_scale_action_1322
 
 }
 
 type Azurerm_autoscale_setting_profile_1316 struct {
 
-    Azurerm_autoscale_setting_profile_1316_id *string `lyra:"ignore"`
+    Capacity []Azurerm_autoscale_setting_profile_1316_capacity_1317
 
-    Capacity Azurerm_autoscale_setting_profile_1316_capacity_1317
-
-    Fixed_date *Azurerm_autoscale_setting_profile_1316_fixed_date_1318
+    Fixed_date *[]Azurerm_autoscale_setting_profile_1316_fixed_date_1318
 
     Name string
 
-    Recurrence *Azurerm_autoscale_setting_profile_1316_recurrence_1319
+    Recurrence *[]Azurerm_autoscale_setting_profile_1316_recurrence_1319
 
-    Rule *Azurerm_autoscale_setting_profile_1316_rule_1320
+    Rule *[]Azurerm_autoscale_setting_profile_1316_rule_1320
 
 }
 
@@ -2269,9 +2161,9 @@ type Azurerm_autoscale_setting struct {
 
     Name string
 
-    Notification *Azurerm_autoscale_setting_notification_1313
+    Notification *[]Azurerm_autoscale_setting_notification_1313
 
-    Profile Azurerm_autoscale_setting_profile_1316
+    Profile []Azurerm_autoscale_setting_profile_1316
 
     Resource_group_name string
 
@@ -2589,8 +2481,6 @@ func (h *Azurerm_batch_accountHandler) Delete(externalID string) error {
 
 type Azurerm_batch_pool_auto_scale_1323 struct {
 
-    Azurerm_batch_pool_auto_scale_1323_id *string `lyra:"ignore"`
-
     Evaluation_interval *string
 
     Formula string
@@ -2598,8 +2488,6 @@ type Azurerm_batch_pool_auto_scale_1323 struct {
 }
 
 type Azurerm_batch_pool_fixed_scale_1324 struct {
-
-    Azurerm_batch_pool_fixed_scale_1324_id *string `lyra:"ignore"`
 
     Resize_timeout *string
 
@@ -2611,8 +2499,6 @@ type Azurerm_batch_pool_fixed_scale_1324 struct {
 
 type Azurerm_batch_pool_start_task_1325_user_identity_1326_auto_user_1327 struct {
 
-    Azurerm_batch_pool_start_task_1325_user_identity_1326_auto_user_1327_id *string `lyra:"ignore"`
-
     Elevation_level *string
 
     Scope *string
@@ -2621,9 +2507,7 @@ type Azurerm_batch_pool_start_task_1325_user_identity_1326_auto_user_1327 struct
 
 type Azurerm_batch_pool_start_task_1325_user_identity_1326 struct {
 
-    Azurerm_batch_pool_start_task_1325_user_identity_1326_id *string `lyra:"ignore"`
-
-    Auto_user *Azurerm_batch_pool_start_task_1325_user_identity_1326_auto_user_1327
+    Auto_user *[]Azurerm_batch_pool_start_task_1325_user_identity_1326_auto_user_1327
 
     User_name *string
 
@@ -2631,23 +2515,19 @@ type Azurerm_batch_pool_start_task_1325_user_identity_1326 struct {
 
 type Azurerm_batch_pool_start_task_1325 struct {
 
-    Azurerm_batch_pool_start_task_1325_id *string `lyra:"ignore"`
-
     Command_line string
 
     Environment *map[string]string
 
     Max_task_retry_count *int
 
-    User_identity Azurerm_batch_pool_start_task_1325_user_identity_1326
+    User_identity []Azurerm_batch_pool_start_task_1325_user_identity_1326
 
     Wait_for_success *bool
 
 }
 
 type Azurerm_batch_pool_storage_image_reference_1328 struct {
-
-    Azurerm_batch_pool_storage_image_reference_1328_id *string `lyra:"ignore"`
 
     Id *string
 
@@ -2667,11 +2547,11 @@ type Azurerm_batch_pool struct {
 
     Account_name string
 
-    Auto_scale *Azurerm_batch_pool_auto_scale_1323
+    Auto_scale *[]Azurerm_batch_pool_auto_scale_1323
 
     Display_name *string
 
-    Fixed_scale *Azurerm_batch_pool_fixed_scale_1324
+    Fixed_scale *[]Azurerm_batch_pool_fixed_scale_1324
 
     Name string
 
@@ -2679,11 +2559,11 @@ type Azurerm_batch_pool struct {
 
     Resource_group_name string
 
-    Start_task *Azurerm_batch_pool_start_task_1325
+    Start_task *[]Azurerm_batch_pool_start_task_1325
 
     Stop_pending_resize_operation *bool
 
-    Storage_image_reference Azurerm_batch_pool_storage_image_reference_1328
+    Storage_image_reference []Azurerm_batch_pool_storage_image_reference_1328
 
     Vm_size string
 
@@ -2728,8 +2608,6 @@ func (h *Azurerm_batch_poolHandler) Delete(externalID string) error {
 
 type Azurerm_cdn_endpoint_geo_filter_1329 struct {
 
-    Azurerm_cdn_endpoint_geo_filter_1329_id *string `lyra:"ignore"`
-
     Action string
 
     Country_codes []string
@@ -2739,8 +2617,6 @@ type Azurerm_cdn_endpoint_geo_filter_1329 struct {
 }
 
 type Azurerm_cdn_endpoint_origin_1330 struct {
-
-    Azurerm_cdn_endpoint_origin_1330_id *string `lyra:"ignore"`
 
     Host_name string
 
@@ -2758,7 +2634,7 @@ type Azurerm_cdn_endpoint struct {
 
     Content_types_to_compress *[]string
 
-    Geo_filter *Azurerm_cdn_endpoint_geo_filter_1329
+    Geo_filter *[]Azurerm_cdn_endpoint_geo_filter_1329
 
     Host_name *string
 
@@ -2884,8 +2760,6 @@ func (h *Azurerm_cdn_profileHandler) Delete(externalID string) error {
 
 type Azurerm_cognitive_account_sku_1331 struct {
 
-    Azurerm_cognitive_account_sku_1331_id *string `lyra:"ignore"`
-
     Name string
 
     Tier string
@@ -2906,7 +2780,7 @@ type Azurerm_cognitive_account struct {
 
     Resource_group_name string
 
-    Sku Azurerm_cognitive_account_sku_1331
+    Sku []Azurerm_cognitive_account_sku_1331
 
     Tags *map[string]string
 
@@ -2951,8 +2825,6 @@ func (h *Azurerm_cognitive_accountHandler) Delete(externalID string) error {
 
 type Azurerm_container_group_container_1332_ports_1333 struct {
 
-    Azurerm_container_group_container_1332_ports_1333_id *string `lyra:"ignore"`
-
     Port *int
 
     Protocol *string
@@ -2960,8 +2832,6 @@ type Azurerm_container_group_container_1332_ports_1333 struct {
 }
 
 type Azurerm_container_group_container_1332_volume_1334 struct {
-
-    Azurerm_container_group_container_1332_volume_1334_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -2978,8 +2848,6 @@ type Azurerm_container_group_container_1332_volume_1334 struct {
 }
 
 type Azurerm_container_group_container_1332 struct {
-
-    Azurerm_container_group_container_1332_id *string `lyra:"ignore"`
 
     Command *string
 
@@ -3003,13 +2871,11 @@ type Azurerm_container_group_container_1332 struct {
 
     Secure_environment_variables *map[string]string
 
-    Volume *Azurerm_container_group_container_1332_volume_1334
+    Volume *[]Azurerm_container_group_container_1332_volume_1334
 
 }
 
 type Azurerm_container_group_image_registry_credential_1335 struct {
-
-    Azurerm_container_group_image_registry_credential_1335_id *string `lyra:"ignore"`
 
     Password string
 
@@ -3023,13 +2889,13 @@ type Azurerm_container_group struct {
 
     Azurerm_container_group_id *string `lyra:"ignore"`
 
-    Container Azurerm_container_group_container_1332
+    Container []Azurerm_container_group_container_1332
 
     Dns_name_label *string
 
     Fqdn *string
 
-    Image_registry_credential *Azurerm_container_group_image_registry_credential_1335
+    Image_registry_credential *[]Azurerm_container_group_image_registry_credential_1335
 
     Ip_address *string
 
@@ -3088,8 +2954,6 @@ func (h *Azurerm_container_groupHandler) Delete(externalID string) error {
 
 type Azurerm_container_registry_storage_account_1336 struct {
 
-    Azurerm_container_registry_storage_account_1336_id *string `lyra:"ignore"`
-
     Access_key string
 
     Name string
@@ -3118,7 +2982,7 @@ type Azurerm_container_registry struct {
 
     Sku *string
 
-    Storage_account *Azurerm_container_registry_storage_account_1336
+    Storage_account *[]Azurerm_container_registry_storage_account_1336
 
     Storage_account_id *string
 
@@ -3165,8 +3029,6 @@ func (h *Azurerm_container_registryHandler) Delete(externalID string) error {
 
 type Azurerm_container_service_agent_pool_profile_1337 struct {
 
-    Azurerm_container_service_agent_pool_profile_1337_id *string `lyra:"ignore"`
-
     Count *int
 
     Dns_prefix string
@@ -3181,8 +3043,6 @@ type Azurerm_container_service_agent_pool_profile_1337 struct {
 
 type Azurerm_container_service_diagnostics_profile_1338 struct {
 
-    Azurerm_container_service_diagnostics_profile_1338_id *string `lyra:"ignore"`
-
     Enabled bool
 
     Storage_uri *string
@@ -3191,15 +3051,11 @@ type Azurerm_container_service_diagnostics_profile_1338 struct {
 
 type Azurerm_container_service_linux_profile_1339_ssh_key_1340 struct {
 
-    Azurerm_container_service_linux_profile_1339_ssh_key_1340_id *string `lyra:"ignore"`
-
     Key_data string
 
 }
 
 type Azurerm_container_service_linux_profile_1339 struct {
-
-    Azurerm_container_service_linux_profile_1339_id *string `lyra:"ignore"`
 
     Admin_username string
 
@@ -3208,8 +3064,6 @@ type Azurerm_container_service_linux_profile_1339 struct {
 }
 
 type Azurerm_container_service_master_profile_1341 struct {
-
-    Azurerm_container_service_master_profile_1341_id *string `lyra:"ignore"`
 
     Count *int
 
@@ -3220,8 +3074,6 @@ type Azurerm_container_service_master_profile_1341 struct {
 }
 
 type Azurerm_container_service_service_principal_1342 struct {
-
-    Azurerm_container_service_service_principal_1342_id *string `lyra:"ignore"`
 
     Client_id string
 
@@ -3294,15 +3146,11 @@ func (h *Azurerm_container_serviceHandler) Delete(externalID string) error {
 
 type Azurerm_cosmosdb_account_capabilities_1343 struct {
 
-    Azurerm_cosmosdb_account_capabilities_1343_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Azurerm_cosmosdb_account_consistency_policy_1344 struct {
-
-    Azurerm_cosmosdb_account_consistency_policy_1344_id *string `lyra:"ignore"`
 
     Consistency_level string
 
@@ -3314,8 +3162,6 @@ type Azurerm_cosmosdb_account_consistency_policy_1344 struct {
 
 type Azurerm_cosmosdb_account_failover_policy_1345 struct {
 
-    Azurerm_cosmosdb_account_failover_policy_1345_id *string `lyra:"ignore"`
-
     Id *string
 
     Location string
@@ -3325,8 +3171,6 @@ type Azurerm_cosmosdb_account_failover_policy_1345 struct {
 }
 
 type Azurerm_cosmosdb_account_geo_location_1346 struct {
-
-    Azurerm_cosmosdb_account_geo_location_1346_id *string `lyra:"ignore"`
 
     Failover_priority int
 
@@ -3340,8 +3184,6 @@ type Azurerm_cosmosdb_account_geo_location_1346 struct {
 
 type Azurerm_cosmosdb_account_virtual_network_rule_1347 struct {
 
-    Azurerm_cosmosdb_account_virtual_network_rule_1347_id *string `lyra:"ignore"`
-
     Id string
 
 }
@@ -3354,7 +3196,7 @@ type Azurerm_cosmosdb_account struct {
 
     Connection_strings *[]string
 
-    Consistency_policy Azurerm_cosmosdb_account_consistency_policy_1344
+    Consistency_policy []Azurerm_cosmosdb_account_consistency_policy_1344
 
     Enable_automatic_failover *bool
 
@@ -3832,8 +3674,6 @@ func (h *Azurerm_dev_test_labHandler) Delete(externalID string) error {
 
 type Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_1348 struct {
 
-    Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_1348_id *string `lyra:"ignore"`
-
     Offer string
 
     Publisher string
@@ -3845,8 +3685,6 @@ type Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_1348 struct 
 }
 
 type Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_1349 struct {
-
-    Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_1349_id *string `lyra:"ignore"`
 
     Backend_port int
 
@@ -3866,7 +3704,7 @@ type Azurerm_dev_test_linux_virtual_machine struct {
 
     Fqdn *string
 
-    Gallery_image_reference Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_1348
+    Gallery_image_reference []Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_1348
 
     Inbound_nat_rule *Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_1349
 
@@ -4000,8 +3838,6 @@ func (h *Azurerm_dev_test_policyHandler) Delete(externalID string) error {
 
 type Azurerm_dev_test_virtual_network_subnet_1350 struct {
 
-    Azurerm_dev_test_virtual_network_subnet_1350_id *string `lyra:"ignore"`
-
     Name *string
 
     Use_in_virtual_machine_creation *string
@@ -4022,7 +3858,7 @@ type Azurerm_dev_test_virtual_network struct {
 
     Resource_group_name string
 
-    Subnet *Azurerm_dev_test_virtual_network_subnet_1350
+    Subnet *[]Azurerm_dev_test_virtual_network_subnet_1350
 
     Tags *map[string]string
 
@@ -4069,8 +3905,6 @@ func (h *Azurerm_dev_test_virtual_networkHandler) Delete(externalID string) erro
 
 type Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_1351 struct {
 
-    Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_1351_id *string `lyra:"ignore"`
-
     Offer string
 
     Publisher string
@@ -4082,8 +3916,6 @@ type Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_1351 struc
 }
 
 type Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_1352 struct {
-
-    Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_1352_id *string `lyra:"ignore"`
 
     Backend_port int
 
@@ -4103,7 +3935,7 @@ type Azurerm_dev_test_windows_virtual_machine struct {
 
     Fqdn *string
 
-    Gallery_image_reference Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_1351
+    Gallery_image_reference []Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_1351
 
     Inbound_nat_rule *Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_1352
 
@@ -4174,8 +4006,6 @@ func (h *Azurerm_dev_test_windows_virtual_machineHandler) Delete(externalID stri
 
 type Azurerm_devspace_controller_sku_1353 struct {
 
-    Azurerm_devspace_controller_sku_1353_id *string `lyra:"ignore"`
-
     Name string
 
     Tier string
@@ -4196,7 +4026,7 @@ type Azurerm_devspace_controller struct {
 
     Resource_group_name string
 
-    Sku Azurerm_devspace_controller_sku_1353
+    Sku []Azurerm_devspace_controller_sku_1353
 
     Tags *map[string]string
 
@@ -4355,8 +4185,6 @@ func (h *Azurerm_dns_aaaa_recordHandler) Delete(externalID string) error {
 
 type Azurerm_dns_caa_record_record_1354 struct {
 
-    Azurerm_dns_caa_record_record_1354_id *string `lyra:"ignore"`
-
     Flags int
 
     Tag string
@@ -4479,8 +4307,6 @@ func (h *Azurerm_dns_cname_recordHandler) Delete(externalID string) error {
 
 type Azurerm_dns_mx_record_record_1355 struct {
 
-    Azurerm_dns_mx_record_record_1355_id *string `lyra:"ignore"`
-
     Exchange string
 
     Preference string
@@ -4543,8 +4369,6 @@ func (h *Azurerm_dns_mx_recordHandler) Delete(externalID string) error {
 }
 
 type Azurerm_dns_ns_record_record_1356 struct {
-
-    Azurerm_dns_ns_record_record_1356_id *string `lyra:"ignore"`
 
     Nsdname string
 
@@ -4664,8 +4488,6 @@ func (h *Azurerm_dns_ptr_recordHandler) Delete(externalID string) error {
 
 type Azurerm_dns_srv_record_record_1357 struct {
 
-    Azurerm_dns_srv_record_record_1357_id *string `lyra:"ignore"`
-
     Port int
 
     Priority int
@@ -4732,8 +4554,6 @@ func (h *Azurerm_dns_srv_recordHandler) Delete(externalID string) error {
 }
 
 type Azurerm_dns_txt_record_record_1358 struct {
-
-    Azurerm_dns_txt_record_record_1358_id *string `lyra:"ignore"`
 
     Value string
 
@@ -4914,8 +4734,6 @@ func (h *Azurerm_eventgrid_topicHandler) Delete(externalID string) error {
 
 type Azurerm_eventhub_capture_description_1359_destination_1360 struct {
 
-    Azurerm_eventhub_capture_description_1359_destination_1360_id *string `lyra:"ignore"`
-
     Archive_name_format string
 
     Blob_container_name string
@@ -4928,9 +4746,7 @@ type Azurerm_eventhub_capture_description_1359_destination_1360 struct {
 
 type Azurerm_eventhub_capture_description_1359 struct {
 
-    Azurerm_eventhub_capture_description_1359_id *string `lyra:"ignore"`
-
-    Destination Azurerm_eventhub_capture_description_1359_destination_1360
+    Destination []Azurerm_eventhub_capture_description_1359_destination_1360
 
     Enabled bool
 
@@ -4946,7 +4762,7 @@ type Azurerm_eventhub struct {
 
     Azurerm_eventhub_id *string `lyra:"ignore"`
 
-    Capture_description *Azurerm_eventhub_capture_description_1359
+    Capture_description *[]Azurerm_eventhub_capture_description_1359
 
     Location *string
 
@@ -5259,8 +5075,6 @@ func (h *Azurerm_eventhub_namespace_authorization_ruleHandler) Delete(externalID
 
 type Azurerm_express_route_circuit_sku_1361 struct {
 
-    Azurerm_express_route_circuit_sku_1361_id *string `lyra:"ignore"`
-
     Family string
 
     Tier string
@@ -5289,7 +5103,7 @@ type Azurerm_express_route_circuit struct {
 
     Service_provider_provisioning_state *string
 
-    Sku Azurerm_express_route_circuit_sku_1361
+    Sku []Azurerm_express_route_circuit_sku_1361
 
     Tags *map[string]string
 
@@ -5387,8 +5201,6 @@ func (h *Azurerm_express_route_circuit_authorizationHandler) Delete(externalID s
 
 type Azurerm_express_route_circuit_peering_microsoft_peering_config_1362 struct {
 
-    Azurerm_express_route_circuit_peering_microsoft_peering_config_1362_id *string `lyra:"ignore"`
-
     Advertised_public_prefixes []string
 
 }
@@ -5401,7 +5213,7 @@ type Azurerm_express_route_circuit_peering struct {
 
     Express_route_circuit_name string
 
-    Microsoft_peering_config *Azurerm_express_route_circuit_peering_microsoft_peering_config_1362
+    Microsoft_peering_config *[]Azurerm_express_route_circuit_peering_microsoft_peering_config_1362
 
     Peer_asn *int
 
@@ -5462,8 +5274,6 @@ func (h *Azurerm_express_route_circuit_peeringHandler) Delete(externalID string)
 
 type Azurerm_firewall_ip_configuration_1363 struct {
 
-    Azurerm_firewall_ip_configuration_1363_id *string `lyra:"ignore"`
-
     Internal_public_ip_address_id *string
 
     Name string
@@ -5480,7 +5290,7 @@ type Azurerm_firewall struct {
 
     Azurerm_firewall_id *string `lyra:"ignore"`
 
-    Ip_configuration Azurerm_firewall_ip_configuration_1363
+    Ip_configuration []Azurerm_firewall_ip_configuration_1363
 
     Location string
 
@@ -5531,8 +5341,6 @@ func (h *Azurerm_firewallHandler) Delete(externalID string) error {
 
 type Azurerm_firewall_application_rule_collection_rule_1364_protocol_1365 struct {
 
-    Azurerm_firewall_application_rule_collection_rule_1364_protocol_1365_id *string `lyra:"ignore"`
-
     Port *int
 
     Type string
@@ -5541,15 +5349,13 @@ type Azurerm_firewall_application_rule_collection_rule_1364_protocol_1365 struct
 
 type Azurerm_firewall_application_rule_collection_rule_1364 struct {
 
-    Azurerm_firewall_application_rule_collection_rule_1364_id *string `lyra:"ignore"`
-
     Description *string
 
     Fqdn_tags *[]string
 
     Name string
 
-    Protocol *Azurerm_firewall_application_rule_collection_rule_1364_protocol_1365
+    Protocol *[]Azurerm_firewall_application_rule_collection_rule_1364_protocol_1365
 
     Source_addresses []string
 
@@ -5571,7 +5377,7 @@ type Azurerm_firewall_application_rule_collection struct {
 
     Resource_group_name string
 
-    Rule Azurerm_firewall_application_rule_collection_rule_1364
+    Rule []Azurerm_firewall_application_rule_collection_rule_1364
 
 }
 
@@ -5613,8 +5419,6 @@ func (h *Azurerm_firewall_application_rule_collectionHandler) Delete(externalID 
 }
 
 type Azurerm_firewall_network_rule_collection_rule_1366 struct {
-
-    Azurerm_firewall_network_rule_collection_rule_1366_id *string `lyra:"ignore"`
 
     Description *string
 
@@ -5687,8 +5491,6 @@ func (h *Azurerm_firewall_network_rule_collectionHandler) Delete(externalID stri
 
 type Azurerm_function_app_connection_string_1367 struct {
 
-    Azurerm_function_app_connection_string_1367_id *string `lyra:"ignore"`
-
     Name string
 
     Type string
@@ -5698,8 +5500,6 @@ type Azurerm_function_app_connection_string_1367 struct {
 }
 
 type Azurerm_function_app_identity_1368 struct {
-
-    Azurerm_function_app_identity_1368_id *string `lyra:"ignore"`
 
     Principal_id *string
 
@@ -5711,8 +5511,6 @@ type Azurerm_function_app_identity_1368 struct {
 
 type Azurerm_function_app_site_config_1369 struct {
 
-    Azurerm_function_app_site_config_1369_id *string `lyra:"ignore"`
-
     Always_on *bool
 
     Use_32_bit_worker_process *bool
@@ -5722,8 +5520,6 @@ type Azurerm_function_app_site_config_1369 struct {
 }
 
 type Azurerm_function_app_site_credential_1370 struct {
-
-    Azurerm_function_app_site_credential_1370_id *string `lyra:"ignore"`
 
     Password *string
 
@@ -5741,7 +5537,7 @@ type Azurerm_function_app struct {
 
     Client_affinity_enabled *bool
 
-    Connection_string *Azurerm_function_app_connection_string_1367
+    Connection_string *[]Azurerm_function_app_connection_string_1367
 
     Default_hostname *string
 
@@ -5751,7 +5547,7 @@ type Azurerm_function_app struct {
 
     Https_only *bool
 
-    Identity *Azurerm_function_app_identity_1368
+    Identity *[]Azurerm_function_app_identity_1368
 
     Location string
 
@@ -5761,9 +5557,9 @@ type Azurerm_function_app struct {
 
     Resource_group_name string
 
-    Site_config *Azurerm_function_app_site_config_1369
+    Site_config *[]Azurerm_function_app_site_config_1369
 
-    Site_credential *Azurerm_function_app_site_credential_1370
+    Site_credential *[]Azurerm_function_app_site_credential_1370
 
     Storage_connection_string string
 
@@ -5812,8 +5608,6 @@ func (h *Azurerm_function_appHandler) Delete(externalID string) error {
 
 type Azurerm_image_data_disk_1371 struct {
 
-    Azurerm_image_data_disk_1371_id *string `lyra:"ignore"`
-
     Blob_uri *string
 
     Caching *string
@@ -5827,8 +5621,6 @@ type Azurerm_image_data_disk_1371 struct {
 }
 
 type Azurerm_image_os_disk_1372 struct {
-
-    Azurerm_image_os_disk_1372_id *string `lyra:"ignore"`
 
     Blob_uri *string
 
@@ -5848,13 +5640,13 @@ type Azurerm_image struct {
 
     Azurerm_image_id *string `lyra:"ignore"`
 
-    Data_disk *Azurerm_image_data_disk_1371
+    Data_disk *[]Azurerm_image_data_disk_1371
 
     Location string
 
     Name string
 
-    Os_disk *Azurerm_image_os_disk_1372
+    Os_disk *[]Azurerm_image_os_disk_1372
 
     Resource_group_name string
 
@@ -5903,8 +5695,6 @@ func (h *Azurerm_imageHandler) Delete(externalID string) error {
 
 type Azurerm_iothub_endpoint_1373 struct {
 
-    Azurerm_iothub_endpoint_1373_id *string `lyra:"ignore"`
-
     Batch_frequency_in_seconds *int
 
     Connection_string string
@@ -5925,8 +5715,6 @@ type Azurerm_iothub_endpoint_1373 struct {
 
 type Azurerm_iothub_route_1374 struct {
 
-    Azurerm_iothub_route_1374_id *string `lyra:"ignore"`
-
     Condition *string
 
     Enabled bool
@@ -5941,8 +5729,6 @@ type Azurerm_iothub_route_1374 struct {
 
 type Azurerm_iothub_shared_access_policy_1375 struct {
 
-    Azurerm_iothub_shared_access_policy_1375_id *string `lyra:"ignore"`
-
     Key_name *string
 
     Permissions *string
@@ -5954,8 +5740,6 @@ type Azurerm_iothub_shared_access_policy_1375 struct {
 }
 
 type Azurerm_iothub_sku_1376 struct {
-
-    Azurerm_iothub_sku_1376_id *string `lyra:"ignore"`
 
     Capacity int
 
@@ -5969,7 +5753,7 @@ type Azurerm_iothub struct {
 
     Azurerm_iothub_id *string `lyra:"ignore"`
 
-    Endpoint *Azurerm_iothub_endpoint_1373
+    Endpoint *[]Azurerm_iothub_endpoint_1373
 
     Event_hub_events_endpoint *string
 
@@ -5987,11 +5771,11 @@ type Azurerm_iothub struct {
 
     Resource_group_name string
 
-    Route *Azurerm_iothub_route_1374
+    Route *[]Azurerm_iothub_route_1374
 
-    Shared_access_policy *Azurerm_iothub_shared_access_policy_1375
+    Shared_access_policy *[]Azurerm_iothub_shared_access_policy_1375
 
-    Sku Azurerm_iothub_sku_1376
+    Sku []Azurerm_iothub_sku_1376
 
     Tags *map[string]string
 
@@ -6089,8 +5873,6 @@ func (h *Azurerm_iothub_consumer_groupHandler) Delete(externalID string) error {
 
 type Azurerm_key_vault_access_policy_1377 struct {
 
-    Azurerm_key_vault_access_policy_1377_id *string `lyra:"ignore"`
-
     Application_id *string
 
     Certificate_permissions *[]string
@@ -6107,8 +5889,6 @@ type Azurerm_key_vault_access_policy_1377 struct {
 
 type Azurerm_key_vault_network_acls_1378 struct {
 
-    Azurerm_key_vault_network_acls_1378_id *string `lyra:"ignore"`
-
     Bypass string
 
     Default_action string
@@ -6121,8 +5901,6 @@ type Azurerm_key_vault_network_acls_1378 struct {
 
 type Azurerm_key_vault_sku_1379 struct {
 
-    Azurerm_key_vault_sku_1379_id *string `lyra:"ignore"`
-
     Name string
 
 }
@@ -6131,7 +5909,7 @@ type Azurerm_key_vault struct {
 
     Azurerm_key_vault_id *string `lyra:"ignore"`
 
-    Access_policy *Azurerm_key_vault_access_policy_1377
+    Access_policy *[]Azurerm_key_vault_access_policy_1377
 
     Enabled_for_deployment *bool
 
@@ -6143,11 +5921,11 @@ type Azurerm_key_vault struct {
 
     Name string
 
-    Network_acls *Azurerm_key_vault_network_acls_1378
+    Network_acls *[]Azurerm_key_vault_network_acls_1378
 
     Resource_group_name string
 
-    Sku Azurerm_key_vault_sku_1379
+    Sku []Azurerm_key_vault_sku_1379
 
     Tags *map[string]string
 
@@ -6255,8 +6033,6 @@ func (h *Azurerm_key_vault_access_policyHandler) Delete(externalID string) error
 
 type Azurerm_key_vault_certificate_certificate_1380 struct {
 
-    Azurerm_key_vault_certificate_certificate_1380_id *string `lyra:"ignore"`
-
     Contents string
 
     Password *string
@@ -6265,15 +6041,11 @@ type Azurerm_key_vault_certificate_certificate_1380 struct {
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_issuer_parameters_1382 struct {
 
-    Azurerm_key_vault_certificate_certificate_policy_1381_issuer_parameters_1382_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_key_properties_1383 struct {
-
-    Azurerm_key_vault_certificate_certificate_policy_1381_key_properties_1383_id *string `lyra:"ignore"`
 
     Exportable bool
 
@@ -6287,15 +6059,11 @@ type Azurerm_key_vault_certificate_certificate_policy_1381_key_properties_1383 s
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_action_1385 struct {
 
-    Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_action_1385_id *string `lyra:"ignore"`
-
     Action_type string
 
 }
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_trigger_1386 struct {
-
-    Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_trigger_1386_id *string `lyra:"ignore"`
 
     Days_before_expiry *int
 
@@ -6305,25 +6073,19 @@ type Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384 struct {
 
-    Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_id *string `lyra:"ignore"`
+    Action []Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_action_1385
 
-    Action Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_action_1385
-
-    Trigger Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_trigger_1386
+    Trigger []Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384_trigger_1386
 
 }
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_secret_properties_1387 struct {
-
-    Azurerm_key_vault_certificate_certificate_policy_1381_secret_properties_1387_id *string `lyra:"ignore"`
 
     Content_type string
 
 }
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388_subject_alternative_names_1389 struct {
-
-    Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388_subject_alternative_names_1389_id *string `lyra:"ignore"`
 
     Dns_names *[]string
 
@@ -6335,15 +6097,13 @@ type Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_prop
 
 type Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388 struct {
 
-    Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388_id *string `lyra:"ignore"`
-
     Extended_key_usage *[]string
 
     Key_usage []string
 
     Subject string
 
-    Subject_alternative_names *Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388_subject_alternative_names_1389
+    Subject_alternative_names *[]Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388_subject_alternative_names_1389
 
     Validity_in_months int
 
@@ -6351,17 +6111,15 @@ type Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_prop
 
 type Azurerm_key_vault_certificate_certificate_policy_1381 struct {
 
-    Azurerm_key_vault_certificate_certificate_policy_1381_id *string `lyra:"ignore"`
+    Issuer_parameters []Azurerm_key_vault_certificate_certificate_policy_1381_issuer_parameters_1382
 
-    Issuer_parameters Azurerm_key_vault_certificate_certificate_policy_1381_issuer_parameters_1382
+    Key_properties []Azurerm_key_vault_certificate_certificate_policy_1381_key_properties_1383
 
-    Key_properties Azurerm_key_vault_certificate_certificate_policy_1381_key_properties_1383
+    Lifetime_action *[]Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384
 
-    Lifetime_action *Azurerm_key_vault_certificate_certificate_policy_1381_lifetime_action_1384
+    Secret_properties []Azurerm_key_vault_certificate_certificate_policy_1381_secret_properties_1387
 
-    Secret_properties Azurerm_key_vault_certificate_certificate_policy_1381_secret_properties_1387
-
-    X509_certificate_properties *Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388
+    X509_certificate_properties *[]Azurerm_key_vault_certificate_certificate_policy_1381_x509_certificate_properties_1388
 
 }
 
@@ -6369,11 +6127,11 @@ type Azurerm_key_vault_certificate struct {
 
     Azurerm_key_vault_certificate_id *string `lyra:"ignore"`
 
-    Certificate *Azurerm_key_vault_certificate_certificate_1380
+    Certificate *[]Azurerm_key_vault_certificate_certificate_1380
 
     Certificate_data *string
 
-    Certificate_policy Azurerm_key_vault_certificate_certificate_policy_1381
+    Certificate_policy []Azurerm_key_vault_certificate_certificate_policy_1381
 
     Name string
 
@@ -6544,8 +6302,6 @@ func (h *Azurerm_key_vault_secretHandler) Delete(externalID string) error {
 
 type Azurerm_kubernetes_cluster_addon_profile_1390_aci_connector_linux_1391 struct {
 
-    Azurerm_kubernetes_cluster_addon_profile_1390_aci_connector_linux_1391_id *string `lyra:"ignore"`
-
     Enabled bool
 
     Subnet_name string
@@ -6553,8 +6309,6 @@ type Azurerm_kubernetes_cluster_addon_profile_1390_aci_connector_linux_1391 stru
 }
 
 type Azurerm_kubernetes_cluster_addon_profile_1390_http_application_routing_1392 struct {
-
-    Azurerm_kubernetes_cluster_addon_profile_1390_http_application_routing_1392_id *string `lyra:"ignore"`
 
     Enabled bool
 
@@ -6564,8 +6318,6 @@ type Azurerm_kubernetes_cluster_addon_profile_1390_http_application_routing_1392
 
 type Azurerm_kubernetes_cluster_addon_profile_1390_oms_agent_1393 struct {
 
-    Azurerm_kubernetes_cluster_addon_profile_1390_oms_agent_1393_id *string `lyra:"ignore"`
-
     Enabled bool
 
     Log_analytics_workspace_id string
@@ -6574,19 +6326,15 @@ type Azurerm_kubernetes_cluster_addon_profile_1390_oms_agent_1393 struct {
 
 type Azurerm_kubernetes_cluster_addon_profile_1390 struct {
 
-    Azurerm_kubernetes_cluster_addon_profile_1390_id *string `lyra:"ignore"`
+    Aci_connector_linux *[]Azurerm_kubernetes_cluster_addon_profile_1390_aci_connector_linux_1391
 
-    Aci_connector_linux *Azurerm_kubernetes_cluster_addon_profile_1390_aci_connector_linux_1391
+    Http_application_routing *[]Azurerm_kubernetes_cluster_addon_profile_1390_http_application_routing_1392
 
-    Http_application_routing *Azurerm_kubernetes_cluster_addon_profile_1390_http_application_routing_1392
-
-    Oms_agent *Azurerm_kubernetes_cluster_addon_profile_1390_oms_agent_1393
+    Oms_agent *[]Azurerm_kubernetes_cluster_addon_profile_1390_oms_agent_1393
 
 }
 
 type Azurerm_kubernetes_cluster_agent_pool_profile_1394 struct {
-
-    Azurerm_kubernetes_cluster_agent_pool_profile_1394_id *string `lyra:"ignore"`
 
     Count *int
 
@@ -6610,8 +6358,6 @@ type Azurerm_kubernetes_cluster_agent_pool_profile_1394 struct {
 
 type Azurerm_kubernetes_cluster_kube_admin_config_1395 struct {
 
-    Azurerm_kubernetes_cluster_kube_admin_config_1395_id *string `lyra:"ignore"`
-
     Client_certificate *string
 
     Client_key *string
@@ -6627,8 +6373,6 @@ type Azurerm_kubernetes_cluster_kube_admin_config_1395 struct {
 }
 
 type Azurerm_kubernetes_cluster_kube_config_1396 struct {
-
-    Azurerm_kubernetes_cluster_kube_config_1396_id *string `lyra:"ignore"`
 
     Client_certificate *string
 
@@ -6646,25 +6390,19 @@ type Azurerm_kubernetes_cluster_kube_config_1396 struct {
 
 type Azurerm_kubernetes_cluster_linux_profile_1397_ssh_key_1398 struct {
 
-    Azurerm_kubernetes_cluster_linux_profile_1397_ssh_key_1398_id *string `lyra:"ignore"`
-
     Key_data string
 
 }
 
 type Azurerm_kubernetes_cluster_linux_profile_1397 struct {
 
-    Azurerm_kubernetes_cluster_linux_profile_1397_id *string `lyra:"ignore"`
-
     Admin_username string
 
-    Ssh_key Azurerm_kubernetes_cluster_linux_profile_1397_ssh_key_1398
+    Ssh_key []Azurerm_kubernetes_cluster_linux_profile_1397_ssh_key_1398
 
 }
 
 type Azurerm_kubernetes_cluster_network_profile_1399 struct {
-
-    Azurerm_kubernetes_cluster_network_profile_1399_id *string `lyra:"ignore"`
 
     Dns_service_ip *string
 
@@ -6680,8 +6418,6 @@ type Azurerm_kubernetes_cluster_network_profile_1399 struct {
 
 type Azurerm_kubernetes_cluster_role_based_access_control_1400_azure_active_directory_1401 struct {
 
-    Azurerm_kubernetes_cluster_role_based_access_control_1400_azure_active_directory_1401_id *string `lyra:"ignore"`
-
     Client_app_id string
 
     Server_app_id string
@@ -6694,17 +6430,13 @@ type Azurerm_kubernetes_cluster_role_based_access_control_1400_azure_active_dire
 
 type Azurerm_kubernetes_cluster_role_based_access_control_1400 struct {
 
-    Azurerm_kubernetes_cluster_role_based_access_control_1400_id *string `lyra:"ignore"`
-
-    Azure_active_directory *Azurerm_kubernetes_cluster_role_based_access_control_1400_azure_active_directory_1401
+    Azure_active_directory *[]Azurerm_kubernetes_cluster_role_based_access_control_1400_azure_active_directory_1401
 
     Enabled bool
 
 }
 
 type Azurerm_kubernetes_cluster_service_principal_1402 struct {
-
-    Azurerm_kubernetes_cluster_service_principal_1402_id *string `lyra:"ignore"`
 
     Client_id string
 
@@ -6716,37 +6448,37 @@ type Azurerm_kubernetes_cluster struct {
 
     Azurerm_kubernetes_cluster_id *string `lyra:"ignore"`
 
-    Addon_profile *Azurerm_kubernetes_cluster_addon_profile_1390
+    Addon_profile *[]Azurerm_kubernetes_cluster_addon_profile_1390
 
-    Agent_pool_profile Azurerm_kubernetes_cluster_agent_pool_profile_1394
+    Agent_pool_profile []Azurerm_kubernetes_cluster_agent_pool_profile_1394
 
     Dns_prefix string
 
     Fqdn *string
 
-    Kube_admin_config *Azurerm_kubernetes_cluster_kube_admin_config_1395
+    Kube_admin_config *[]Azurerm_kubernetes_cluster_kube_admin_config_1395
 
     Kube_admin_config_raw *string
 
-    Kube_config *Azurerm_kubernetes_cluster_kube_config_1396
+    Kube_config *[]Azurerm_kubernetes_cluster_kube_config_1396
 
     Kube_config_raw *string
 
     Kubernetes_version *string
 
-    Linux_profile *Azurerm_kubernetes_cluster_linux_profile_1397
+    Linux_profile *[]Azurerm_kubernetes_cluster_linux_profile_1397
 
     Location string
 
     Name string
 
-    Network_profile *Azurerm_kubernetes_cluster_network_profile_1399
+    Network_profile *[]Azurerm_kubernetes_cluster_network_profile_1399
 
     Node_resource_group *string
 
     Resource_group_name string
 
-    Role_based_access_control *Azurerm_kubernetes_cluster_role_based_access_control_1400
+    Role_based_access_control *[]Azurerm_kubernetes_cluster_role_based_access_control_1400
 
     Service_principal Azurerm_kubernetes_cluster_service_principal_1402
 
@@ -6793,8 +6525,6 @@ func (h *Azurerm_kubernetes_clusterHandler) Delete(externalID string) error {
 
 type Azurerm_lb_frontend_ip_configuration_1403 struct {
 
-    Azurerm_lb_frontend_ip_configuration_1403_id *string `lyra:"ignore"`
-
     Inbound_nat_rules *[]string
 
     Load_balancer_rules *[]string
@@ -6817,7 +6547,7 @@ type Azurerm_lb struct {
 
     Azurerm_lb_id *string `lyra:"ignore"`
 
-    Frontend_ip_configuration *Azurerm_lb_frontend_ip_configuration_1403
+    Frontend_ip_configuration *[]Azurerm_lb_frontend_ip_configuration_1403
 
     Location string
 
@@ -7191,8 +6921,6 @@ func (h *Azurerm_lb_ruleHandler) Delete(externalID string) error {
 
 type Azurerm_local_network_gateway_bgp_settings_1404 struct {
 
-    Azurerm_local_network_gateway_bgp_settings_1404_id *string `lyra:"ignore"`
-
     Asn int
 
     Bgp_peering_address string
@@ -7207,7 +6935,7 @@ type Azurerm_local_network_gateway struct {
 
     Address_space []string
 
-    Bgp_settings *Azurerm_local_network_gateway_bgp_settings_1404
+    Bgp_settings *[]Azurerm_local_network_gateway_bgp_settings_1404
 
     Gateway_address string
 
@@ -7260,8 +6988,6 @@ func (h *Azurerm_local_network_gatewayHandler) Delete(externalID string) error {
 
 type Azurerm_log_analytics_solution_plan_1405 struct {
 
-    Azurerm_log_analytics_solution_plan_1405_id *string `lyra:"ignore"`
-
     Name *string
 
     Product string
@@ -7278,7 +7004,7 @@ type Azurerm_log_analytics_solution struct {
 
     Location string
 
-    Plan Azurerm_log_analytics_solution_plan_1405
+    Plan []Azurerm_log_analytics_solution_plan_1405
 
     Resource_group_name string
 
@@ -7763,8 +7489,6 @@ func (h *Azurerm_logic_app_workflowHandler) Delete(externalID string) error {
 
 type Azurerm_managed_disk_encryption_settings_1406_disk_encryption_key_1407 struct {
 
-    Azurerm_managed_disk_encryption_settings_1406_disk_encryption_key_1407_id *string `lyra:"ignore"`
-
     Secret_url string
 
     Source_vault_id string
@@ -7772,8 +7496,6 @@ type Azurerm_managed_disk_encryption_settings_1406_disk_encryption_key_1407 stru
 }
 
 type Azurerm_managed_disk_encryption_settings_1406_key_encryption_key_1408 struct {
-
-    Azurerm_managed_disk_encryption_settings_1406_key_encryption_key_1408_id *string `lyra:"ignore"`
 
     Key_url string
 
@@ -7783,13 +7505,11 @@ type Azurerm_managed_disk_encryption_settings_1406_key_encryption_key_1408 struc
 
 type Azurerm_managed_disk_encryption_settings_1406 struct {
 
-    Azurerm_managed_disk_encryption_settings_1406_id *string `lyra:"ignore"`
-
-    Disk_encryption_key *Azurerm_managed_disk_encryption_settings_1406_disk_encryption_key_1407
+    Disk_encryption_key *[]Azurerm_managed_disk_encryption_settings_1406_disk_encryption_key_1407
 
     Enabled bool
 
-    Key_encryption_key *Azurerm_managed_disk_encryption_settings_1406_key_encryption_key_1408
+    Key_encryption_key *[]Azurerm_managed_disk_encryption_settings_1406_key_encryption_key_1408
 
 }
 
@@ -7801,7 +7521,7 @@ type Azurerm_managed_disk struct {
 
     Disk_size_gb *int
 
-    Encryption_settings *Azurerm_managed_disk_encryption_settings_1406
+    Encryption_settings *[]Azurerm_managed_disk_encryption_settings_1406
 
     Image_reference_id *string
 
@@ -8019,8 +7739,6 @@ func (h *Azurerm_mariadb_databaseHandler) Delete(externalID string) error {
 
 type Azurerm_mariadb_server_sku_1409 struct {
 
-    Azurerm_mariadb_server_sku_1409_id *string `lyra:"ignore"`
-
     Capacity int
 
     Family string
@@ -8032,8 +7750,6 @@ type Azurerm_mariadb_server_sku_1409 struct {
 }
 
 type Azurerm_mariadb_server_storage_profile_1410 struct {
-
-    Azurerm_mariadb_server_storage_profile_1410_id *string `lyra:"ignore"`
 
     Backup_retention_days *int
 
@@ -8059,11 +7775,11 @@ type Azurerm_mariadb_server struct {
 
     Resource_group_name string
 
-    Sku Azurerm_mariadb_server_sku_1409
+    Sku []Azurerm_mariadb_server_sku_1409
 
     Ssl_enforcement string
 
-    Storage_profile Azurerm_mariadb_server_storage_profile_1410
+    Storage_profile []Azurerm_mariadb_server_storage_profile_1410
 
     Tags *map[string]string
 
@@ -8110,8 +7826,6 @@ func (h *Azurerm_mariadb_serverHandler) Delete(externalID string) error {
 
 type Azurerm_metric_alertrule_email_action_1411 struct {
 
-    Azurerm_metric_alertrule_email_action_1411_id *string `lyra:"ignore"`
-
     Custom_emails *[]string
 
     Send_to_service_owners *bool
@@ -8119,8 +7833,6 @@ type Azurerm_metric_alertrule_email_action_1411 struct {
 }
 
 type Azurerm_metric_alertrule_webhook_action_1412 struct {
-
-    Azurerm_metric_alertrule_webhook_action_1412_id *string `lyra:"ignore"`
 
     Properties *map[string]string
 
@@ -8136,7 +7848,7 @@ type Azurerm_metric_alertrule struct {
 
     Description *string
 
-    Email_action *Azurerm_metric_alertrule_email_action_1411
+    Email_action *[]Azurerm_metric_alertrule_email_action_1411
 
     Enabled *bool
 
@@ -8158,7 +7870,7 @@ type Azurerm_metric_alertrule struct {
 
     Threshold float64
 
-    Webhook_action *Azurerm_metric_alertrule_webhook_action_1412
+    Webhook_action *[]Azurerm_metric_alertrule_webhook_action_1412
 
 }
 
@@ -8201,8 +7913,6 @@ func (h *Azurerm_metric_alertruleHandler) Delete(externalID string) error {
 
 type Azurerm_monitor_action_group_email_receiver_1413 struct {
 
-    Azurerm_monitor_action_group_email_receiver_1413_id *string `lyra:"ignore"`
-
     Email_address string
 
     Name string
@@ -8210,8 +7920,6 @@ type Azurerm_monitor_action_group_email_receiver_1413 struct {
 }
 
 type Azurerm_monitor_action_group_sms_receiver_1414 struct {
-
-    Azurerm_monitor_action_group_sms_receiver_1414_id *string `lyra:"ignore"`
 
     Country_code string
 
@@ -8223,8 +7931,6 @@ type Azurerm_monitor_action_group_sms_receiver_1414 struct {
 
 type Azurerm_monitor_action_group_webhook_receiver_1415 struct {
 
-    Azurerm_monitor_action_group_webhook_receiver_1415_id *string `lyra:"ignore"`
-
     Name string
 
     Service_uri string
@@ -8235,7 +7941,7 @@ type Azurerm_monitor_action_group struct {
 
     Azurerm_monitor_action_group_id *string `lyra:"ignore"`
 
-    Email_receiver *Azurerm_monitor_action_group_email_receiver_1413
+    Email_receiver *[]Azurerm_monitor_action_group_email_receiver_1413
 
     Enabled *bool
 
@@ -8245,11 +7951,11 @@ type Azurerm_monitor_action_group struct {
 
     Short_name string
 
-    Sms_receiver *Azurerm_monitor_action_group_sms_receiver_1414
+    Sms_receiver *[]Azurerm_monitor_action_group_sms_receiver_1414
 
     Tags *map[string]string
 
-    Webhook_receiver *Azurerm_monitor_action_group_webhook_receiver_1415
+    Webhook_receiver *[]Azurerm_monitor_action_group_webhook_receiver_1415
 
 }
 
@@ -8292,8 +7998,6 @@ func (h *Azurerm_monitor_action_groupHandler) Delete(externalID string) error {
 
 type Azurerm_monitor_activity_log_alert_action_1416 struct {
 
-    Azurerm_monitor_activity_log_alert_action_1416_id *string `lyra:"ignore"`
-
     Action_group_id string
 
     Webhook_properties *map[string]string
@@ -8301,8 +8005,6 @@ type Azurerm_monitor_activity_log_alert_action_1416 struct {
 }
 
 type Azurerm_monitor_activity_log_alert_criteria_1417 struct {
-
-    Azurerm_monitor_activity_log_alert_criteria_1417_id *string `lyra:"ignore"`
 
     Caller *string
 
@@ -8332,7 +8034,7 @@ type Azurerm_monitor_activity_log_alert struct {
 
     Action *Azurerm_monitor_activity_log_alert_action_1416
 
-    Criteria Azurerm_monitor_activity_log_alert_criteria_1417
+    Criteria []Azurerm_monitor_activity_log_alert_criteria_1417
 
     Description *string
 
@@ -8387,8 +8089,6 @@ func (h *Azurerm_monitor_activity_log_alertHandler) Delete(externalID string) er
 
 type Azurerm_monitor_diagnostic_setting_log_1418_retention_policy_1419 struct {
 
-    Azurerm_monitor_diagnostic_setting_log_1418_retention_policy_1419_id *string `lyra:"ignore"`
-
     Days *int
 
     Enabled bool
@@ -8397,19 +8097,15 @@ type Azurerm_monitor_diagnostic_setting_log_1418_retention_policy_1419 struct {
 
 type Azurerm_monitor_diagnostic_setting_log_1418 struct {
 
-    Azurerm_monitor_diagnostic_setting_log_1418_id *string `lyra:"ignore"`
-
     Category string
 
     Enabled *bool
 
-    Retention_policy Azurerm_monitor_diagnostic_setting_log_1418_retention_policy_1419
+    Retention_policy []Azurerm_monitor_diagnostic_setting_log_1418_retention_policy_1419
 
 }
 
 type Azurerm_monitor_diagnostic_setting_metric_1420_retention_policy_1421 struct {
-
-    Azurerm_monitor_diagnostic_setting_metric_1420_retention_policy_1421_id *string `lyra:"ignore"`
 
     Days *int
 
@@ -8419,13 +8115,11 @@ type Azurerm_monitor_diagnostic_setting_metric_1420_retention_policy_1421 struct
 
 type Azurerm_monitor_diagnostic_setting_metric_1420 struct {
 
-    Azurerm_monitor_diagnostic_setting_metric_1420_id *string `lyra:"ignore"`
-
     Category string
 
     Enabled *bool
 
-    Retention_policy Azurerm_monitor_diagnostic_setting_metric_1420_retention_policy_1421
+    Retention_policy []Azurerm_monitor_diagnostic_setting_metric_1420_retention_policy_1421
 
 }
 
@@ -8490,8 +8184,6 @@ func (h *Azurerm_monitor_diagnostic_settingHandler) Delete(externalID string) er
 
 type Azurerm_monitor_log_profile_retention_policy_1422 struct {
 
-    Azurerm_monitor_log_profile_retention_policy_1422_id *string `lyra:"ignore"`
-
     Days *int
 
     Enabled bool
@@ -8508,7 +8200,7 @@ type Azurerm_monitor_log_profile struct {
 
     Name string
 
-    Retention_policy Azurerm_monitor_log_profile_retention_policy_1422
+    Retention_policy []Azurerm_monitor_log_profile_retention_policy_1422
 
     Servicebus_rule_id *string
 
@@ -8555,8 +8247,6 @@ func (h *Azurerm_monitor_log_profileHandler) Delete(externalID string) error {
 
 type Azurerm_monitor_metric_alert_action_1423 struct {
 
-    Azurerm_monitor_metric_alert_action_1423_id *string `lyra:"ignore"`
-
     Action_group_id string
 
     Webhook_properties *map[string]string
@@ -8564,8 +8254,6 @@ type Azurerm_monitor_metric_alert_action_1423 struct {
 }
 
 type Azurerm_monitor_metric_alert_criteria_1424_dimension_1425 struct {
-
-    Azurerm_monitor_metric_alert_criteria_1424_dimension_1425_id *string `lyra:"ignore"`
 
     Name string
 
@@ -8577,11 +8265,9 @@ type Azurerm_monitor_metric_alert_criteria_1424_dimension_1425 struct {
 
 type Azurerm_monitor_metric_alert_criteria_1424 struct {
 
-    Azurerm_monitor_metric_alert_criteria_1424_id *string `lyra:"ignore"`
-
     Aggregation string
 
-    Dimension *Azurerm_monitor_metric_alert_criteria_1424_dimension_1425
+    Dimension *[]Azurerm_monitor_metric_alert_criteria_1424_dimension_1425
 
     Metric_name string
 
@@ -8601,7 +8287,7 @@ type Azurerm_monitor_metric_alert struct {
 
     Auto_mitigate *bool
 
-    Criteria Azurerm_monitor_metric_alert_criteria_1424
+    Criteria []Azurerm_monitor_metric_alert_criteria_1424
 
     Description *string
 
@@ -8662,8 +8348,6 @@ func (h *Azurerm_monitor_metric_alertHandler) Delete(externalID string) error {
 
 type Azurerm_mssql_elasticpool_elastic_pool_properties_1426 struct {
 
-    Azurerm_mssql_elasticpool_elastic_pool_properties_1426_id *string `lyra:"ignore"`
-
     Creation_date *string
 
     License_type *string
@@ -8678,8 +8362,6 @@ type Azurerm_mssql_elasticpool_elastic_pool_properties_1426 struct {
 
 type Azurerm_mssql_elasticpool_per_database_settings_1427 struct {
 
-    Azurerm_mssql_elasticpool_per_database_settings_1427_id *string `lyra:"ignore"`
-
     Max_capacity float64
 
     Min_capacity float64
@@ -8687,8 +8369,6 @@ type Azurerm_mssql_elasticpool_per_database_settings_1427 struct {
 }
 
 type Azurerm_mssql_elasticpool_sku_1428 struct {
-
-    Azurerm_mssql_elasticpool_sku_1428_id *string `lyra:"ignore"`
 
     Capacity int
 
@@ -8704,7 +8384,7 @@ type Azurerm_mssql_elasticpool struct {
 
     Azurerm_mssql_elasticpool_id *string `lyra:"ignore"`
 
-    Elastic_pool_properties *Azurerm_mssql_elasticpool_elastic_pool_properties_1426
+    Elastic_pool_properties *[]Azurerm_mssql_elasticpool_elastic_pool_properties_1426
 
     Location string
 
@@ -8712,13 +8392,13 @@ type Azurerm_mssql_elasticpool struct {
 
     Name string
 
-    Per_database_settings Azurerm_mssql_elasticpool_per_database_settings_1427
+    Per_database_settings []Azurerm_mssql_elasticpool_per_database_settings_1427
 
     Resource_group_name string
 
     Server_name string
 
-    Sku Azurerm_mssql_elasticpool_sku_1428
+    Sku []Azurerm_mssql_elasticpool_sku_1428
 
     Tags *map[string]string
 
@@ -8922,8 +8602,6 @@ func (h *Azurerm_mysql_firewall_ruleHandler) Delete(externalID string) error {
 
 type Azurerm_mysql_server_sku_1429 struct {
 
-    Azurerm_mysql_server_sku_1429_id *string `lyra:"ignore"`
-
     Capacity int
 
     Family string
@@ -8935,8 +8613,6 @@ type Azurerm_mysql_server_sku_1429 struct {
 }
 
 type Azurerm_mysql_server_storage_profile_1430 struct {
-
-    Azurerm_mysql_server_storage_profile_1430_id *string `lyra:"ignore"`
 
     Backup_retention_days *int
 
@@ -8962,11 +8638,11 @@ type Azurerm_mysql_server struct {
 
     Resource_group_name string
 
-    Sku Azurerm_mysql_server_sku_1429
+    Sku []Azurerm_mysql_server_sku_1429
 
     Ssl_enforcement string
 
-    Storage_profile Azurerm_mysql_server_storage_profile_1430
+    Storage_profile []Azurerm_mysql_server_storage_profile_1430
 
     Tags *map[string]string
 
@@ -9064,8 +8740,6 @@ func (h *Azurerm_mysql_virtual_network_ruleHandler) Delete(externalID string) er
 
 type Azurerm_network_interface_ip_configuration_1431 struct {
 
-    Azurerm_network_interface_ip_configuration_1431_id *string `lyra:"ignore"`
-
     Application_gateway_backend_address_pools_ids *[]string
 
     Application_security_group_ids *[]string
@@ -9106,7 +8780,7 @@ type Azurerm_network_interface struct {
 
     Internal_fqdn *string
 
-    Ip_configuration Azurerm_network_interface_ip_configuration_1431
+    Ip_configuration []Azurerm_network_interface_ip_configuration_1431
 
     Location string
 
@@ -9313,8 +8987,6 @@ func (h *Azurerm_network_interface_nat_rule_associationHandler) Delete(externalI
 }
 
 type Azurerm_network_security_group_security_rule_1432 struct {
-
-    Azurerm_network_security_group_security_rule_1432_id *string `lyra:"ignore"`
 
     Access string
 
@@ -9535,8 +9207,6 @@ func (h *Azurerm_network_watcherHandler) Delete(externalID string) error {
 
 type Azurerm_notification_hub_apns_credential_1433 struct {
 
-    Azurerm_notification_hub_apns_credential_1433_id *string `lyra:"ignore"`
-
     Application_mode string
 
     Bundle_id string
@@ -9551,8 +9221,6 @@ type Azurerm_notification_hub_apns_credential_1433 struct {
 
 type Azurerm_notification_hub_gcm_credential_1434 struct {
 
-    Azurerm_notification_hub_gcm_credential_1434_id *string `lyra:"ignore"`
-
     Api_key string
 
 }
@@ -9561,9 +9229,9 @@ type Azurerm_notification_hub struct {
 
     Azurerm_notification_hub_id *string `lyra:"ignore"`
 
-    Apns_credential *Azurerm_notification_hub_apns_credential_1433
+    Apns_credential *[]Azurerm_notification_hub_apns_credential_1433
 
-    Gcm_credential *Azurerm_notification_hub_gcm_credential_1434
+    Gcm_credential *[]Azurerm_notification_hub_gcm_credential_1434
 
     Location string
 
@@ -9675,8 +9343,6 @@ func (h *Azurerm_notification_hub_authorization_ruleHandler) Delete(externalID s
 
 type Azurerm_notification_hub_namespace_sku_1435 struct {
 
-    Azurerm_notification_hub_namespace_sku_1435_id *string `lyra:"ignore"`
-
     Name string
 
 }
@@ -9697,7 +9363,7 @@ type Azurerm_notification_hub_namespace struct {
 
     Servicebus_endpoint *string
 
-    Sku Azurerm_notification_hub_namespace_sku_1435
+    Sku []Azurerm_notification_hub_namespace_sku_1435
 
 }
 
@@ -9740,8 +9406,6 @@ func (h *Azurerm_notification_hub_namespaceHandler) Delete(externalID string) er
 
 type Azurerm_packet_capture_filter_1436 struct {
 
-    Azurerm_packet_capture_filter_1436_id *string `lyra:"ignore"`
-
     Local_ip_address *string
 
     Local_port *string
@@ -9756,8 +9420,6 @@ type Azurerm_packet_capture_filter_1436 struct {
 
 type Azurerm_packet_capture_storage_location_1437 struct {
 
-    Azurerm_packet_capture_storage_location_1437_id *string `lyra:"ignore"`
-
     File_path *string
 
     Storage_account_id *string
@@ -9770,7 +9432,7 @@ type Azurerm_packet_capture struct {
 
     Azurerm_packet_capture_id *string `lyra:"ignore"`
 
-    Filter *Azurerm_packet_capture_filter_1436
+    Filter *[]Azurerm_packet_capture_filter_1436
 
     Maximum_bytes_per_packet *int
 
@@ -9784,7 +9446,7 @@ type Azurerm_packet_capture struct {
 
     Resource_group_name string
 
-    Storage_location Azurerm_packet_capture_storage_location_1437
+    Storage_location []Azurerm_packet_capture_storage_location_1437
 
     Target_resource_id string
 
@@ -9829,8 +9491,6 @@ func (h *Azurerm_packet_captureHandler) Delete(externalID string) error {
 
 type Azurerm_policy_assignment_identity_1438 struct {
 
-    Azurerm_policy_assignment_identity_1438_id *string `lyra:"ignore"`
-
     Principal_id *string
 
     Tenant_id *string
@@ -9847,7 +9507,7 @@ type Azurerm_policy_assignment struct {
 
     Display_name *string
 
-    Identity *Azurerm_policy_assignment_identity_1438
+    Identity *[]Azurerm_policy_assignment_identity_1438
 
     Location *string
 
@@ -10179,8 +9839,6 @@ func (h *Azurerm_postgresql_firewall_ruleHandler) Delete(externalID string) erro
 
 type Azurerm_postgresql_server_sku_1439 struct {
 
-    Azurerm_postgresql_server_sku_1439_id *string `lyra:"ignore"`
-
     Capacity int
 
     Family string
@@ -10192,8 +9850,6 @@ type Azurerm_postgresql_server_sku_1439 struct {
 }
 
 type Azurerm_postgresql_server_storage_profile_1440 struct {
-
-    Azurerm_postgresql_server_storage_profile_1440_id *string `lyra:"ignore"`
 
     Backup_retention_days *int
 
@@ -10219,11 +9875,11 @@ type Azurerm_postgresql_server struct {
 
     Resource_group_name string
 
-    Sku Azurerm_postgresql_server_sku_1439
+    Sku []Azurerm_postgresql_server_sku_1439
 
     Ssl_enforcement string
 
-    Storage_profile Azurerm_postgresql_server_storage_profile_1440
+    Storage_profile []Azurerm_postgresql_server_storage_profile_1440
 
     Tags *map[string]string
 
@@ -10447,8 +10103,6 @@ func (h *Azurerm_recovery_services_protected_vmHandler) Delete(externalID string
 
 type Azurerm_recovery_services_protection_policy_vm_backup_1441 struct {
 
-    Azurerm_recovery_services_protection_policy_vm_backup_1441_id *string `lyra:"ignore"`
-
     Frequency string
 
     Time string
@@ -10459,15 +10113,11 @@ type Azurerm_recovery_services_protection_policy_vm_backup_1441 struct {
 
 type Azurerm_recovery_services_protection_policy_vm_retention_daily_1442 struct {
 
-    Azurerm_recovery_services_protection_policy_vm_retention_daily_1442_id *string `lyra:"ignore"`
-
     Count int
 
 }
 
 type Azurerm_recovery_services_protection_policy_vm_retention_monthly_1443 struct {
-
-    Azurerm_recovery_services_protection_policy_vm_retention_monthly_1443_id *string `lyra:"ignore"`
 
     Count int
 
@@ -10479,8 +10129,6 @@ type Azurerm_recovery_services_protection_policy_vm_retention_monthly_1443 struc
 
 type Azurerm_recovery_services_protection_policy_vm_retention_weekly_1444 struct {
 
-    Azurerm_recovery_services_protection_policy_vm_retention_weekly_1444_id *string `lyra:"ignore"`
-
     Count int
 
     Weekdays []string
@@ -10488,8 +10136,6 @@ type Azurerm_recovery_services_protection_policy_vm_retention_weekly_1444 struct
 }
 
 type Azurerm_recovery_services_protection_policy_vm_retention_yearly_1445 struct {
-
-    Azurerm_recovery_services_protection_policy_vm_retention_yearly_1445_id *string `lyra:"ignore"`
 
     Count int
 
@@ -10505,7 +10151,7 @@ type Azurerm_recovery_services_protection_policy_vm struct {
 
     Azurerm_recovery_services_protection_policy_vm_id *string `lyra:"ignore"`
 
-    Backup Azurerm_recovery_services_protection_policy_vm_backup_1441
+    Backup []Azurerm_recovery_services_protection_policy_vm_backup_1441
 
     Name string
 
@@ -10513,13 +10159,13 @@ type Azurerm_recovery_services_protection_policy_vm struct {
 
     Resource_group_name string
 
-    Retention_daily *Azurerm_recovery_services_protection_policy_vm_retention_daily_1442
+    Retention_daily *[]Azurerm_recovery_services_protection_policy_vm_retention_daily_1442
 
-    Retention_monthly *Azurerm_recovery_services_protection_policy_vm_retention_monthly_1443
+    Retention_monthly *[]Azurerm_recovery_services_protection_policy_vm_retention_monthly_1443
 
-    Retention_weekly *Azurerm_recovery_services_protection_policy_vm_retention_weekly_1444
+    Retention_weekly *[]Azurerm_recovery_services_protection_policy_vm_retention_weekly_1444
 
-    Retention_yearly *Azurerm_recovery_services_protection_policy_vm_retention_yearly_1445
+    Retention_yearly *[]Azurerm_recovery_services_protection_policy_vm_retention_yearly_1445
 
     Tags *map[string]string
 
@@ -10619,8 +10265,6 @@ func (h *Azurerm_recovery_services_vaultHandler) Delete(externalID string) error
 
 type Azurerm_redis_cache_patch_schedule_1446 struct {
 
-    Azurerm_redis_cache_patch_schedule_1446_id *string `lyra:"ignore"`
-
     Day_of_week string
 
     Start_hour_utc *int
@@ -10628,8 +10272,6 @@ type Azurerm_redis_cache_patch_schedule_1446 struct {
 }
 
 type Azurerm_redis_cache_redis_configuration_1447 struct {
-
-    Azurerm_redis_cache_redis_configuration_1447_id *string `lyra:"ignore"`
 
     Maxclients *int
 
@@ -10667,7 +10309,7 @@ type Azurerm_redis_cache struct {
 
     Name string
 
-    Patch_schedule *Azurerm_redis_cache_patch_schedule_1446
+    Patch_schedule *[]Azurerm_redis_cache_patch_schedule_1446
 
     Port *int
 
@@ -10675,7 +10317,7 @@ type Azurerm_redis_cache struct {
 
     Private_static_ip_address *string
 
-    Redis_configuration Azurerm_redis_cache_redis_configuration_1447
+    Redis_configuration []Azurerm_redis_cache_redis_configuration_1447
 
     Resource_group_name string
 
@@ -10787,8 +10429,6 @@ func (h *Azurerm_redis_firewall_ruleHandler) Delete(externalID string) error {
 
 type Azurerm_relay_namespace_sku_1448 struct {
 
-    Azurerm_relay_namespace_sku_1448_id *string `lyra:"ignore"`
-
     Name string
 
 }
@@ -10813,7 +10453,7 @@ type Azurerm_relay_namespace struct {
 
     Secondary_key *string
 
-    Sku Azurerm_relay_namespace_sku_1448
+    Sku []Azurerm_relay_namespace_sku_1448
 
     Tags *map[string]string
 
@@ -10960,8 +10600,6 @@ func (h *Azurerm_role_assignmentHandler) Delete(externalID string) error {
 
 type Azurerm_role_definition_permissions_1449 struct {
 
-    Azurerm_role_definition_permissions_1449_id *string `lyra:"ignore"`
-
     Actions *[]string
 
     Data_actions *[]string
@@ -10982,7 +10620,7 @@ type Azurerm_role_definition struct {
 
     Name string
 
-    Permissions Azurerm_role_definition_permissions_1449
+    Permissions []Azurerm_role_definition_permissions_1449
 
     Role_definition_id *string
 
@@ -11084,8 +10722,6 @@ func (h *Azurerm_routeHandler) Delete(externalID string) error {
 
 type Azurerm_route_table_route_1450 struct {
 
-    Azurerm_route_table_route_1450_id *string `lyra:"ignore"`
-
     Address_prefix string
 
     Name string
@@ -11108,7 +10744,7 @@ type Azurerm_route_table struct {
 
     Resource_group_name string
 
-    Route *Azurerm_route_table_route_1450
+    Route *[]Azurerm_route_table_route_1450
 
     Subnets *[]string
 
@@ -11155,8 +10791,6 @@ func (h *Azurerm_route_tableHandler) Delete(externalID string) error {
 
 type Azurerm_scheduler_job_action_storage_queue_1451 struct {
 
-    Azurerm_scheduler_job_action_storage_queue_1451_id *string `lyra:"ignore"`
-
     Message string
 
     Sas_token string
@@ -11168,8 +10802,6 @@ type Azurerm_scheduler_job_action_storage_queue_1451 struct {
 }
 
 type Azurerm_scheduler_job_action_web_1452_authentication_active_directory_1453 struct {
-
-    Azurerm_scheduler_job_action_web_1452_authentication_active_directory_1453_id *string `lyra:"ignore"`
 
     Audience *string
 
@@ -11183,8 +10815,6 @@ type Azurerm_scheduler_job_action_web_1452_authentication_active_directory_1453 
 
 type Azurerm_scheduler_job_action_web_1452_authentication_basic_1454 struct {
 
-    Azurerm_scheduler_job_action_web_1452_authentication_basic_1454_id *string `lyra:"ignore"`
-
     Password string
 
     Username string
@@ -11192,8 +10822,6 @@ type Azurerm_scheduler_job_action_web_1452_authentication_basic_1454 struct {
 }
 
 type Azurerm_scheduler_job_action_web_1452_authentication_certificate_1455 struct {
-
-    Azurerm_scheduler_job_action_web_1452_authentication_certificate_1455_id *string `lyra:"ignore"`
 
     Expiration *string
 
@@ -11209,13 +10837,11 @@ type Azurerm_scheduler_job_action_web_1452_authentication_certificate_1455 struc
 
 type Azurerm_scheduler_job_action_web_1452 struct {
 
-    Azurerm_scheduler_job_action_web_1452_id *string `lyra:"ignore"`
+    Authentication_active_directory *[]Azurerm_scheduler_job_action_web_1452_authentication_active_directory_1453
 
-    Authentication_active_directory *Azurerm_scheduler_job_action_web_1452_authentication_active_directory_1453
+    Authentication_basic *[]Azurerm_scheduler_job_action_web_1452_authentication_basic_1454
 
-    Authentication_basic *Azurerm_scheduler_job_action_web_1452_authentication_basic_1454
-
-    Authentication_certificate *Azurerm_scheduler_job_action_web_1452_authentication_certificate_1455
+    Authentication_certificate *[]Azurerm_scheduler_job_action_web_1452_authentication_certificate_1455
 
     Body *string
 
@@ -11229,8 +10855,6 @@ type Azurerm_scheduler_job_action_web_1452 struct {
 
 type Azurerm_scheduler_job_error_action_storage_queue_1456 struct {
 
-    Azurerm_scheduler_job_error_action_storage_queue_1456_id *string `lyra:"ignore"`
-
     Message string
 
     Sas_token string
@@ -11242,8 +10866,6 @@ type Azurerm_scheduler_job_error_action_storage_queue_1456 struct {
 }
 
 type Azurerm_scheduler_job_error_action_web_1457_authentication_active_directory_1458 struct {
-
-    Azurerm_scheduler_job_error_action_web_1457_authentication_active_directory_1458_id *string `lyra:"ignore"`
 
     Audience *string
 
@@ -11257,8 +10879,6 @@ type Azurerm_scheduler_job_error_action_web_1457_authentication_active_directory
 
 type Azurerm_scheduler_job_error_action_web_1457_authentication_basic_1459 struct {
 
-    Azurerm_scheduler_job_error_action_web_1457_authentication_basic_1459_id *string `lyra:"ignore"`
-
     Password string
 
     Username string
@@ -11266,8 +10886,6 @@ type Azurerm_scheduler_job_error_action_web_1457_authentication_basic_1459 struc
 }
 
 type Azurerm_scheduler_job_error_action_web_1457_authentication_certificate_1460 struct {
-
-    Azurerm_scheduler_job_error_action_web_1457_authentication_certificate_1460_id *string `lyra:"ignore"`
 
     Expiration *string
 
@@ -11283,13 +10901,11 @@ type Azurerm_scheduler_job_error_action_web_1457_authentication_certificate_1460
 
 type Azurerm_scheduler_job_error_action_web_1457 struct {
 
-    Azurerm_scheduler_job_error_action_web_1457_id *string `lyra:"ignore"`
+    Authentication_active_directory *[]Azurerm_scheduler_job_error_action_web_1457_authentication_active_directory_1458
 
-    Authentication_active_directory *Azurerm_scheduler_job_error_action_web_1457_authentication_active_directory_1458
+    Authentication_basic *[]Azurerm_scheduler_job_error_action_web_1457_authentication_basic_1459
 
-    Authentication_basic *Azurerm_scheduler_job_error_action_web_1457_authentication_basic_1459
-
-    Authentication_certificate *Azurerm_scheduler_job_error_action_web_1457_authentication_certificate_1460
+    Authentication_certificate *[]Azurerm_scheduler_job_error_action_web_1457_authentication_certificate_1460
 
     Body *string
 
@@ -11303,8 +10919,6 @@ type Azurerm_scheduler_job_error_action_web_1457 struct {
 
 type Azurerm_scheduler_job_recurrence_1461_monthly_occurrences_1462 struct {
 
-    Azurerm_scheduler_job_recurrence_1461_monthly_occurrences_1462_id *string `lyra:"ignore"`
-
     Day string
 
     Occurrence int
@@ -11312,8 +10926,6 @@ type Azurerm_scheduler_job_recurrence_1461_monthly_occurrences_1462 struct {
 }
 
 type Azurerm_scheduler_job_recurrence_1461 struct {
-
-    Azurerm_scheduler_job_recurrence_1461_id *string `lyra:"ignore"`
 
     Count *int
 
@@ -11337,8 +10949,6 @@ type Azurerm_scheduler_job_recurrence_1461 struct {
 
 type Azurerm_scheduler_job_retry_1463 struct {
 
-    Azurerm_scheduler_job_retry_1463_id *string `lyra:"ignore"`
-
     Count *int
 
     Interval *string
@@ -11349,23 +10959,23 @@ type Azurerm_scheduler_job struct {
 
     Azurerm_scheduler_job_id *string `lyra:"ignore"`
 
-    Action_storage_queue *Azurerm_scheduler_job_action_storage_queue_1451
+    Action_storage_queue *[]Azurerm_scheduler_job_action_storage_queue_1451
 
-    Action_web *Azurerm_scheduler_job_action_web_1452
+    Action_web *[]Azurerm_scheduler_job_action_web_1452
 
-    Error_action_storage_queue *Azurerm_scheduler_job_error_action_storage_queue_1456
+    Error_action_storage_queue *[]Azurerm_scheduler_job_error_action_storage_queue_1456
 
-    Error_action_web *Azurerm_scheduler_job_error_action_web_1457
+    Error_action_web *[]Azurerm_scheduler_job_error_action_web_1457
 
     Job_collection_name string
 
     Name string
 
-    Recurrence *Azurerm_scheduler_job_recurrence_1461
+    Recurrence *[]Azurerm_scheduler_job_recurrence_1461
 
     Resource_group_name string
 
-    Retry *Azurerm_scheduler_job_retry_1463
+    Retry *[]Azurerm_scheduler_job_retry_1463
 
     Start_time *string
 
@@ -11412,8 +11022,6 @@ func (h *Azurerm_scheduler_jobHandler) Delete(externalID string) error {
 
 type Azurerm_scheduler_job_collection_quota_1464 struct {
 
-    Azurerm_scheduler_job_collection_quota_1464_id *string `lyra:"ignore"`
-
     Max_job_count *int
 
     Max_recurrence_frequency string
@@ -11432,7 +11040,7 @@ type Azurerm_scheduler_job_collection struct {
 
     Name string
 
-    Quota *Azurerm_scheduler_job_collection_quota_1464
+    Quota *[]Azurerm_scheduler_job_collection_quota_1464
 
     Resource_group_name string
 
@@ -11687,8 +11295,6 @@ func (h *Azurerm_security_center_workspaceHandler) Delete(externalID string) err
 
 type Azurerm_service_fabric_cluster_azure_active_directory_1465 struct {
 
-    Azurerm_service_fabric_cluster_azure_active_directory_1465_id *string `lyra:"ignore"`
-
     Client_application_id string
 
     Cluster_application_id string
@@ -11698,8 +11304,6 @@ type Azurerm_service_fabric_cluster_azure_active_directory_1465 struct {
 }
 
 type Azurerm_service_fabric_cluster_certificate_1466 struct {
-
-    Azurerm_service_fabric_cluster_certificate_1466_id *string `lyra:"ignore"`
 
     Thumbprint string
 
@@ -11711,8 +11315,6 @@ type Azurerm_service_fabric_cluster_certificate_1466 struct {
 
 type Azurerm_service_fabric_cluster_client_certificate_thumbprint_1467 struct {
 
-    Azurerm_service_fabric_cluster_client_certificate_thumbprint_1467_id *string `lyra:"ignore"`
-
     Is_admin bool
 
     Thumbprint string
@@ -11720,8 +11322,6 @@ type Azurerm_service_fabric_cluster_client_certificate_thumbprint_1467 struct {
 }
 
 type Azurerm_service_fabric_cluster_diagnostics_config_1468 struct {
-
-    Azurerm_service_fabric_cluster_diagnostics_config_1468_id *string `lyra:"ignore"`
 
     Blob_endpoint string
 
@@ -11737,8 +11337,6 @@ type Azurerm_service_fabric_cluster_diagnostics_config_1468 struct {
 
 type Azurerm_service_fabric_cluster_fabric_settings_1469 struct {
 
-    Azurerm_service_fabric_cluster_fabric_settings_1469_id *string `lyra:"ignore"`
-
     Name string
 
     Parameters *map[string]string
@@ -11746,8 +11344,6 @@ type Azurerm_service_fabric_cluster_fabric_settings_1469 struct {
 }
 
 type Azurerm_service_fabric_cluster_node_type_1470_application_ports_1471 struct {
-
-    Azurerm_service_fabric_cluster_node_type_1470_application_ports_1471_id *string `lyra:"ignore"`
 
     End_port int
 
@@ -11757,8 +11353,6 @@ type Azurerm_service_fabric_cluster_node_type_1470_application_ports_1471 struct
 
 type Azurerm_service_fabric_cluster_node_type_1470_ephemeral_ports_1472 struct {
 
-    Azurerm_service_fabric_cluster_node_type_1470_ephemeral_ports_1472_id *string `lyra:"ignore"`
-
     End_port int
 
     Start_port int
@@ -11767,15 +11361,13 @@ type Azurerm_service_fabric_cluster_node_type_1470_ephemeral_ports_1472 struct {
 
 type Azurerm_service_fabric_cluster_node_type_1470 struct {
 
-    Azurerm_service_fabric_cluster_node_type_1470_id *string `lyra:"ignore"`
-
-    Application_ports *Azurerm_service_fabric_cluster_node_type_1470_application_ports_1471
+    Application_ports *[]Azurerm_service_fabric_cluster_node_type_1470_application_ports_1471
 
     Client_endpoint_port int
 
     Durability_level *string
 
-    Ephemeral_ports *Azurerm_service_fabric_cluster_node_type_1470_ephemeral_ports_1472
+    Ephemeral_ports *[]Azurerm_service_fabric_cluster_node_type_1470_ephemeral_ports_1472
 
     Http_endpoint_port int
 
@@ -11791,8 +11383,6 @@ type Azurerm_service_fabric_cluster_node_type_1470 struct {
 
 type Azurerm_service_fabric_cluster_reverse_proxy_certificate_1473 struct {
 
-    Azurerm_service_fabric_cluster_reverse_proxy_certificate_1473_id *string `lyra:"ignore"`
-
     Thumbprint string
 
     Thumbprint_secondary *string
@@ -11807,19 +11397,19 @@ type Azurerm_service_fabric_cluster struct {
 
     Add_on_features *[]string
 
-    Azure_active_directory *Azurerm_service_fabric_cluster_azure_active_directory_1465
+    Azure_active_directory *[]Azurerm_service_fabric_cluster_azure_active_directory_1465
 
-    Certificate *Azurerm_service_fabric_cluster_certificate_1466
+    Certificate *[]Azurerm_service_fabric_cluster_certificate_1466
 
-    Client_certificate_thumbprint *Azurerm_service_fabric_cluster_client_certificate_thumbprint_1467
+    Client_certificate_thumbprint *[]Azurerm_service_fabric_cluster_client_certificate_thumbprint_1467
 
     Cluster_code_version *string
 
     Cluster_endpoint *string
 
-    Diagnostics_config *Azurerm_service_fabric_cluster_diagnostics_config_1468
+    Diagnostics_config *[]Azurerm_service_fabric_cluster_diagnostics_config_1468
 
-    Fabric_settings *Azurerm_service_fabric_cluster_fabric_settings_1469
+    Fabric_settings *[]Azurerm_service_fabric_cluster_fabric_settings_1469
 
     Location string
 
@@ -11827,13 +11417,13 @@ type Azurerm_service_fabric_cluster struct {
 
     Name string
 
-    Node_type Azurerm_service_fabric_cluster_node_type_1470
+    Node_type []Azurerm_service_fabric_cluster_node_type_1470
 
     Reliability_level string
 
     Resource_group_name string
 
-    Reverse_proxy_certificate *Azurerm_service_fabric_cluster_reverse_proxy_certificate_1473
+    Reverse_proxy_certificate *[]Azurerm_service_fabric_cluster_reverse_proxy_certificate_1473
 
     Tags *map[string]string
 
@@ -12221,8 +11811,6 @@ func (h *Azurerm_servicebus_subscriptionHandler) Delete(externalID string) error
 
 type Azurerm_servicebus_subscription_rule_correlation_filter_1474 struct {
 
-    Azurerm_servicebus_subscription_rule_correlation_filter_1474_id *string `lyra:"ignore"`
-
     Content_type *string
 
     Correlation_id *string
@@ -12247,7 +11835,7 @@ type Azurerm_servicebus_subscription_rule struct {
 
     Action *string
 
-    Correlation_filter *Azurerm_servicebus_subscription_rule_correlation_filter_1474
+    Correlation_filter *[]Azurerm_servicebus_subscription_rule_correlation_filter_1474
 
     Filter_type string
 
@@ -12442,8 +12030,6 @@ func (h *Azurerm_servicebus_topic_authorization_ruleHandler) Delete(externalID s
 
 type Azurerm_shared_image_identifier_1475 struct {
 
-    Azurerm_shared_image_identifier_1475_id *string `lyra:"ignore"`
-
     Offer string
 
     Publisher string
@@ -12462,7 +12048,7 @@ type Azurerm_shared_image struct {
 
     Gallery_name string
 
-    Identifier Azurerm_shared_image_identifier_1475
+    Identifier []Azurerm_shared_image_identifier_1475
 
     Location string
 
@@ -12574,8 +12160,6 @@ func (h *Azurerm_shared_image_galleryHandler) Delete(externalID string) error {
 
 type Azurerm_shared_image_version_target_region_1476 struct {
 
-    Azurerm_shared_image_version_target_region_1476_id *string `lyra:"ignore"`
-
     Name string
 
     Regional_replica_count int
@@ -12645,8 +12229,6 @@ func (h *Azurerm_shared_image_versionHandler) Delete(externalID string) error {
 
 type Azurerm_signalr_service_sku_1477 struct {
 
-    Azurerm_signalr_service_sku_1477_id *string `lyra:"ignore"`
-
     Capacity int
 
     Name string
@@ -12671,7 +12253,7 @@ type Azurerm_signalr_service struct {
 
     Server_port *int
 
-    Sku Azurerm_signalr_service_sku_1477
+    Sku []Azurerm_signalr_service_sku_1477
 
     Tags *map[string]string
 
@@ -12716,8 +12298,6 @@ func (h *Azurerm_signalr_serviceHandler) Delete(externalID string) error {
 
 type Azurerm_snapshot_encryption_settings_1478_disk_encryption_key_1479 struct {
 
-    Azurerm_snapshot_encryption_settings_1478_disk_encryption_key_1479_id *string `lyra:"ignore"`
-
     Secret_url string
 
     Source_vault_id string
@@ -12725,8 +12305,6 @@ type Azurerm_snapshot_encryption_settings_1478_disk_encryption_key_1479 struct {
 }
 
 type Azurerm_snapshot_encryption_settings_1478_key_encryption_key_1480 struct {
-
-    Azurerm_snapshot_encryption_settings_1478_key_encryption_key_1480_id *string `lyra:"ignore"`
 
     Key_url string
 
@@ -12736,13 +12314,11 @@ type Azurerm_snapshot_encryption_settings_1478_key_encryption_key_1480 struct {
 
 type Azurerm_snapshot_encryption_settings_1478 struct {
 
-    Azurerm_snapshot_encryption_settings_1478_id *string `lyra:"ignore"`
-
-    Disk_encryption_key *Azurerm_snapshot_encryption_settings_1478_disk_encryption_key_1479
+    Disk_encryption_key *[]Azurerm_snapshot_encryption_settings_1478_disk_encryption_key_1479
 
     Enabled bool
 
-    Key_encryption_key *Azurerm_snapshot_encryption_settings_1478_key_encryption_key_1480
+    Key_encryption_key *[]Azurerm_snapshot_encryption_settings_1478_key_encryption_key_1480
 
 }
 
@@ -12754,7 +12330,7 @@ type Azurerm_snapshot struct {
 
     Disk_size_gb *int
 
-    Encryption_settings *Azurerm_snapshot_encryption_settings_1478
+    Encryption_settings *[]Azurerm_snapshot_encryption_settings_1478
 
     Location string
 
@@ -12864,8 +12440,6 @@ func (h *Azurerm_sql_active_directory_administratorHandler) Delete(externalID st
 
 type Azurerm_sql_database_import_1481 struct {
 
-    Azurerm_sql_database_import_1481_id *string `lyra:"ignore"`
-
     Administrator_login string
 
     Administrator_login_password string
@@ -12883,8 +12457,6 @@ type Azurerm_sql_database_import_1481 struct {
 }
 
 type Azurerm_sql_database_threat_detection_policy_1482 struct {
-
-    Azurerm_sql_database_threat_detection_policy_1482_id *string `lyra:"ignore"`
 
     Disabled_alerts *[]string
 
@@ -12922,7 +12494,7 @@ type Azurerm_sql_database struct {
 
     Encryption *string
 
-    Import *Azurerm_sql_database_import_1481
+    Import *[]Azurerm_sql_database_import_1481
 
     Location string
 
@@ -12946,7 +12518,7 @@ type Azurerm_sql_database struct {
 
     Tags *map[string]string
 
-    Threat_detection_policy *Azurerm_sql_database_threat_detection_policy_1482
+    Threat_detection_policy *[]Azurerm_sql_database_threat_detection_policy_1482
 
 }
 
@@ -13219,8 +12791,6 @@ func (h *Azurerm_sql_virtual_network_ruleHandler) Delete(externalID string) erro
 
 type Azurerm_storage_account_custom_domain_1483 struct {
 
-    Azurerm_storage_account_custom_domain_1483_id *string `lyra:"ignore"`
-
     Name string
 
     Use_subdomain *bool
@@ -13228,8 +12798,6 @@ type Azurerm_storage_account_custom_domain_1483 struct {
 }
 
 type Azurerm_storage_account_identity_1484 struct {
-
-    Azurerm_storage_account_identity_1484_id *string `lyra:"ignore"`
 
     Principal_id *string
 
@@ -13240,8 +12808,6 @@ type Azurerm_storage_account_identity_1484 struct {
 }
 
 type Azurerm_storage_account_network_rules_1485 struct {
-
-    Azurerm_storage_account_network_rules_1485_id *string `lyra:"ignore"`
 
     Bypass *[]string
 
@@ -13267,7 +12833,7 @@ type Azurerm_storage_account struct {
 
     Account_type *string
 
-    Custom_domain *Azurerm_storage_account_custom_domain_1483
+    Custom_domain *[]Azurerm_storage_account_custom_domain_1483
 
     Enable_blob_encryption *bool
 
@@ -13275,13 +12841,13 @@ type Azurerm_storage_account struct {
 
     Enable_https_traffic_only *bool
 
-    Identity *Azurerm_storage_account_identity_1484
+    Identity *[]Azurerm_storage_account_identity_1484
 
     Location string
 
     Name string
 
-    Network_rules *Azurerm_storage_account_network_rules_1485
+    Network_rules *[]Azurerm_storage_account_network_rules_1485
 
     Primary_access_key *string
 
@@ -13629,8 +13195,6 @@ func (h *Azurerm_storage_tableHandler) Delete(externalID string) error {
 
 type Azurerm_subnet_delegation_1486_service_delegation_1487 struct {
 
-    Azurerm_subnet_delegation_1486_service_delegation_1487_id *string `lyra:"ignore"`
-
     Actions *[]string
 
     Name string
@@ -13639,11 +13203,9 @@ type Azurerm_subnet_delegation_1486_service_delegation_1487 struct {
 
 type Azurerm_subnet_delegation_1486 struct {
 
-    Azurerm_subnet_delegation_1486_id *string `lyra:"ignore"`
-
     Name string
 
-    Service_delegation Azurerm_subnet_delegation_1486_service_delegation_1487
+    Service_delegation []Azurerm_subnet_delegation_1486_service_delegation_1487
 
 }
 
@@ -13653,7 +13215,7 @@ type Azurerm_subnet struct {
 
     Address_prefix string
 
-    Delegation *Azurerm_subnet_delegation_1486
+    Delegation *[]Azurerm_subnet_delegation_1486
 
     Ip_configurations *[]string
 
@@ -13930,8 +13492,6 @@ func (h *Azurerm_traffic_manager_endpointHandler) Delete(externalID string) erro
 
 type Azurerm_traffic_manager_profile_dns_config_1488 struct {
 
-    Azurerm_traffic_manager_profile_dns_config_1488_id *string `lyra:"ignore"`
-
     Relative_name string
 
     Ttl int
@@ -13939,8 +13499,6 @@ type Azurerm_traffic_manager_profile_dns_config_1488 struct {
 }
 
 type Azurerm_traffic_manager_profile_monitor_config_1489 struct {
-
-    Azurerm_traffic_manager_profile_monitor_config_1489_id *string `lyra:"ignore"`
 
     Path *string
 
@@ -14066,8 +13624,6 @@ func (h *Azurerm_user_assigned_identityHandler) Delete(externalID string) error 
 
 type Azurerm_virtual_machine_boot_diagnostics_1490 struct {
 
-    Azurerm_virtual_machine_boot_diagnostics_1490_id *string `lyra:"ignore"`
-
     Enabled bool
 
     Storage_uri string
@@ -14075,8 +13631,6 @@ type Azurerm_virtual_machine_boot_diagnostics_1490 struct {
 }
 
 type Azurerm_virtual_machine_identity_1491 struct {
-
-    Azurerm_virtual_machine_identity_1491_id *string `lyra:"ignore"`
 
     Identity_ids *[]string
 
@@ -14087,8 +13641,6 @@ type Azurerm_virtual_machine_identity_1491 struct {
 }
 
 type Azurerm_virtual_machine_os_profile_1492 struct {
-
-    Azurerm_virtual_machine_os_profile_1492_id *string `lyra:"ignore"`
 
     Admin_password *string
 
@@ -14102,8 +13654,6 @@ type Azurerm_virtual_machine_os_profile_1492 struct {
 
 type Azurerm_virtual_machine_os_profile_linux_config_1493_ssh_keys_1494 struct {
 
-    Azurerm_virtual_machine_os_profile_linux_config_1493_ssh_keys_1494_id *string `lyra:"ignore"`
-
     Key_data string
 
     Path string
@@ -14112,17 +13662,13 @@ type Azurerm_virtual_machine_os_profile_linux_config_1493_ssh_keys_1494 struct {
 
 type Azurerm_virtual_machine_os_profile_linux_config_1493 struct {
 
-    Azurerm_virtual_machine_os_profile_linux_config_1493_id *string `lyra:"ignore"`
-
     Disable_password_authentication bool
 
-    Ssh_keys *Azurerm_virtual_machine_os_profile_linux_config_1493_ssh_keys_1494
+    Ssh_keys *[]Azurerm_virtual_machine_os_profile_linux_config_1493_ssh_keys_1494
 
 }
 
 type Azurerm_virtual_machine_os_profile_secrets_1495_vault_certificates_1496 struct {
-
-    Azurerm_virtual_machine_os_profile_secrets_1495_vault_certificates_1496_id *string `lyra:"ignore"`
 
     Certificate_store *string
 
@@ -14132,17 +13678,13 @@ type Azurerm_virtual_machine_os_profile_secrets_1495_vault_certificates_1496 str
 
 type Azurerm_virtual_machine_os_profile_secrets_1495 struct {
 
-    Azurerm_virtual_machine_os_profile_secrets_1495_id *string `lyra:"ignore"`
-
     Source_vault_id string
 
-    Vault_certificates *Azurerm_virtual_machine_os_profile_secrets_1495_vault_certificates_1496
+    Vault_certificates *[]Azurerm_virtual_machine_os_profile_secrets_1495_vault_certificates_1496
 
 }
 
 type Azurerm_virtual_machine_os_profile_windows_config_1497_additional_unattend_config_1498 struct {
-
-    Azurerm_virtual_machine_os_profile_windows_config_1497_additional_unattend_config_1498_id *string `lyra:"ignore"`
 
     Component string
 
@@ -14156,8 +13698,6 @@ type Azurerm_virtual_machine_os_profile_windows_config_1497_additional_unattend_
 
 type Azurerm_virtual_machine_os_profile_windows_config_1497_winrm_1499 struct {
 
-    Azurerm_virtual_machine_os_profile_windows_config_1497_winrm_1499_id *string `lyra:"ignore"`
-
     Certificate_url *string
 
     Protocol string
@@ -14166,9 +13706,7 @@ type Azurerm_virtual_machine_os_profile_windows_config_1497_winrm_1499 struct {
 
 type Azurerm_virtual_machine_os_profile_windows_config_1497 struct {
 
-    Azurerm_virtual_machine_os_profile_windows_config_1497_id *string `lyra:"ignore"`
-
-    Additional_unattend_config *Azurerm_virtual_machine_os_profile_windows_config_1497_additional_unattend_config_1498
+    Additional_unattend_config *[]Azurerm_virtual_machine_os_profile_windows_config_1497_additional_unattend_config_1498
 
     Enable_automatic_upgrades *bool
 
@@ -14176,13 +13714,11 @@ type Azurerm_virtual_machine_os_profile_windows_config_1497 struct {
 
     Timezone *string
 
-    Winrm *Azurerm_virtual_machine_os_profile_windows_config_1497_winrm_1499
+    Winrm *[]Azurerm_virtual_machine_os_profile_windows_config_1497_winrm_1499
 
 }
 
 type Azurerm_virtual_machine_plan_1500 struct {
-
-    Azurerm_virtual_machine_plan_1500_id *string `lyra:"ignore"`
 
     Name string
 
@@ -14193,8 +13729,6 @@ type Azurerm_virtual_machine_plan_1500 struct {
 }
 
 type Azurerm_virtual_machine_storage_data_disk_1501 struct {
-
-    Azurerm_virtual_machine_storage_data_disk_1501_id *string `lyra:"ignore"`
 
     Caching *string
 
@@ -14218,8 +13752,6 @@ type Azurerm_virtual_machine_storage_data_disk_1501 struct {
 
 type Azurerm_virtual_machine_storage_image_reference_1502 struct {
 
-    Azurerm_virtual_machine_storage_image_reference_1502_id *string `lyra:"ignore"`
-
     Id *string
 
     Offer *string
@@ -14233,8 +13765,6 @@ type Azurerm_virtual_machine_storage_image_reference_1502 struct {
 }
 
 type Azurerm_virtual_machine_storage_os_disk_1503 struct {
-
-    Azurerm_virtual_machine_storage_os_disk_1503_id *string `lyra:"ignore"`
 
     Caching *string
 
@@ -14264,13 +13794,13 @@ type Azurerm_virtual_machine struct {
 
     Availability_set_id *string
 
-    Boot_diagnostics *Azurerm_virtual_machine_boot_diagnostics_1490
+    Boot_diagnostics *[]Azurerm_virtual_machine_boot_diagnostics_1490
 
     Delete_data_disks_on_termination *bool
 
     Delete_os_disk_on_termination *bool
 
-    Identity *Azurerm_virtual_machine_identity_1491
+    Identity *[]Azurerm_virtual_machine_identity_1491
 
     License_type *string
 
@@ -14284,21 +13814,21 @@ type Azurerm_virtual_machine struct {
 
     Os_profile_linux_config *Azurerm_virtual_machine_os_profile_linux_config_1493
 
-    Os_profile_secrets *Azurerm_virtual_machine_os_profile_secrets_1495
+    Os_profile_secrets *[]Azurerm_virtual_machine_os_profile_secrets_1495
 
     Os_profile_windows_config *Azurerm_virtual_machine_os_profile_windows_config_1497
 
-    Plan *Azurerm_virtual_machine_plan_1500
+    Plan *[]Azurerm_virtual_machine_plan_1500
 
     Primary_network_interface_id *string
 
     Resource_group_name string
 
-    Storage_data_disk *Azurerm_virtual_machine_storage_data_disk_1501
+    Storage_data_disk *[]Azurerm_virtual_machine_storage_data_disk_1501
 
     Storage_image_reference *Azurerm_virtual_machine_storage_image_reference_1502
 
-    Storage_os_disk Azurerm_virtual_machine_storage_os_disk_1503
+    Storage_os_disk []Azurerm_virtual_machine_storage_os_disk_1503
 
     Tags *map[string]string
 
@@ -14467,8 +13997,6 @@ func (h *Azurerm_virtual_machine_extensionHandler) Delete(externalID string) err
 
 type Azurerm_virtual_machine_scale_set_boot_diagnostics_1504 struct {
 
-    Azurerm_virtual_machine_scale_set_boot_diagnostics_1504_id *string `lyra:"ignore"`
-
     Enabled *bool
 
     Storage_uri string
@@ -14476,8 +14004,6 @@ type Azurerm_virtual_machine_scale_set_boot_diagnostics_1504 struct {
 }
 
 type Azurerm_virtual_machine_scale_set_extension_1505 struct {
-
-    Azurerm_virtual_machine_scale_set_extension_1505_id *string `lyra:"ignore"`
 
     Auto_upgrade_minor_version *bool
 
@@ -14497,8 +14023,6 @@ type Azurerm_virtual_machine_scale_set_extension_1505 struct {
 
 type Azurerm_virtual_machine_scale_set_identity_1506 struct {
 
-    Azurerm_virtual_machine_scale_set_identity_1506_id *string `lyra:"ignore"`
-
     Identity_ids *[]string
 
     Principal_id *string
@@ -14509,15 +14033,11 @@ type Azurerm_virtual_machine_scale_set_identity_1506 struct {
 
 type Azurerm_virtual_machine_scale_set_network_profile_1507_dns_settings_1508 struct {
 
-    Azurerm_virtual_machine_scale_set_network_profile_1507_dns_settings_1508_id *string `lyra:"ignore"`
-
     Dns_servers []string
 
 }
 
 type Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509_public_ip_address_configuration_1510 struct {
-
-    Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509_public_ip_address_configuration_1510_id *string `lyra:"ignore"`
 
     Domain_name_label string
 
@@ -14528,8 +14048,6 @@ type Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_150
 }
 
 type Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509 struct {
-
-    Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509_id *string `lyra:"ignore"`
 
     Application_gateway_backend_address_pool_ids *[]string
 
@@ -14543,7 +14061,7 @@ type Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_150
 
     Primary bool
 
-    Public_ip_address_configuration *Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509_public_ip_address_configuration_1510
+    Public_ip_address_configuration *[]Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509_public_ip_address_configuration_1510
 
     Subnet_id string
 
@@ -14551,13 +14069,11 @@ type Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_150
 
 type Azurerm_virtual_machine_scale_set_network_profile_1507 struct {
 
-    Azurerm_virtual_machine_scale_set_network_profile_1507_id *string `lyra:"ignore"`
-
     Accelerated_networking *bool
 
-    Dns_settings *Azurerm_virtual_machine_scale_set_network_profile_1507_dns_settings_1508
+    Dns_settings *[]Azurerm_virtual_machine_scale_set_network_profile_1507_dns_settings_1508
 
-    Ip_configuration Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509
+    Ip_configuration []Azurerm_virtual_machine_scale_set_network_profile_1507_ip_configuration_1509
 
     Ip_forwarding *bool
 
@@ -14571,8 +14087,6 @@ type Azurerm_virtual_machine_scale_set_network_profile_1507 struct {
 
 type Azurerm_virtual_machine_scale_set_os_profile_1511 struct {
 
-    Azurerm_virtual_machine_scale_set_os_profile_1511_id *string `lyra:"ignore"`
-
     Admin_password *string
 
     Admin_username string
@@ -14585,8 +14099,6 @@ type Azurerm_virtual_machine_scale_set_os_profile_1511 struct {
 
 type Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512_ssh_keys_1513 struct {
 
-    Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512_ssh_keys_1513_id *string `lyra:"ignore"`
-
     Key_data *string
 
     Path string
@@ -14595,17 +14107,13 @@ type Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512_ssh_keys_151
 
 type Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512 struct {
 
-    Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512_id *string `lyra:"ignore"`
-
     Disable_password_authentication *bool
 
-    Ssh_keys *Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512_ssh_keys_1513
+    Ssh_keys *[]Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512_ssh_keys_1513
 
 }
 
 type Azurerm_virtual_machine_scale_set_os_profile_secrets_1514_vault_certificates_1515 struct {
-
-    Azurerm_virtual_machine_scale_set_os_profile_secrets_1514_vault_certificates_1515_id *string `lyra:"ignore"`
 
     Certificate_store *string
 
@@ -14615,17 +14123,13 @@ type Azurerm_virtual_machine_scale_set_os_profile_secrets_1514_vault_certificate
 
 type Azurerm_virtual_machine_scale_set_os_profile_secrets_1514 struct {
 
-    Azurerm_virtual_machine_scale_set_os_profile_secrets_1514_id *string `lyra:"ignore"`
-
     Source_vault_id string
 
-    Vault_certificates *Azurerm_virtual_machine_scale_set_os_profile_secrets_1514_vault_certificates_1515
+    Vault_certificates *[]Azurerm_virtual_machine_scale_set_os_profile_secrets_1514_vault_certificates_1515
 
 }
 
 type Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_additional_unattend_config_1517 struct {
-
-    Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_additional_unattend_config_1517_id *string `lyra:"ignore"`
 
     Component string
 
@@ -14639,8 +14143,6 @@ type Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_additional
 
 type Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_winrm_1518 struct {
 
-    Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_winrm_1518_id *string `lyra:"ignore"`
-
     Certificate_url *string
 
     Protocol string
@@ -14649,21 +14151,17 @@ type Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_winrm_1518
 
 type Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516 struct {
 
-    Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_id *string `lyra:"ignore"`
-
-    Additional_unattend_config *Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_additional_unattend_config_1517
+    Additional_unattend_config *[]Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_additional_unattend_config_1517
 
     Enable_automatic_upgrades *bool
 
     Provision_vm_agent *bool
 
-    Winrm *Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_winrm_1518
+    Winrm *[]Azurerm_virtual_machine_scale_set_os_profile_windows_config_1516_winrm_1518
 
 }
 
 type Azurerm_virtual_machine_scale_set_plan_1519 struct {
-
-    Azurerm_virtual_machine_scale_set_plan_1519_id *string `lyra:"ignore"`
 
     Name string
 
@@ -14674,8 +14172,6 @@ type Azurerm_virtual_machine_scale_set_plan_1519 struct {
 }
 
 type Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_1520 struct {
-
-    Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_1520_id *string `lyra:"ignore"`
 
     Max_batch_instance_percent *int
 
@@ -14689,8 +14185,6 @@ type Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_1520 struct {
 
 type Azurerm_virtual_machine_scale_set_sku_1521 struct {
 
-    Azurerm_virtual_machine_scale_set_sku_1521_id *string `lyra:"ignore"`
-
     Capacity int
 
     Name string
@@ -14700,8 +14194,6 @@ type Azurerm_virtual_machine_scale_set_sku_1521 struct {
 }
 
 type Azurerm_virtual_machine_scale_set_storage_profile_data_disk_1522 struct {
-
-    Azurerm_virtual_machine_scale_set_storage_profile_data_disk_1522_id *string `lyra:"ignore"`
 
     Caching *string
 
@@ -14717,8 +14209,6 @@ type Azurerm_virtual_machine_scale_set_storage_profile_data_disk_1522 struct {
 
 type Azurerm_virtual_machine_scale_set_storage_profile_image_reference_1523 struct {
 
-    Azurerm_virtual_machine_scale_set_storage_profile_image_reference_1523_id *string `lyra:"ignore"`
-
     Id *string
 
     Offer *string
@@ -14732,8 +14222,6 @@ type Azurerm_virtual_machine_scale_set_storage_profile_image_reference_1523 stru
 }
 
 type Azurerm_virtual_machine_scale_set_storage_profile_os_disk_1524 struct {
-
-    Azurerm_virtual_machine_scale_set_storage_profile_os_disk_1524_id *string `lyra:"ignore"`
 
     Caching *string
 
@@ -14757,7 +14245,7 @@ type Azurerm_virtual_machine_scale_set struct {
 
     Automatic_os_upgrade *bool
 
-    Boot_diagnostics *Azurerm_virtual_machine_scale_set_boot_diagnostics_1504
+    Boot_diagnostics *[]Azurerm_virtual_machine_scale_set_boot_diagnostics_1504
 
     Eviction_policy *string
 
@@ -14765,7 +14253,7 @@ type Azurerm_virtual_machine_scale_set struct {
 
     Health_probe_id *string
 
-    Identity *Azurerm_virtual_machine_scale_set_identity_1506
+    Identity *[]Azurerm_virtual_machine_scale_set_identity_1506
 
     License_type *string
 
@@ -14775,7 +14263,7 @@ type Azurerm_virtual_machine_scale_set struct {
 
     Network_profile Azurerm_virtual_machine_scale_set_network_profile_1507
 
-    Os_profile Azurerm_virtual_machine_scale_set_os_profile_1511
+    Os_profile []Azurerm_virtual_machine_scale_set_os_profile_1511
 
     Os_profile_linux_config *Azurerm_virtual_machine_scale_set_os_profile_linux_config_1512
 
@@ -14791,13 +14279,13 @@ type Azurerm_virtual_machine_scale_set struct {
 
     Resource_group_name string
 
-    Rolling_upgrade_policy *Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_1520
+    Rolling_upgrade_policy *[]Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_1520
 
     Single_placement_group *bool
 
-    Sku Azurerm_virtual_machine_scale_set_sku_1521
+    Sku []Azurerm_virtual_machine_scale_set_sku_1521
 
-    Storage_profile_data_disk *Azurerm_virtual_machine_scale_set_storage_profile_data_disk_1522
+    Storage_profile_data_disk *[]Azurerm_virtual_machine_scale_set_storage_profile_data_disk_1522
 
     Storage_profile_image_reference *Azurerm_virtual_machine_scale_set_storage_profile_image_reference_1523
 
@@ -14849,8 +14337,6 @@ func (h *Azurerm_virtual_machine_scale_setHandler) Delete(externalID string) err
 }
 
 type Azurerm_virtual_network_subnet_1525 struct {
-
-    Azurerm_virtual_network_subnet_1525_id *string `lyra:"ignore"`
 
     Address_prefix string
 
@@ -14921,8 +14407,6 @@ func (h *Azurerm_virtual_networkHandler) Delete(externalID string) error {
 
 type Azurerm_virtual_network_gateway_bgp_settings_1526 struct {
 
-    Azurerm_virtual_network_gateway_bgp_settings_1526_id *string `lyra:"ignore"`
-
     Asn *int
 
     Peer_weight *int
@@ -14932,8 +14416,6 @@ type Azurerm_virtual_network_gateway_bgp_settings_1526 struct {
 }
 
 type Azurerm_virtual_network_gateway_ip_configuration_1527 struct {
-
-    Azurerm_virtual_network_gateway_ip_configuration_1527_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -14947,8 +14429,6 @@ type Azurerm_virtual_network_gateway_ip_configuration_1527 struct {
 
 type Azurerm_virtual_network_gateway_vpn_client_configuration_1528_revoked_certificate_1529 struct {
 
-    Azurerm_virtual_network_gateway_vpn_client_configuration_1528_revoked_certificate_1529_id *string `lyra:"ignore"`
-
     Name string
 
     Thumbprint string
@@ -14957,8 +14437,6 @@ type Azurerm_virtual_network_gateway_vpn_client_configuration_1528_revoked_certi
 
 type Azurerm_virtual_network_gateway_vpn_client_configuration_1528_root_certificate_1530 struct {
 
-    Azurerm_virtual_network_gateway_vpn_client_configuration_1528_root_certificate_1530_id *string `lyra:"ignore"`
-
     Name string
 
     Public_cert_data string
@@ -14966,8 +14444,6 @@ type Azurerm_virtual_network_gateway_vpn_client_configuration_1528_root_certific
 }
 
 type Azurerm_virtual_network_gateway_vpn_client_configuration_1528 struct {
-
-    Azurerm_virtual_network_gateway_vpn_client_configuration_1528_id *string `lyra:"ignore"`
 
     Address_space []string
 
@@ -14989,13 +14465,13 @@ type Azurerm_virtual_network_gateway struct {
 
     Active_active *bool
 
-    Bgp_settings *Azurerm_virtual_network_gateway_bgp_settings_1526
+    Bgp_settings *[]Azurerm_virtual_network_gateway_bgp_settings_1526
 
     Default_local_network_gateway_id *string
 
     Enable_bgp *bool
 
-    Ip_configuration Azurerm_virtual_network_gateway_ip_configuration_1527
+    Ip_configuration []Azurerm_virtual_network_gateway_ip_configuration_1527
 
     Location string
 
@@ -15009,7 +14485,7 @@ type Azurerm_virtual_network_gateway struct {
 
     Type string
 
-    Vpn_client_configuration *Azurerm_virtual_network_gateway_vpn_client_configuration_1528
+    Vpn_client_configuration *[]Azurerm_virtual_network_gateway_vpn_client_configuration_1528
 
     Vpn_type *string
 
@@ -15054,8 +14530,6 @@ func (h *Azurerm_virtual_network_gatewayHandler) Delete(externalID string) error
 
 type Azurerm_virtual_network_gateway_connection_ipsec_policy_1531 struct {
 
-    Azurerm_virtual_network_gateway_connection_ipsec_policy_1531_id *string `lyra:"ignore"`
-
     Dh_group string
 
     Ike_encryption string
@@ -15084,7 +14558,7 @@ type Azurerm_virtual_network_gateway_connection struct {
 
     Express_route_circuit_id *string
 
-    Ipsec_policy *Azurerm_virtual_network_gateway_connection_ipsec_policy_1531
+    Ipsec_policy *[]Azurerm_virtual_network_gateway_connection_ipsec_policy_1531
 
     Local_network_gateway_id *string
 

--- a/cmd/goplugin-tf-google/generated/generated.go
+++ b/cmd/goplugin-tf-google/generated/generated.go
@@ -328,15 +328,11 @@ func Initialize(sb *service.ServerBuilder, p *schema.Provider) {
 
 type Google_app_engine_application_feature_settings_1532 struct {
 
-    Google_app_engine_application_feature_settings_1532_id *string `lyra:"ignore"`
-
     Split_health_checks *bool
 
 }
 
 type Google_app_engine_application_url_dispatch_rule_1533 struct {
-
-    Google_app_engine_application_url_dispatch_rule_1533_id *string `lyra:"ignore"`
 
     Domain *string
 
@@ -358,7 +354,7 @@ type Google_app_engine_application struct {
 
     Default_hostname *string
 
-    Feature_settings *Google_app_engine_application_feature_settings_1532
+    Feature_settings *[]Google_app_engine_application_feature_settings_1532
 
     Gcr_domain *string
 
@@ -370,7 +366,7 @@ type Google_app_engine_application struct {
 
     Serving_status *string
 
-    Url_dispatch_rule *Google_app_engine_application_url_dispatch_rule_1533
+    Url_dispatch_rule *[]Google_app_engine_application_url_dispatch_rule_1533
 
 }
 
@@ -413,8 +409,6 @@ func (h *Google_app_engine_applicationHandler) Delete(externalID string) error {
 
 type Google_bigquery_dataset_access_1534_view_1535 struct {
 
-    Google_bigquery_dataset_access_1534_view_1535_id *string `lyra:"ignore"`
-
     Dataset_id string
 
     Project_id string
@@ -424,8 +418,6 @@ type Google_bigquery_dataset_access_1534_view_1535 struct {
 }
 
 type Google_bigquery_dataset_access_1534 struct {
-
-    Google_bigquery_dataset_access_1534_id *string `lyra:"ignore"`
 
     Domain *string
 
@@ -437,7 +429,7 @@ type Google_bigquery_dataset_access_1534 struct {
 
     User_by_email *string
 
-    View *Google_bigquery_dataset_access_1534_view_1535
+    View *[]Google_bigquery_dataset_access_1534_view_1535
 
 }
 
@@ -445,7 +437,7 @@ type Google_bigquery_dataset struct {
 
     Google_bigquery_dataset_id *string `lyra:"ignore"`
 
-    Access *Google_bigquery_dataset_access_1534
+    Access *[]Google_bigquery_dataset_access_1534
 
     Creation_time *int
 
@@ -510,8 +502,6 @@ func (h *Google_bigquery_datasetHandler) Delete(externalID string) error {
 
 type Google_bigquery_table_time_partitioning_1536 struct {
 
-    Google_bigquery_table_time_partitioning_1536_id *string `lyra:"ignore"`
-
     Expiration_ms *int
 
     Field *string
@@ -521,8 +511,6 @@ type Google_bigquery_table_time_partitioning_1536 struct {
 }
 
 type Google_bigquery_table_view_1537 struct {
-
-    Google_bigquery_table_view_1537_id *string `lyra:"ignore"`
 
     Query string
 
@@ -566,11 +554,11 @@ type Google_bigquery_table struct {
 
     Table_id string
 
-    Time_partitioning *Google_bigquery_table_time_partitioning_1536
+    Time_partitioning *[]Google_bigquery_table_time_partitioning_1536
 
     Type *string
 
-    View *Google_bigquery_table_view_1537
+    View *[]Google_bigquery_table_view_1537
 
 }
 
@@ -612,8 +600,6 @@ func (h *Google_bigquery_tableHandler) Delete(externalID string) error {
 }
 
 type Google_bigtable_instance_cluster_1538 struct {
-
-    Google_bigtable_instance_cluster_1538_id *string `lyra:"ignore"`
 
     Cluster_id *string
 
@@ -890,8 +876,6 @@ func (h *Google_billing_account_iam_policyHandler) Delete(externalID string) err
 
 type Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540 struct {
 
-    Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540_id *string `lyra:"ignore"`
-
     Ascii_armored_pgp_public_key string
 
     Comment *string
@@ -902,13 +886,11 @@ type Google_binary_authorization_attestor_attestation_authority_note_1539_public
 
 type Google_binary_authorization_attestor_attestation_authority_note_1539 struct {
 
-    Google_binary_authorization_attestor_attestation_authority_note_1539_id *string `lyra:"ignore"`
-
     Delegation_service_account_email *string
 
     Note_reference string
 
-    Public_keys *Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540
+    Public_keys *[]Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540
 
 }
 
@@ -916,7 +898,7 @@ type Google_binary_authorization_attestor struct {
 
     Google_binary_authorization_attestor_id *string `lyra:"ignore"`
 
-    Attestation_authority_note Google_binary_authorization_attestor_attestation_authority_note_1539
+    Attestation_authority_note []Google_binary_authorization_attestor_attestation_authority_note_1539
 
     Description *string
 
@@ -965,15 +947,11 @@ func (h *Google_binary_authorization_attestorHandler) Delete(externalID string) 
 
 type Google_binary_authorization_policy_admission_whitelist_patterns_1541 struct {
 
-    Google_binary_authorization_policy_admission_whitelist_patterns_1541_id *string `lyra:"ignore"`
-
     Name_pattern *string
 
 }
 
 type Google_binary_authorization_policy_cluster_admission_rules_1542 struct {
-
-    Google_binary_authorization_policy_cluster_admission_rules_1542_id *string `lyra:"ignore"`
 
     Cluster string
 
@@ -987,8 +965,6 @@ type Google_binary_authorization_policy_cluster_admission_rules_1542 struct {
 
 type Google_binary_authorization_policy_default_admission_rule_1543 struct {
 
-    Google_binary_authorization_policy_default_admission_rule_1543_id *string `lyra:"ignore"`
-
     Enforcement_mode string
 
     Evaluation_mode string
@@ -1001,11 +977,11 @@ type Google_binary_authorization_policy struct {
 
     Google_binary_authorization_policy_id *string `lyra:"ignore"`
 
-    Admission_whitelist_patterns *Google_binary_authorization_policy_admission_whitelist_patterns_1541
+    Admission_whitelist_patterns *[]Google_binary_authorization_policy_admission_whitelist_patterns_1541
 
     Cluster_admission_rules *Google_binary_authorization_policy_cluster_admission_rules_1542
 
-    Default_admission_rule Google_binary_authorization_policy_default_admission_rule_1543
+    Default_admission_rule []Google_binary_authorization_policy_default_admission_rule_1543
 
     Description *string
 
@@ -1052,8 +1028,6 @@ func (h *Google_binary_authorization_policyHandler) Delete(externalID string) er
 
 type Google_cloudbuild_trigger_build_1544_step_1545 struct {
 
-    Google_cloudbuild_trigger_build_1544_step_1545_id *string `lyra:"ignore"`
-
     Args *string
 
     Name *string
@@ -1062,19 +1036,15 @@ type Google_cloudbuild_trigger_build_1544_step_1545 struct {
 
 type Google_cloudbuild_trigger_build_1544 struct {
 
-    Google_cloudbuild_trigger_build_1544_id *string `lyra:"ignore"`
-
     Images *[]string
 
-    Step *Google_cloudbuild_trigger_build_1544_step_1545
+    Step *[]Google_cloudbuild_trigger_build_1544_step_1545
 
     Tags *[]string
 
 }
 
 type Google_cloudbuild_trigger_trigger_template_1546 struct {
-
-    Google_cloudbuild_trigger_trigger_template_1546_id *string `lyra:"ignore"`
 
     Branch_name *string
 
@@ -1094,7 +1064,7 @@ type Google_cloudbuild_trigger struct {
 
     Google_cloudbuild_trigger_id *string `lyra:"ignore"`
 
-    Build *Google_cloudbuild_trigger_build_1544
+    Build *[]Google_cloudbuild_trigger_build_1544
 
     Description *string
 
@@ -1104,7 +1074,7 @@ type Google_cloudbuild_trigger struct {
 
     Substitutions *map[string]string
 
-    Trigger_template *Google_cloudbuild_trigger_trigger_template_1546
+    Trigger_template *[]Google_cloudbuild_trigger_trigger_template_1546
 
 }
 
@@ -1147,19 +1117,15 @@ func (h *Google_cloudbuild_triggerHandler) Delete(externalID string) error {
 
 type Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548 struct {
 
-    Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548_id *string `lyra:"ignore"`
-
     Retry bool
 
 }
 
 type Google_cloudfunctions_function_event_trigger_1547 struct {
 
-    Google_cloudfunctions_function_event_trigger_1547_id *string `lyra:"ignore"`
-
     Event_type string
 
-    Failure_policy *Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548
+    Failure_policy *[]Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548
 
     Resource string
 
@@ -1177,7 +1143,7 @@ type Google_cloudfunctions_function struct {
 
     Environment_variables *map[string]string
 
-    Event_trigger *Google_cloudfunctions_function_event_trigger_1547
+    Event_trigger *[]Google_cloudfunctions_function_event_trigger_1547
 
     Https_trigger_url *string
 
@@ -1246,8 +1212,6 @@ func (h *Google_cloudfunctions_functionHandler) Delete(externalID string) error 
 
 type Google_cloudiot_registry_credentials_1549 struct {
 
-    Google_cloudiot_registry_credentials_1549_id *string `lyra:"ignore"`
-
     Public_key_certificate *map[string]string
 
 }
@@ -1256,7 +1220,7 @@ type Google_cloudiot_registry struct {
 
     Google_cloudiot_registry_id *string `lyra:"ignore"`
 
-    Credentials *Google_cloudiot_registry_credentials_1549
+    Credentials *[]Google_cloudiot_registry_credentials_1549
 
     Event_notification_config *map[string]string
 
@@ -1313,8 +1277,6 @@ func (h *Google_cloudiot_registryHandler) Delete(externalID string) error {
 
 type Google_composer_environment_config_1550_node_config_1551 struct {
 
-    Google_composer_environment_config_1550_node_config_1551_id *string `lyra:"ignore"`
-
     Disk_size_gb *int
 
     Machine_type *string
@@ -1335,8 +1297,6 @@ type Google_composer_environment_config_1550_node_config_1551 struct {
 
 type Google_composer_environment_config_1550_software_config_1552 struct {
 
-    Google_composer_environment_config_1550_software_config_1552_id *string `lyra:"ignore"`
-
     Airflow_config_overrides *map[string]string
 
     Env_variables *map[string]string
@@ -1349,19 +1309,17 @@ type Google_composer_environment_config_1550_software_config_1552 struct {
 
 type Google_composer_environment_config_1550 struct {
 
-    Google_composer_environment_config_1550_id *string `lyra:"ignore"`
-
     Airflow_uri *string
 
     Dag_gcs_prefix *string
 
     Gke_cluster *string
 
-    Node_config *Google_composer_environment_config_1550_node_config_1551
+    Node_config *[]Google_composer_environment_config_1550_node_config_1551
 
     Node_count *int
 
-    Software_config *Google_composer_environment_config_1550_software_config_1552
+    Software_config *[]Google_composer_environment_config_1550_software_config_1552
 
 }
 
@@ -1369,7 +1327,7 @@ type Google_composer_environment struct {
 
     Google_composer_environment_id *string `lyra:"ignore"`
 
-    Config *Google_composer_environment_config_1550
+    Config *[]Google_composer_environment_config_1550
 
     Labels *map[string]string
 
@@ -1544,23 +1502,17 @@ func (h *Google_compute_attached_diskHandler) Delete(externalID string) error {
 
 type Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554 struct {
 
-    Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554_id *string `lyra:"ignore"`
-
     Target float64
 
 }
 
 type Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555 struct {
 
-    Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555_id *string `lyra:"ignore"`
-
     Target float64
 
 }
 
 type Google_compute_autoscaler_autoscaling_policy_1553_metric_1556 struct {
-
-    Google_compute_autoscaler_autoscaling_policy_1553_metric_1556_id *string `lyra:"ignore"`
 
     Name string
 
@@ -1572,17 +1524,15 @@ type Google_compute_autoscaler_autoscaling_policy_1553_metric_1556 struct {
 
 type Google_compute_autoscaler_autoscaling_policy_1553 struct {
 
-    Google_compute_autoscaler_autoscaling_policy_1553_id *string `lyra:"ignore"`
-
     Cooldown_period *int
 
-    Cpu_utilization *Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554
+    Cpu_utilization *[]Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554
 
-    Load_balancing_utilization *Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555
+    Load_balancing_utilization *[]Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555
 
     Max_replicas int
 
-    Metric *Google_compute_autoscaler_autoscaling_policy_1553_metric_1556
+    Metric *[]Google_compute_autoscaler_autoscaling_policy_1553_metric_1556
 
     Min_replicas int
 
@@ -1592,7 +1542,7 @@ type Google_compute_autoscaler struct {
 
     Google_compute_autoscaler_id *string `lyra:"ignore"`
 
-    Autoscaling_policy Google_compute_autoscaler_autoscaling_policy_1553
+    Autoscaling_policy []Google_compute_autoscaler_autoscaling_policy_1553
 
     Creation_timestamp *string
 
@@ -1706,8 +1656,6 @@ func (h *Google_compute_backend_bucketHandler) Delete(externalID string) error {
 
 type Google_compute_backend_service_backend_1557 struct {
 
-    Google_compute_backend_service_backend_1557_id *string `lyra:"ignore"`
-
     Balancing_mode *string
 
     Capacity_scaler *float64
@@ -1730,8 +1678,6 @@ type Google_compute_backend_service_backend_1557 struct {
 
 type Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559 struct {
 
-    Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559_id *string `lyra:"ignore"`
-
     Include_host *bool
 
     Include_protocol *bool
@@ -1746,15 +1692,11 @@ type Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559 struct
 
 type Google_compute_backend_service_cdn_policy_1558 struct {
 
-    Google_compute_backend_service_cdn_policy_1558_id *string `lyra:"ignore"`
-
-    Cache_key_policy *Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559
+    Cache_key_policy *[]Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559
 
 }
 
 type Google_compute_backend_service_iap_1560 struct {
-
-    Google_compute_backend_service_iap_1560_id *string `lyra:"ignore"`
 
     Oauth2_client_id string
 
@@ -1768,7 +1710,7 @@ type Google_compute_backend_service struct {
 
     Backend *Google_compute_backend_service_backend_1557
 
-    Cdn_policy *Google_compute_backend_service_cdn_policy_1558
+    Cdn_policy *[]Google_compute_backend_service_cdn_policy_1558
 
     Connection_draining_timeout_sec *int
 
@@ -1782,7 +1724,7 @@ type Google_compute_backend_service struct {
 
     Health_checks []string
 
-    Iap *Google_compute_backend_service_iap_1560
+    Iap *[]Google_compute_backend_service_iap_1560
 
     Name string
 
@@ -1843,8 +1785,6 @@ func (h *Google_compute_backend_serviceHandler) Delete(externalID string) error 
 
 type Google_compute_disk_disk_encryption_key_1561 struct {
 
-    Google_compute_disk_disk_encryption_key_1561_id *string `lyra:"ignore"`
-
     Raw_key *string
 
     Sha256 *string
@@ -1853,8 +1793,6 @@ type Google_compute_disk_disk_encryption_key_1561 struct {
 
 type Google_compute_disk_source_image_encryption_key_1562 struct {
 
-    Google_compute_disk_source_image_encryption_key_1562_id *string `lyra:"ignore"`
-
     Raw_key *string
 
     Sha256 *string
@@ -1862,8 +1800,6 @@ type Google_compute_disk_source_image_encryption_key_1562 struct {
 }
 
 type Google_compute_disk_source_snapshot_encryption_key_1563 struct {
-
-    Google_compute_disk_source_snapshot_encryption_key_1563_id *string `lyra:"ignore"`
 
     Raw_key *string
 
@@ -1879,7 +1815,7 @@ type Google_compute_disk struct {
 
     Description *string
 
-    Disk_encryption_key *Google_compute_disk_disk_encryption_key_1561
+    Disk_encryption_key *[]Google_compute_disk_disk_encryption_key_1561
 
     Disk_encryption_key_raw *string
 
@@ -1905,11 +1841,11 @@ type Google_compute_disk struct {
 
     Snapshot *string
 
-    Source_image_encryption_key *Google_compute_disk_source_image_encryption_key_1562
+    Source_image_encryption_key *[]Google_compute_disk_source_image_encryption_key_1562
 
     Source_image_id *string
 
-    Source_snapshot_encryption_key *Google_compute_disk_source_snapshot_encryption_key_1563
+    Source_snapshot_encryption_key *[]Google_compute_disk_source_snapshot_encryption_key_1563
 
     Source_snapshot_id *string
 
@@ -1960,8 +1896,6 @@ func (h *Google_compute_diskHandler) Delete(externalID string) error {
 
 type Google_compute_firewall_allow_1564 struct {
 
-    Google_compute_firewall_allow_1564_id *string `lyra:"ignore"`
-
     Ports *[]string
 
     Protocol string
@@ -1969,8 +1903,6 @@ type Google_compute_firewall_allow_1564 struct {
 }
 
 type Google_compute_firewall_deny_1565 struct {
-
-    Google_compute_firewall_deny_1565_id *string `lyra:"ignore"`
 
     Ports *[]string
 
@@ -2280,8 +2212,6 @@ func (h *Google_compute_global_forwarding_ruleHandler) Delete(externalID string)
 
 type Google_compute_health_check_http_health_check_1566 struct {
 
-    Google_compute_health_check_http_health_check_1566_id *string `lyra:"ignore"`
-
     Host *string
 
     Port *int
@@ -2295,8 +2225,6 @@ type Google_compute_health_check_http_health_check_1566 struct {
 }
 
 type Google_compute_health_check_https_health_check_1567 struct {
-
-    Google_compute_health_check_https_health_check_1567_id *string `lyra:"ignore"`
 
     Host *string
 
@@ -2312,8 +2240,6 @@ type Google_compute_health_check_https_health_check_1567 struct {
 
 type Google_compute_health_check_ssl_health_check_1568 struct {
 
-    Google_compute_health_check_ssl_health_check_1568_id *string `lyra:"ignore"`
-
     Port *int
 
     Proxy_header *string
@@ -2325,8 +2251,6 @@ type Google_compute_health_check_ssl_health_check_1568 struct {
 }
 
 type Google_compute_health_check_tcp_health_check_1569 struct {
-
-    Google_compute_health_check_tcp_health_check_1569_id *string `lyra:"ignore"`
 
     Port *int
 
@@ -2350,9 +2274,9 @@ type Google_compute_health_check struct {
 
     Healthy_threshold *int
 
-    Http_health_check *Google_compute_health_check_http_health_check_1566
+    Http_health_check *[]Google_compute_health_check_http_health_check_1566
 
-    Https_health_check *Google_compute_health_check_https_health_check_1567
+    Https_health_check *[]Google_compute_health_check_https_health_check_1567
 
     Name string
 
@@ -2360,9 +2284,9 @@ type Google_compute_health_check struct {
 
     Self_link *string
 
-    Ssl_health_check *Google_compute_health_check_ssl_health_check_1568
+    Ssl_health_check *[]Google_compute_health_check_ssl_health_check_1568
 
-    Tcp_health_check *Google_compute_health_check_tcp_health_check_1569
+    Tcp_health_check *[]Google_compute_health_check_tcp_health_check_1569
 
     Timeout_sec *int
 
@@ -2545,8 +2469,6 @@ func (h *Google_compute_https_health_checkHandler) Delete(externalID string) err
 
 type Google_compute_image_raw_disk_1570 struct {
 
-    Google_compute_image_raw_disk_1570_id *string `lyra:"ignore"`
-
     Container_type *string
 
     Sha1 *string
@@ -2575,7 +2497,7 @@ type Google_compute_image struct {
 
     Project *string
 
-    Raw_disk *Google_compute_image_raw_disk_1570
+    Raw_disk *[]Google_compute_image_raw_disk_1570
 
     Self_link *string
 
@@ -2622,8 +2544,6 @@ func (h *Google_compute_imageHandler) Delete(externalID string) error {
 
 type Google_compute_instance_attached_disk_1571 struct {
 
-    Google_compute_instance_attached_disk_1571_id *string `lyra:"ignore"`
-
     Device_name *string
 
     Disk_encryption_key_raw *string
@@ -2638,8 +2558,6 @@ type Google_compute_instance_attached_disk_1571 struct {
 
 type Google_compute_instance_boot_disk_1572_initialize_params_1573 struct {
 
-    Google_compute_instance_boot_disk_1572_initialize_params_1573_id *string `lyra:"ignore"`
-
     Image *string
 
     Size *int
@@ -2650,8 +2568,6 @@ type Google_compute_instance_boot_disk_1572_initialize_params_1573 struct {
 
 type Google_compute_instance_boot_disk_1572 struct {
 
-    Google_compute_instance_boot_disk_1572_id *string `lyra:"ignore"`
-
     Auto_delete *bool
 
     Device_name *string
@@ -2660,15 +2576,13 @@ type Google_compute_instance_boot_disk_1572 struct {
 
     Disk_encryption_key_sha256 *string
 
-    Initialize_params *Google_compute_instance_boot_disk_1572_initialize_params_1573
+    Initialize_params *[]Google_compute_instance_boot_disk_1572_initialize_params_1573
 
     Source *string
 
 }
 
 type Google_compute_instance_disk_1574 struct {
-
-    Google_compute_instance_disk_1574_id *string `lyra:"ignore"`
 
     Auto_delete *bool
 
@@ -2692,8 +2606,6 @@ type Google_compute_instance_disk_1574 struct {
 
 type Google_compute_instance_guest_accelerator_1575 struct {
 
-    Google_compute_instance_guest_accelerator_1575_id *string `lyra:"ignore"`
-
     Count int
 
     Type string
@@ -2701,8 +2613,6 @@ type Google_compute_instance_guest_accelerator_1575 struct {
 }
 
 type Google_compute_instance_network_1576 struct {
-
-    Google_compute_instance_network_1576_id *string `lyra:"ignore"`
 
     Address *string
 
@@ -2718,8 +2628,6 @@ type Google_compute_instance_network_1576 struct {
 
 type Google_compute_instance_network_interface_1577_access_config_1578 struct {
 
-    Google_compute_instance_network_interface_1577_access_config_1578_id *string `lyra:"ignore"`
-
     Assigned_nat_ip *string
 
     Nat_ip *string
@@ -2732,8 +2640,6 @@ type Google_compute_instance_network_interface_1577_access_config_1578 struct {
 
 type Google_compute_instance_network_interface_1577_alias_ip_range_1579 struct {
 
-    Google_compute_instance_network_interface_1577_alias_ip_range_1579_id *string `lyra:"ignore"`
-
     Ip_cidr_range string
 
     Subnetwork_range_name *string
@@ -2742,13 +2648,11 @@ type Google_compute_instance_network_interface_1577_alias_ip_range_1579 struct {
 
 type Google_compute_instance_network_interface_1577 struct {
 
-    Google_compute_instance_network_interface_1577_id *string `lyra:"ignore"`
-
-    Access_config *Google_compute_instance_network_interface_1577_access_config_1578
+    Access_config *[]Google_compute_instance_network_interface_1577_access_config_1578
 
     Address *string
 
-    Alias_ip_range *Google_compute_instance_network_interface_1577_alias_ip_range_1579
+    Alias_ip_range *[]Google_compute_instance_network_interface_1577_alias_ip_range_1579
 
     Name *string
 
@@ -2764,8 +2668,6 @@ type Google_compute_instance_network_interface_1577 struct {
 
 type Google_compute_instance_scheduling_1580 struct {
 
-    Google_compute_instance_scheduling_1580_id *string `lyra:"ignore"`
-
     Automatic_restart *bool
 
     On_host_maintenance *string
@@ -2776,15 +2678,11 @@ type Google_compute_instance_scheduling_1580 struct {
 
 type Google_compute_instance_scratch_disk_1581 struct {
 
-    Google_compute_instance_scratch_disk_1581_id *string `lyra:"ignore"`
-
     Interface *string
 
 }
 
 type Google_compute_instance_service_account_1582 struct {
-
-    Google_compute_instance_service_account_1582_id *string `lyra:"ignore"`
 
     Email *string
 
@@ -2798,9 +2696,9 @@ type Google_compute_instance struct {
 
     Allow_stopping_for_update *bool
 
-    Attached_disk *Google_compute_instance_attached_disk_1571
+    Attached_disk *[]Google_compute_instance_attached_disk_1571
 
-    Boot_disk Google_compute_instance_boot_disk_1572
+    Boot_disk []Google_compute_instance_boot_disk_1572
 
     Can_ip_forward *bool
 
@@ -2812,9 +2710,9 @@ type Google_compute_instance struct {
 
     Description *string
 
-    Disk *Google_compute_instance_disk_1574
+    Disk *[]Google_compute_instance_disk_1574
 
-    Guest_accelerator *Google_compute_instance_guest_accelerator_1575
+    Guest_accelerator *[]Google_compute_instance_guest_accelerator_1575
 
     Instance_id *string
 
@@ -2834,19 +2732,19 @@ type Google_compute_instance struct {
 
     Name string
 
-    Network *Google_compute_instance_network_1576
+    Network *[]Google_compute_instance_network_1576
 
-    Network_interface Google_compute_instance_network_interface_1577
+    Network_interface []Google_compute_instance_network_interface_1577
 
     Project *string
 
-    Scheduling *Google_compute_instance_scheduling_1580
+    Scheduling *[]Google_compute_instance_scheduling_1580
 
-    Scratch_disk *Google_compute_instance_scratch_disk_1581
+    Scratch_disk *[]Google_compute_instance_scratch_disk_1581
 
     Self_link *string
 
-    Service_account *Google_compute_instance_service_account_1582
+    Service_account *[]Google_compute_instance_service_account_1582
 
     Tags *[]string
 
@@ -2895,8 +2793,6 @@ func (h *Google_compute_instanceHandler) Delete(externalID string) error {
 
 type Google_compute_instance_from_template_attached_disk_1583 struct {
 
-    Google_compute_instance_from_template_attached_disk_1583_id *string `lyra:"ignore"`
-
     Device_name *string
 
     Disk_encryption_key_raw *string
@@ -2911,8 +2807,6 @@ type Google_compute_instance_from_template_attached_disk_1583 struct {
 
 type Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585 struct {
 
-    Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585_id *string `lyra:"ignore"`
-
     Image *string
 
     Size *int
@@ -2923,8 +2817,6 @@ type Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585
 
 type Google_compute_instance_from_template_boot_disk_1584 struct {
 
-    Google_compute_instance_from_template_boot_disk_1584_id *string `lyra:"ignore"`
-
     Auto_delete *bool
 
     Device_name *string
@@ -2933,15 +2825,13 @@ type Google_compute_instance_from_template_boot_disk_1584 struct {
 
     Disk_encryption_key_sha256 *string
 
-    Initialize_params *Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585
+    Initialize_params *[]Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585
 
     Source *string
 
 }
 
 type Google_compute_instance_from_template_guest_accelerator_1586 struct {
-
-    Google_compute_instance_from_template_guest_accelerator_1586_id *string `lyra:"ignore"`
 
     Count int
 
@@ -2950,8 +2840,6 @@ type Google_compute_instance_from_template_guest_accelerator_1586 struct {
 }
 
 type Google_compute_instance_from_template_network_interface_1587_access_config_1588 struct {
-
-    Google_compute_instance_from_template_network_interface_1587_access_config_1588_id *string `lyra:"ignore"`
 
     Assigned_nat_ip *string
 
@@ -2965,8 +2853,6 @@ type Google_compute_instance_from_template_network_interface_1587_access_config_
 
 type Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589 struct {
 
-    Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589_id *string `lyra:"ignore"`
-
     Ip_cidr_range string
 
     Subnetwork_range_name *string
@@ -2975,13 +2861,11 @@ type Google_compute_instance_from_template_network_interface_1587_alias_ip_range
 
 type Google_compute_instance_from_template_network_interface_1587 struct {
 
-    Google_compute_instance_from_template_network_interface_1587_id *string `lyra:"ignore"`
-
-    Access_config *Google_compute_instance_from_template_network_interface_1587_access_config_1588
+    Access_config *[]Google_compute_instance_from_template_network_interface_1587_access_config_1588
 
     Address *string
 
-    Alias_ip_range *Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589
+    Alias_ip_range *[]Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589
 
     Name *string
 
@@ -2997,8 +2881,6 @@ type Google_compute_instance_from_template_network_interface_1587 struct {
 
 type Google_compute_instance_from_template_scheduling_1590 struct {
 
-    Google_compute_instance_from_template_scheduling_1590_id *string `lyra:"ignore"`
-
     Automatic_restart *bool
 
     On_host_maintenance *string
@@ -3009,15 +2891,11 @@ type Google_compute_instance_from_template_scheduling_1590 struct {
 
 type Google_compute_instance_from_template_scratch_disk_1591 struct {
 
-    Google_compute_instance_from_template_scratch_disk_1591_id *string `lyra:"ignore"`
-
     Interface *string
 
 }
 
 type Google_compute_instance_from_template_service_account_1592 struct {
-
-    Google_compute_instance_from_template_service_account_1592_id *string `lyra:"ignore"`
 
     Email *string
 
@@ -3031,9 +2909,9 @@ type Google_compute_instance_from_template struct {
 
     Allow_stopping_for_update *bool
 
-    Attached_disk *Google_compute_instance_from_template_attached_disk_1583
+    Attached_disk *[]Google_compute_instance_from_template_attached_disk_1583
 
-    Boot_disk *Google_compute_instance_from_template_boot_disk_1584
+    Boot_disk *[]Google_compute_instance_from_template_boot_disk_1584
 
     Can_ip_forward *bool
 
@@ -3043,7 +2921,7 @@ type Google_compute_instance_from_template struct {
 
     Description *string
 
-    Guest_accelerator *Google_compute_instance_from_template_guest_accelerator_1586
+    Guest_accelerator *[]Google_compute_instance_from_template_guest_accelerator_1586
 
     Instance_id *string
 
@@ -3063,17 +2941,17 @@ type Google_compute_instance_from_template struct {
 
     Name string
 
-    Network_interface *Google_compute_instance_from_template_network_interface_1587
+    Network_interface *[]Google_compute_instance_from_template_network_interface_1587
 
     Project *string
 
-    Scheduling *Google_compute_instance_from_template_scheduling_1590
+    Scheduling *[]Google_compute_instance_from_template_scheduling_1590
 
-    Scratch_disk *Google_compute_instance_from_template_scratch_disk_1591
+    Scratch_disk *[]Google_compute_instance_from_template_scratch_disk_1591
 
     Self_link *string
 
-    Service_account *Google_compute_instance_from_template_service_account_1592
+    Service_account *[]Google_compute_instance_from_template_service_account_1592
 
     Source_instance_template string
 
@@ -3124,8 +3002,6 @@ func (h *Google_compute_instance_from_templateHandler) Delete(externalID string)
 
 type Google_compute_instance_group_named_port_1593 struct {
 
-    Google_compute_instance_group_named_port_1593_id *string `lyra:"ignore"`
-
     Name string
 
     Port int
@@ -3142,7 +3018,7 @@ type Google_compute_instance_group struct {
 
     Name string
 
-    Named_port *Google_compute_instance_group_named_port_1593
+    Named_port *[]Google_compute_instance_group_named_port_1593
 
     Network *string
 
@@ -3195,8 +3071,6 @@ func (h *Google_compute_instance_groupHandler) Delete(externalID string) error {
 
 type Google_compute_instance_group_manager_auto_healing_policies_1594 struct {
 
-    Google_compute_instance_group_manager_auto_healing_policies_1594_id *string `lyra:"ignore"`
-
     Health_check string
 
     Initial_delay_sec int
@@ -3205,8 +3079,6 @@ type Google_compute_instance_group_manager_auto_healing_policies_1594 struct {
 
 type Google_compute_instance_group_manager_named_port_1595 struct {
 
-    Google_compute_instance_group_manager_named_port_1595_id *string `lyra:"ignore"`
-
     Name string
 
     Port int
@@ -3214,8 +3086,6 @@ type Google_compute_instance_group_manager_named_port_1595 struct {
 }
 
 type Google_compute_instance_group_manager_rolling_update_policy_1596 struct {
-
-    Google_compute_instance_group_manager_rolling_update_policy_1596_id *string `lyra:"ignore"`
 
     Max_surge_fixed *int
 
@@ -3235,8 +3105,6 @@ type Google_compute_instance_group_manager_rolling_update_policy_1596 struct {
 
 type Google_compute_instance_group_manager_version_1597_target_size_1598 struct {
 
-    Google_compute_instance_group_manager_version_1597_target_size_1598_id *string `lyra:"ignore"`
-
     Fixed *int
 
     Percent *int
@@ -3245,13 +3113,11 @@ type Google_compute_instance_group_manager_version_1597_target_size_1598 struct 
 
 type Google_compute_instance_group_manager_version_1597 struct {
 
-    Google_compute_instance_group_manager_version_1597_id *string `lyra:"ignore"`
-
     Instance_template string
 
     Name string
 
-    Target_size *Google_compute_instance_group_manager_version_1597_target_size_1598
+    Target_size *[]Google_compute_instance_group_manager_version_1597_target_size_1598
 
 }
 
@@ -3259,7 +3125,7 @@ type Google_compute_instance_group_manager struct {
 
     Google_compute_instance_group_manager_id *string `lyra:"ignore"`
 
-    Auto_healing_policies *Google_compute_instance_group_manager_auto_healing_policies_1594
+    Auto_healing_policies *[]Google_compute_instance_group_manager_auto_healing_policies_1594
 
     Base_instance_name string
 
@@ -3273,11 +3139,11 @@ type Google_compute_instance_group_manager struct {
 
     Name string
 
-    Named_port *Google_compute_instance_group_manager_named_port_1595
+    Named_port *[]Google_compute_instance_group_manager_named_port_1595
 
     Project *string
 
-    Rolling_update_policy *Google_compute_instance_group_manager_rolling_update_policy_1596
+    Rolling_update_policy *[]Google_compute_instance_group_manager_rolling_update_policy_1596
 
     Self_link *string
 
@@ -3287,7 +3153,7 @@ type Google_compute_instance_group_manager struct {
 
     Update_strategy *string
 
-    Version *Google_compute_instance_group_manager_version_1597
+    Version *[]Google_compute_instance_group_manager_version_1597
 
     Wait_for_instances *bool
 
@@ -3334,15 +3200,11 @@ func (h *Google_compute_instance_group_managerHandler) Delete(externalID string)
 
 type Google_compute_instance_template_disk_1599_disk_encryption_key_1600 struct {
 
-    Google_compute_instance_template_disk_1599_disk_encryption_key_1600_id *string `lyra:"ignore"`
-
     Kms_key_self_link *string
 
 }
 
 type Google_compute_instance_template_disk_1599 struct {
-
-    Google_compute_instance_template_disk_1599_id *string `lyra:"ignore"`
 
     Auto_delete *bool
 
@@ -3350,7 +3212,7 @@ type Google_compute_instance_template_disk_1599 struct {
 
     Device_name *string
 
-    Disk_encryption_key *Google_compute_instance_template_disk_1599_disk_encryption_key_1600
+    Disk_encryption_key *[]Google_compute_instance_template_disk_1599_disk_encryption_key_1600
 
     Disk_name *string
 
@@ -3372,8 +3234,6 @@ type Google_compute_instance_template_disk_1599 struct {
 
 type Google_compute_instance_template_guest_accelerator_1601 struct {
 
-    Google_compute_instance_template_guest_accelerator_1601_id *string `lyra:"ignore"`
-
     Count int
 
     Type string
@@ -3381,8 +3241,6 @@ type Google_compute_instance_template_guest_accelerator_1601 struct {
 }
 
 type Google_compute_instance_template_network_interface_1602_access_config_1603 struct {
-
-    Google_compute_instance_template_network_interface_1602_access_config_1603_id *string `lyra:"ignore"`
 
     Assigned_nat_ip *string
 
@@ -3394,8 +3252,6 @@ type Google_compute_instance_template_network_interface_1602_access_config_1603 
 
 type Google_compute_instance_template_network_interface_1602_alias_ip_range_1604 struct {
 
-    Google_compute_instance_template_network_interface_1602_alias_ip_range_1604_id *string `lyra:"ignore"`
-
     Ip_cidr_range string
 
     Subnetwork_range_name *string
@@ -3404,13 +3260,11 @@ type Google_compute_instance_template_network_interface_1602_alias_ip_range_1604
 
 type Google_compute_instance_template_network_interface_1602 struct {
 
-    Google_compute_instance_template_network_interface_1602_id *string `lyra:"ignore"`
-
-    Access_config *Google_compute_instance_template_network_interface_1602_access_config_1603
+    Access_config *[]Google_compute_instance_template_network_interface_1602_access_config_1603
 
     Address *string
 
-    Alias_ip_range *Google_compute_instance_template_network_interface_1602_alias_ip_range_1604
+    Alias_ip_range *[]Google_compute_instance_template_network_interface_1602_alias_ip_range_1604
 
     Network *string
 
@@ -3424,8 +3278,6 @@ type Google_compute_instance_template_network_interface_1602 struct {
 
 type Google_compute_instance_template_scheduling_1605 struct {
 
-    Google_compute_instance_template_scheduling_1605_id *string `lyra:"ignore"`
-
     Automatic_restart *bool
 
     On_host_maintenance *string
@@ -3435,8 +3287,6 @@ type Google_compute_instance_template_scheduling_1605 struct {
 }
 
 type Google_compute_instance_template_service_account_1606 struct {
-
-    Google_compute_instance_template_service_account_1606_id *string `lyra:"ignore"`
 
     Email *string
 
@@ -3454,9 +3304,9 @@ type Google_compute_instance_template struct {
 
     Description *string
 
-    Disk Google_compute_instance_template_disk_1599
+    Disk []Google_compute_instance_template_disk_1599
 
-    Guest_accelerator *Google_compute_instance_template_guest_accelerator_1601
+    Guest_accelerator *[]Google_compute_instance_template_guest_accelerator_1601
 
     Instance_description *string
 
@@ -3476,7 +3326,7 @@ type Google_compute_instance_template struct {
 
     Name_prefix *string
 
-    Network_interface *Google_compute_instance_template_network_interface_1602
+    Network_interface *[]Google_compute_instance_template_network_interface_1602
 
     On_host_maintenance *string
 
@@ -3484,11 +3334,11 @@ type Google_compute_instance_template struct {
 
     Region *string
 
-    Scheduling *Google_compute_instance_template_scheduling_1605
+    Scheduling *[]Google_compute_instance_template_scheduling_1605
 
     Self_link *string
 
-    Service_account *Google_compute_instance_template_service_account_1606
+    Service_account *[]Google_compute_instance_template_service_account_1606
 
     Tags *[]string
 
@@ -3535,8 +3385,6 @@ func (h *Google_compute_instance_templateHandler) Delete(externalID string) erro
 
 type Google_compute_interconnect_attachment_private_interconnect_info_1607 struct {
 
-    Google_compute_interconnect_attachment_private_interconnect_info_1607_id *string `lyra:"ignore"`
-
     Tag8021q *int
 
 }
@@ -3559,7 +3407,7 @@ type Google_compute_interconnect_attachment struct {
 
     Name string
 
-    Private_interconnect_info *Google_compute_interconnect_attachment_private_interconnect_info_1607
+    Private_interconnect_info *[]Google_compute_interconnect_attachment_private_interconnect_info_1607
 
     Project *string
 
@@ -3820,23 +3668,17 @@ func (h *Google_compute_project_metadata_itemHandler) Delete(externalID string) 
 
 type Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609 struct {
 
-    Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609_id *string `lyra:"ignore"`
-
     Target float64
 
 }
 
 type Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610 struct {
 
-    Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610_id *string `lyra:"ignore"`
-
     Target float64
 
 }
 
 type Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611 struct {
-
-    Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611_id *string `lyra:"ignore"`
 
     Name string
 
@@ -3848,17 +3690,15 @@ type Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611 struct
 
 type Google_compute_region_autoscaler_autoscaling_policy_1608 struct {
 
-    Google_compute_region_autoscaler_autoscaling_policy_1608_id *string `lyra:"ignore"`
-
     Cooldown_period *int
 
-    Cpu_utilization *Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609
+    Cpu_utilization *[]Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609
 
-    Load_balancing_utilization *Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610
+    Load_balancing_utilization *[]Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610
 
     Max_replicas int
 
-    Metric *Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611
+    Metric *[]Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611
 
     Min_replicas int
 
@@ -3868,7 +3708,7 @@ type Google_compute_region_autoscaler struct {
 
     Google_compute_region_autoscaler_id *string `lyra:"ignore"`
 
-    Autoscaling_policy Google_compute_region_autoscaler_autoscaling_policy_1608
+    Autoscaling_policy []Google_compute_region_autoscaler_autoscaling_policy_1608
 
     Creation_timestamp *string
 
@@ -3924,8 +3764,6 @@ func (h *Google_compute_region_autoscalerHandler) Delete(externalID string) erro
 }
 
 type Google_compute_region_backend_service_backend_1612 struct {
-
-    Google_compute_region_backend_service_backend_1612_id *string `lyra:"ignore"`
 
     Description *string
 
@@ -4002,8 +3840,6 @@ func (h *Google_compute_region_backend_serviceHandler) Delete(externalID string)
 
 type Google_compute_region_disk_disk_encryption_key_1613 struct {
 
-    Google_compute_region_disk_disk_encryption_key_1613_id *string `lyra:"ignore"`
-
     Raw_key *string
 
     Sha256 *string
@@ -4011,8 +3847,6 @@ type Google_compute_region_disk_disk_encryption_key_1613 struct {
 }
 
 type Google_compute_region_disk_source_snapshot_encryption_key_1614 struct {
-
-    Google_compute_region_disk_source_snapshot_encryption_key_1614_id *string `lyra:"ignore"`
 
     Raw_key *string
 
@@ -4028,7 +3862,7 @@ type Google_compute_region_disk struct {
 
     Description *string
 
-    Disk_encryption_key *Google_compute_region_disk_disk_encryption_key_1613
+    Disk_encryption_key *[]Google_compute_region_disk_disk_encryption_key_1613
 
     Label_fingerprint *string
 
@@ -4052,7 +3886,7 @@ type Google_compute_region_disk struct {
 
     Snapshot *string
 
-    Source_snapshot_encryption_key *Google_compute_region_disk_source_snapshot_encryption_key_1614
+    Source_snapshot_encryption_key *[]Google_compute_region_disk_source_snapshot_encryption_key_1614
 
     Source_snapshot_id *string
 
@@ -4101,8 +3935,6 @@ func (h *Google_compute_region_diskHandler) Delete(externalID string) error {
 
 type Google_compute_region_instance_group_manager_auto_healing_policies_1615 struct {
 
-    Google_compute_region_instance_group_manager_auto_healing_policies_1615_id *string `lyra:"ignore"`
-
     Health_check string
 
     Initial_delay_sec int
@@ -4111,8 +3943,6 @@ type Google_compute_region_instance_group_manager_auto_healing_policies_1615 str
 
 type Google_compute_region_instance_group_manager_named_port_1616 struct {
 
-    Google_compute_region_instance_group_manager_named_port_1616_id *string `lyra:"ignore"`
-
     Name string
 
     Port int
@@ -4120,8 +3950,6 @@ type Google_compute_region_instance_group_manager_named_port_1616 struct {
 }
 
 type Google_compute_region_instance_group_manager_rolling_update_policy_1617 struct {
-
-    Google_compute_region_instance_group_manager_rolling_update_policy_1617_id *string `lyra:"ignore"`
 
     Max_surge_fixed *int
 
@@ -4141,8 +3969,6 @@ type Google_compute_region_instance_group_manager_rolling_update_policy_1617 str
 
 type Google_compute_region_instance_group_manager_version_1618_target_size_1619 struct {
 
-    Google_compute_region_instance_group_manager_version_1618_target_size_1619_id *string `lyra:"ignore"`
-
     Fixed *int
 
     Percent *int
@@ -4151,13 +3977,11 @@ type Google_compute_region_instance_group_manager_version_1618_target_size_1619 
 
 type Google_compute_region_instance_group_manager_version_1618 struct {
 
-    Google_compute_region_instance_group_manager_version_1618_id *string `lyra:"ignore"`
-
     Instance_template string
 
     Name string
 
-    Target_size *Google_compute_region_instance_group_manager_version_1618_target_size_1619
+    Target_size *[]Google_compute_region_instance_group_manager_version_1618_target_size_1619
 
 }
 
@@ -4165,7 +3989,7 @@ type Google_compute_region_instance_group_manager struct {
 
     Google_compute_region_instance_group_manager_id *string `lyra:"ignore"`
 
-    Auto_healing_policies *Google_compute_region_instance_group_manager_auto_healing_policies_1615
+    Auto_healing_policies *[]Google_compute_region_instance_group_manager_auto_healing_policies_1615
 
     Base_instance_name string
 
@@ -4181,13 +4005,13 @@ type Google_compute_region_instance_group_manager struct {
 
     Name string
 
-    Named_port *Google_compute_region_instance_group_manager_named_port_1616
+    Named_port *[]Google_compute_region_instance_group_manager_named_port_1616
 
     Project *string
 
     Region string
 
-    Rolling_update_policy *Google_compute_region_instance_group_manager_rolling_update_policy_1617
+    Rolling_update_policy *[]Google_compute_region_instance_group_manager_rolling_update_policy_1617
 
     Self_link *string
 
@@ -4197,7 +4021,7 @@ type Google_compute_region_instance_group_manager struct {
 
     Update_strategy *string
 
-    Version *Google_compute_region_instance_group_manager_version_1618
+    Version *[]Google_compute_region_instance_group_manager_version_1618
 
     Wait_for_instances *bool
 
@@ -4313,8 +4137,6 @@ func (h *Google_compute_routeHandler) Delete(externalID string) error {
 
 type Google_compute_router_bgp_1620_advertised_ip_ranges_1621 struct {
 
-    Google_compute_router_bgp_1620_advertised_ip_ranges_1621_id *string `lyra:"ignore"`
-
     Description *string
 
     Range *string
@@ -4323,13 +4145,11 @@ type Google_compute_router_bgp_1620_advertised_ip_ranges_1621 struct {
 
 type Google_compute_router_bgp_1620 struct {
 
-    Google_compute_router_bgp_1620_id *string `lyra:"ignore"`
-
     Advertise_mode *string
 
     Advertised_groups *[]string
 
-    Advertised_ip_ranges *Google_compute_router_bgp_1620_advertised_ip_ranges_1621
+    Advertised_ip_ranges *[]Google_compute_router_bgp_1620_advertised_ip_ranges_1621
 
     Asn int
 
@@ -4339,7 +4159,7 @@ type Google_compute_router struct {
 
     Google_compute_router_id *string `lyra:"ignore"`
 
-    Bgp *Google_compute_router_bgp_1620
+    Bgp *[]Google_compute_router_bgp_1620
 
     Creation_timestamp *string
 
@@ -4450,8 +4270,6 @@ func (h *Google_compute_router_interfaceHandler) Delete(externalID string) error
 }
 
 type Google_compute_router_nat_subnetwork_1622 struct {
-
-    Google_compute_router_nat_subnetwork_1622_id *string `lyra:"ignore"`
 
     Name string
 
@@ -4593,17 +4411,13 @@ func (h *Google_compute_router_peerHandler) Delete(externalID string) error {
 
 type Google_compute_security_policy_rule_1623_match_1624_config_1625 struct {
 
-    Google_compute_security_policy_rule_1623_match_1624_config_1625_id *string `lyra:"ignore"`
-
     Src_ip_ranges []string
 
 }
 
 type Google_compute_security_policy_rule_1623_match_1624 struct {
 
-    Google_compute_security_policy_rule_1623_match_1624_id *string `lyra:"ignore"`
-
-    Config Google_compute_security_policy_rule_1623_match_1624_config_1625
+    Config []Google_compute_security_policy_rule_1623_match_1624_config_1625
 
     Versioned_expr string
 
@@ -4611,13 +4425,11 @@ type Google_compute_security_policy_rule_1623_match_1624 struct {
 
 type Google_compute_security_policy_rule_1623 struct {
 
-    Google_compute_security_policy_rule_1623_id *string `lyra:"ignore"`
-
     Action string
 
     Description *string
 
-    Match Google_compute_security_policy_rule_1623_match_1624
+    Match []Google_compute_security_policy_rule_1623_match_1624
 
     Preview *bool
 
@@ -4774,8 +4586,6 @@ func (h *Google_compute_shared_vpc_service_projectHandler) Delete(externalID str
 
 type Google_compute_snapshot_snapshot_encryption_key_1626 struct {
 
-    Google_compute_snapshot_snapshot_encryption_key_1626_id *string `lyra:"ignore"`
-
     Raw_key *string
 
     Sha256 *string
@@ -4783,8 +4593,6 @@ type Google_compute_snapshot_snapshot_encryption_key_1626 struct {
 }
 
 type Google_compute_snapshot_source_disk_encryption_key_1627 struct {
-
-    Google_compute_snapshot_source_disk_encryption_key_1627_id *string `lyra:"ignore"`
 
     Raw_key *string
 
@@ -4812,7 +4620,7 @@ type Google_compute_snapshot struct {
 
     Self_link *string
 
-    Snapshot_encryption_key *Google_compute_snapshot_snapshot_encryption_key_1626
+    Snapshot_encryption_key *[]Google_compute_snapshot_snapshot_encryption_key_1626
 
     Snapshot_encryption_key_raw *string
 
@@ -4822,7 +4630,7 @@ type Google_compute_snapshot struct {
 
     Source_disk string
 
-    Source_disk_encryption_key *Google_compute_snapshot_source_disk_encryption_key_1627
+    Source_disk_encryption_key *[]Google_compute_snapshot_source_disk_encryption_key_1627
 
     Source_disk_encryption_key_raw *string
 
@@ -4999,8 +4807,6 @@ func (h *Google_compute_ssl_policyHandler) Delete(externalID string) error {
 
 type Google_compute_subnetwork_secondary_ip_range_1628 struct {
 
-    Google_compute_subnetwork_secondary_ip_range_1628_id *string `lyra:"ignore"`
-
     Ip_cidr_range string
 
     Range_name string
@@ -5033,7 +4839,7 @@ type Google_compute_subnetwork struct {
 
     Region *string
 
-    Secondary_ip_range *Google_compute_subnetwork_secondary_ip_range_1628
+    Secondary_ip_range *[]Google_compute_subnetwork_secondary_ip_range_1628
 
     Self_link *string
 
@@ -5546,8 +5352,6 @@ func (h *Google_compute_target_tcp_proxyHandler) Delete(externalID string) error
 
 type Google_compute_url_map_host_rule_1629 struct {
 
-    Google_compute_url_map_host_rule_1629_id *string `lyra:"ignore"`
-
     Description *string
 
     Hosts []string
@@ -5558,8 +5362,6 @@ type Google_compute_url_map_host_rule_1629 struct {
 
 type Google_compute_url_map_path_matcher_1630_path_rule_1631 struct {
 
-    Google_compute_url_map_path_matcher_1630_path_rule_1631_id *string `lyra:"ignore"`
-
     Paths []string
 
     Service string
@@ -5568,21 +5370,17 @@ type Google_compute_url_map_path_matcher_1630_path_rule_1631 struct {
 
 type Google_compute_url_map_path_matcher_1630 struct {
 
-    Google_compute_url_map_path_matcher_1630_id *string `lyra:"ignore"`
-
     Default_service string
 
     Description *string
 
     Name string
 
-    Path_rule *Google_compute_url_map_path_matcher_1630_path_rule_1631
+    Path_rule *[]Google_compute_url_map_path_matcher_1630_path_rule_1631
 
 }
 
 type Google_compute_url_map_test_1632 struct {
-
-    Google_compute_url_map_test_1632_id *string `lyra:"ignore"`
 
     Description *string
 
@@ -5610,13 +5408,13 @@ type Google_compute_url_map struct {
 
     Name string
 
-    Path_matcher *Google_compute_url_map_path_matcher_1630
+    Path_matcher *[]Google_compute_url_map_path_matcher_1630
 
     Project *string
 
     Self_link *string
 
-    Test *Google_compute_url_map_test_1632
+    Test *[]Google_compute_url_map_test_1632
 
 }
 
@@ -5793,17 +5591,13 @@ func (h *Google_compute_vpn_tunnelHandler) Delete(externalID string) error {
 
 type Google_container_analysis_note_attestation_authority_1633_hint_1634 struct {
 
-    Google_container_analysis_note_attestation_authority_1633_hint_1634_id *string `lyra:"ignore"`
-
     Human_readable_name string
 
 }
 
 type Google_container_analysis_note_attestation_authority_1633 struct {
 
-    Google_container_analysis_note_attestation_authority_1633_id *string `lyra:"ignore"`
-
-    Hint Google_container_analysis_note_attestation_authority_1633_hint_1634
+    Hint []Google_container_analysis_note_attestation_authority_1633_hint_1634
 
 }
 
@@ -5811,7 +5605,7 @@ type Google_container_analysis_note struct {
 
     Google_container_analysis_note_id *string `lyra:"ignore"`
 
-    Attestation_authority Google_container_analysis_note_attestation_authority_1633
+    Attestation_authority []Google_container_analysis_note_attestation_authority_1633
 
     Name string
 
@@ -5858,15 +5652,11 @@ func (h *Google_container_analysis_noteHandler) Delete(externalID string) error 
 
 type Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636 struct {
 
-    Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636_id *string `lyra:"ignore"`
-
     Disabled *bool
 
 }
 
 type Google_container_cluster_addons_config_1635_http_load_balancing_1637 struct {
-
-    Google_container_cluster_addons_config_1635_http_load_balancing_1637_id *string `lyra:"ignore"`
 
     Disabled *bool
 
@@ -5874,15 +5664,11 @@ type Google_container_cluster_addons_config_1635_http_load_balancing_1637 struct
 
 type Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638 struct {
 
-    Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638_id *string `lyra:"ignore"`
-
     Disabled *bool
 
 }
 
 type Google_container_cluster_addons_config_1635_network_policy_config_1639 struct {
-
-    Google_container_cluster_addons_config_1635_network_policy_config_1639_id *string `lyra:"ignore"`
 
     Disabled *bool
 
@@ -5890,21 +5676,17 @@ type Google_container_cluster_addons_config_1635_network_policy_config_1639 stru
 
 type Google_container_cluster_addons_config_1635 struct {
 
-    Google_container_cluster_addons_config_1635_id *string `lyra:"ignore"`
+    Horizontal_pod_autoscaling *[]Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636
 
-    Horizontal_pod_autoscaling *Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636
+    Http_load_balancing *[]Google_container_cluster_addons_config_1635_http_load_balancing_1637
 
-    Http_load_balancing *Google_container_cluster_addons_config_1635_http_load_balancing_1637
+    Kubernetes_dashboard *[]Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638
 
-    Kubernetes_dashboard *Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638
-
-    Network_policy_config *Google_container_cluster_addons_config_1635_network_policy_config_1639
+    Network_policy_config *[]Google_container_cluster_addons_config_1635_network_policy_config_1639
 
 }
 
 type Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641 struct {
-
-    Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641_id *string `lyra:"ignore"`
 
     Maximum *int
 
@@ -5916,17 +5698,13 @@ type Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641 stru
 
 type Google_container_cluster_cluster_autoscaling_1640 struct {
 
-    Google_container_cluster_cluster_autoscaling_1640_id *string `lyra:"ignore"`
-
     Enabled bool
 
-    Resource_limits *Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641
+    Resource_limits *[]Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641
 
 }
 
 type Google_container_cluster_ip_allocation_policy_1642 struct {
-
-    Google_container_cluster_ip_allocation_policy_1642_id *string `lyra:"ignore"`
 
     Cluster_ipv4_cidr_block *string
 
@@ -5944,8 +5722,6 @@ type Google_container_cluster_ip_allocation_policy_1642 struct {
 
 type Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644 struct {
 
-    Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644_id *string `lyra:"ignore"`
-
     Duration *string
 
     Start_time string
@@ -5954,15 +5730,11 @@ type Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1
 
 type Google_container_cluster_maintenance_policy_1643 struct {
 
-    Google_container_cluster_maintenance_policy_1643_id *string `lyra:"ignore"`
-
-    Daily_maintenance_window Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644
+    Daily_maintenance_window []Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644
 
 }
 
 type Google_container_cluster_master_auth_1645_client_certificate_config_1646 struct {
-
-    Google_container_cluster_master_auth_1645_client_certificate_config_1646_id *string `lyra:"ignore"`
 
     Issue_client_certificate bool
 
@@ -5970,11 +5742,9 @@ type Google_container_cluster_master_auth_1645_client_certificate_config_1646 st
 
 type Google_container_cluster_master_auth_1645 struct {
 
-    Google_container_cluster_master_auth_1645_id *string `lyra:"ignore"`
-
     Client_certificate *string
 
-    Client_certificate_config *Google_container_cluster_master_auth_1645_client_certificate_config_1646
+    Client_certificate_config *[]Google_container_cluster_master_auth_1645_client_certificate_config_1646
 
     Client_key *string
 
@@ -5988,8 +5758,6 @@ type Google_container_cluster_master_auth_1645 struct {
 
 type Google_container_cluster_master_authorized_networks_config_1647_cidr_blocks_1648 struct {
 
-    Google_container_cluster_master_authorized_networks_config_1647_cidr_blocks_1648_id *string `lyra:"ignore"`
-
     Cidr_block string
 
     Display_name *string
@@ -5998,15 +5766,11 @@ type Google_container_cluster_master_authorized_networks_config_1647_cidr_blocks
 
 type Google_container_cluster_master_authorized_networks_config_1647 struct {
 
-    Google_container_cluster_master_authorized_networks_config_1647_id *string `lyra:"ignore"`
-
     Cidr_blocks *Google_container_cluster_master_authorized_networks_config_1647_cidr_blocks_1648
 
 }
 
 type Google_container_cluster_network_policy_1649 struct {
-
-    Google_container_cluster_network_policy_1649_id *string `lyra:"ignore"`
 
     Enabled *bool
 
@@ -6016,8 +5780,6 @@ type Google_container_cluster_network_policy_1649 struct {
 
 type Google_container_cluster_node_config_1650_guest_accelerator_1651 struct {
 
-    Google_container_cluster_node_config_1650_guest_accelerator_1651_id *string `lyra:"ignore"`
-
     Count int
 
     Type string
@@ -6025,8 +5787,6 @@ type Google_container_cluster_node_config_1650_guest_accelerator_1651 struct {
 }
 
 type Google_container_cluster_node_config_1650_taint_1652 struct {
-
-    Google_container_cluster_node_config_1650_taint_1652_id *string `lyra:"ignore"`
 
     Effect string
 
@@ -6038,21 +5798,17 @@ type Google_container_cluster_node_config_1650_taint_1652 struct {
 
 type Google_container_cluster_node_config_1650_workload_metadata_config_1653 struct {
 
-    Google_container_cluster_node_config_1650_workload_metadata_config_1653_id *string `lyra:"ignore"`
-
     Node_metadata string
 
 }
 
 type Google_container_cluster_node_config_1650 struct {
 
-    Google_container_cluster_node_config_1650_id *string `lyra:"ignore"`
-
     Disk_size_gb *int
 
     Disk_type *string
 
-    Guest_accelerator *Google_container_cluster_node_config_1650_guest_accelerator_1651
+    Guest_accelerator *[]Google_container_cluster_node_config_1650_guest_accelerator_1651
 
     Image_type *string
 
@@ -6074,15 +5830,13 @@ type Google_container_cluster_node_config_1650 struct {
 
     Tags *[]string
 
-    Taint *Google_container_cluster_node_config_1650_taint_1652
+    Taint *[]Google_container_cluster_node_config_1650_taint_1652
 
-    Workload_metadata_config *Google_container_cluster_node_config_1650_workload_metadata_config_1653
+    Workload_metadata_config *[]Google_container_cluster_node_config_1650_workload_metadata_config_1653
 
 }
 
 type Google_container_cluster_node_pool_1654_autoscaling_1655 struct {
-
-    Google_container_cluster_node_pool_1654_autoscaling_1655_id *string `lyra:"ignore"`
 
     Max_node_count int
 
@@ -6092,8 +5846,6 @@ type Google_container_cluster_node_pool_1654_autoscaling_1655 struct {
 
 type Google_container_cluster_node_pool_1654_management_1656 struct {
 
-    Google_container_cluster_node_pool_1654_management_1656_id *string `lyra:"ignore"`
-
     Auto_repair *bool
 
     Auto_upgrade *bool
@@ -6102,8 +5854,6 @@ type Google_container_cluster_node_pool_1654_management_1656 struct {
 
 type Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658 struct {
 
-    Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658_id *string `lyra:"ignore"`
-
     Count int
 
     Type string
@@ -6111,8 +5861,6 @@ type Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_
 }
 
 type Google_container_cluster_node_pool_1654_node_config_1657_taint_1659 struct {
-
-    Google_container_cluster_node_pool_1654_node_config_1657_taint_1659_id *string `lyra:"ignore"`
 
     Effect string
 
@@ -6124,21 +5872,17 @@ type Google_container_cluster_node_pool_1654_node_config_1657_taint_1659 struct 
 
 type Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660 struct {
 
-    Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660_id *string `lyra:"ignore"`
-
     Node_metadata string
 
 }
 
 type Google_container_cluster_node_pool_1654_node_config_1657 struct {
 
-    Google_container_cluster_node_pool_1654_node_config_1657_id *string `lyra:"ignore"`
-
     Disk_size_gb *int
 
     Disk_type *string
 
-    Guest_accelerator *Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658
+    Guest_accelerator *[]Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658
 
     Image_type *string
 
@@ -6160,23 +5904,21 @@ type Google_container_cluster_node_pool_1654_node_config_1657 struct {
 
     Tags *[]string
 
-    Taint *Google_container_cluster_node_pool_1654_node_config_1657_taint_1659
+    Taint *[]Google_container_cluster_node_pool_1654_node_config_1657_taint_1659
 
-    Workload_metadata_config *Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660
+    Workload_metadata_config *[]Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660
 
 }
 
 type Google_container_cluster_node_pool_1654 struct {
 
-    Google_container_cluster_node_pool_1654_id *string `lyra:"ignore"`
-
-    Autoscaling *Google_container_cluster_node_pool_1654_autoscaling_1655
+    Autoscaling *[]Google_container_cluster_node_pool_1654_autoscaling_1655
 
     Initial_node_count *int
 
     Instance_group_urls *[]string
 
-    Management *Google_container_cluster_node_pool_1654_management_1656
+    Management *[]Google_container_cluster_node_pool_1654_management_1656
 
     Max_pods_per_node *int
 
@@ -6184,7 +5926,7 @@ type Google_container_cluster_node_pool_1654 struct {
 
     Name_prefix *string
 
-    Node_config *Google_container_cluster_node_pool_1654_node_config_1657
+    Node_config *[]Google_container_cluster_node_pool_1654_node_config_1657
 
     Node_count *int
 
@@ -6194,15 +5936,11 @@ type Google_container_cluster_node_pool_1654 struct {
 
 type Google_container_cluster_pod_security_policy_config_1661 struct {
 
-    Google_container_cluster_pod_security_policy_config_1661_id *string `lyra:"ignore"`
-
     Enabled bool
 
 }
 
 type Google_container_cluster_private_cluster_config_1662 struct {
-
-    Google_container_cluster_private_cluster_config_1662_id *string `lyra:"ignore"`
 
     Enable_private_endpoint *bool
 
@@ -6222,9 +5960,9 @@ type Google_container_cluster struct {
 
     Additional_zones *[]string
 
-    Addons_config *Google_container_cluster_addons_config_1635
+    Addons_config *[]Google_container_cluster_addons_config_1635
 
-    Cluster_autoscaling *Google_container_cluster_cluster_autoscaling_1640
+    Cluster_autoscaling *[]Google_container_cluster_cluster_autoscaling_1640
 
     Cluster_ipv4_cidr *string
 
@@ -6244,15 +5982,15 @@ type Google_container_cluster struct {
 
     Instance_group_urls *[]string
 
-    Ip_allocation_policy *Google_container_cluster_ip_allocation_policy_1642
+    Ip_allocation_policy *[]Google_container_cluster_ip_allocation_policy_1642
 
     Logging_service *string
 
-    Maintenance_policy *Google_container_cluster_maintenance_policy_1643
+    Maintenance_policy *[]Google_container_cluster_maintenance_policy_1643
 
-    Master_auth *Google_container_cluster_master_auth_1645
+    Master_auth *[]Google_container_cluster_master_auth_1645
 
-    Master_authorized_networks_config *Google_container_cluster_master_authorized_networks_config_1647
+    Master_authorized_networks_config *[]Google_container_cluster_master_authorized_networks_config_1647
 
     Master_ipv4_cidr_block *string
 
@@ -6266,19 +6004,19 @@ type Google_container_cluster struct {
 
     Network *string
 
-    Network_policy *Google_container_cluster_network_policy_1649
+    Network_policy *[]Google_container_cluster_network_policy_1649
 
-    Node_config *Google_container_cluster_node_config_1650
+    Node_config *[]Google_container_cluster_node_config_1650
 
-    Node_pool *Google_container_cluster_node_pool_1654
+    Node_pool *[]Google_container_cluster_node_pool_1654
 
     Node_version *string
 
-    Pod_security_policy_config *Google_container_cluster_pod_security_policy_config_1661
+    Pod_security_policy_config *[]Google_container_cluster_pod_security_policy_config_1661
 
     Private_cluster *bool
 
-    Private_cluster_config *Google_container_cluster_private_cluster_config_1662
+    Private_cluster_config *[]Google_container_cluster_private_cluster_config_1662
 
     Project *string
 
@@ -6333,8 +6071,6 @@ func (h *Google_container_clusterHandler) Delete(externalID string) error {
 
 type Google_container_node_pool_autoscaling_1663 struct {
 
-    Google_container_node_pool_autoscaling_1663_id *string `lyra:"ignore"`
-
     Max_node_count int
 
     Min_node_count int
@@ -6342,8 +6078,6 @@ type Google_container_node_pool_autoscaling_1663 struct {
 }
 
 type Google_container_node_pool_management_1664 struct {
-
-    Google_container_node_pool_management_1664_id *string `lyra:"ignore"`
 
     Auto_repair *bool
 
@@ -6353,8 +6087,6 @@ type Google_container_node_pool_management_1664 struct {
 
 type Google_container_node_pool_node_config_1665_guest_accelerator_1666 struct {
 
-    Google_container_node_pool_node_config_1665_guest_accelerator_1666_id *string `lyra:"ignore"`
-
     Count int
 
     Type string
@@ -6362,8 +6094,6 @@ type Google_container_node_pool_node_config_1665_guest_accelerator_1666 struct {
 }
 
 type Google_container_node_pool_node_config_1665_taint_1667 struct {
-
-    Google_container_node_pool_node_config_1665_taint_1667_id *string `lyra:"ignore"`
 
     Effect string
 
@@ -6375,21 +6105,17 @@ type Google_container_node_pool_node_config_1665_taint_1667 struct {
 
 type Google_container_node_pool_node_config_1665_workload_metadata_config_1668 struct {
 
-    Google_container_node_pool_node_config_1665_workload_metadata_config_1668_id *string `lyra:"ignore"`
-
     Node_metadata string
 
 }
 
 type Google_container_node_pool_node_config_1665 struct {
 
-    Google_container_node_pool_node_config_1665_id *string `lyra:"ignore"`
-
     Disk_size_gb *int
 
     Disk_type *string
 
-    Guest_accelerator *Google_container_node_pool_node_config_1665_guest_accelerator_1666
+    Guest_accelerator *[]Google_container_node_pool_node_config_1665_guest_accelerator_1666
 
     Image_type *string
 
@@ -6411,9 +6137,9 @@ type Google_container_node_pool_node_config_1665 struct {
 
     Tags *[]string
 
-    Taint *Google_container_node_pool_node_config_1665_taint_1667
+    Taint *[]Google_container_node_pool_node_config_1665_taint_1667
 
-    Workload_metadata_config *Google_container_node_pool_node_config_1665_workload_metadata_config_1668
+    Workload_metadata_config *[]Google_container_node_pool_node_config_1665_workload_metadata_config_1668
 
 }
 
@@ -6421,7 +6147,7 @@ type Google_container_node_pool struct {
 
     Google_container_node_pool_id *string `lyra:"ignore"`
 
-    Autoscaling *Google_container_node_pool_autoscaling_1663
+    Autoscaling *[]Google_container_node_pool_autoscaling_1663
 
     Cluster string
 
@@ -6429,7 +6155,7 @@ type Google_container_node_pool struct {
 
     Instance_group_urls *[]string
 
-    Management *Google_container_node_pool_management_1664
+    Management *[]Google_container_node_pool_management_1664
 
     Max_pods_per_node *int
 
@@ -6437,7 +6163,7 @@ type Google_container_node_pool struct {
 
     Name_prefix *string
 
-    Node_config *Google_container_node_pool_node_config_1665
+    Node_config *[]Google_container_node_pool_node_config_1665
 
     Node_count *int
 
@@ -6553,8 +6279,6 @@ func (h *Google_dataflow_jobHandler) Delete(externalID string) error {
 
 type Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670_id *string `lyra:"ignore"`
-
     Internal_ip_only *bool
 
     Metadata *map[string]string
@@ -6575,8 +6299,6 @@ type Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670 struct 
 
 type Google_dataproc_cluster_cluster_config_1669_initialization_action_1671 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_initialization_action_1671_id *string `lyra:"ignore"`
-
     Script string
 
     Timeout_sec *int
@@ -6584,8 +6306,6 @@ type Google_dataproc_cluster_cluster_config_1669_initialization_action_1671 stru
 }
 
 type Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673 struct {
-
-    Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673_id *string `lyra:"ignore"`
 
     Boot_disk_size_gb *int
 
@@ -6597,9 +6317,7 @@ type Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_
 
 type Google_dataproc_cluster_cluster_config_1669_master_config_1672 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_master_config_1672_id *string `lyra:"ignore"`
-
-    Disk_config *Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673
+    Disk_config *[]Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673
 
     Instance_names *[]string
 
@@ -6611,17 +6329,13 @@ type Google_dataproc_cluster_cluster_config_1669_master_config_1672 struct {
 
 type Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675_id *string `lyra:"ignore"`
-
     Boot_disk_size_gb *int
 
 }
 
 type Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_id *string `lyra:"ignore"`
-
-    Disk_config *Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675
+    Disk_config *[]Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675
 
     Instance_names *[]string
 
@@ -6630,8 +6344,6 @@ type Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674 
 }
 
 type Google_dataproc_cluster_cluster_config_1669_software_config_1676 struct {
-
-    Google_dataproc_cluster_cluster_config_1669_software_config_1676_id *string `lyra:"ignore"`
 
     Image_version *string
 
@@ -6643,8 +6355,6 @@ type Google_dataproc_cluster_cluster_config_1669_software_config_1676 struct {
 
 type Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678_id *string `lyra:"ignore"`
-
     Boot_disk_size_gb *int
 
     Boot_disk_type *string
@@ -6655,9 +6365,7 @@ type Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_
 
 type Google_dataproc_cluster_cluster_config_1669_worker_config_1677 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_worker_config_1677_id *string `lyra:"ignore"`
-
-    Disk_config *Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678
+    Disk_config *[]Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678
 
     Instance_names *[]string
 
@@ -6669,25 +6377,23 @@ type Google_dataproc_cluster_cluster_config_1669_worker_config_1677 struct {
 
 type Google_dataproc_cluster_cluster_config_1669 struct {
 
-    Google_dataproc_cluster_cluster_config_1669_id *string `lyra:"ignore"`
-
     Bucket *string
 
     Delete_autogen_bucket *bool
 
-    Gce_cluster_config *Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670
+    Gce_cluster_config *[]Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670
 
-    Initialization_action *Google_dataproc_cluster_cluster_config_1669_initialization_action_1671
+    Initialization_action *[]Google_dataproc_cluster_cluster_config_1669_initialization_action_1671
 
-    Master_config *Google_dataproc_cluster_cluster_config_1669_master_config_1672
+    Master_config *[]Google_dataproc_cluster_cluster_config_1669_master_config_1672
 
-    Preemptible_worker_config *Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674
+    Preemptible_worker_config *[]Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674
 
-    Software_config *Google_dataproc_cluster_cluster_config_1669_software_config_1676
+    Software_config *[]Google_dataproc_cluster_cluster_config_1669_software_config_1676
 
     Staging_bucket *string
 
-    Worker_config *Google_dataproc_cluster_cluster_config_1669_worker_config_1677
+    Worker_config *[]Google_dataproc_cluster_cluster_config_1669_worker_config_1677
 
 }
 
@@ -6695,7 +6401,7 @@ type Google_dataproc_cluster struct {
 
     Google_dataproc_cluster_id *string `lyra:"ignore"`
 
-    Cluster_config *Google_dataproc_cluster_cluster_config_1669
+    Cluster_config *[]Google_dataproc_cluster_cluster_config_1669
 
     Labels *map[string]string
 
@@ -6746,15 +6452,11 @@ func (h *Google_dataproc_clusterHandler) Delete(externalID string) error {
 
 type Google_dataproc_job_hadoop_config_1679_logging_config_1680 struct {
 
-    Google_dataproc_job_hadoop_config_1679_logging_config_1680_id *string `lyra:"ignore"`
-
     Driver_log_levels *map[string]string
 
 }
 
 type Google_dataproc_job_hadoop_config_1679 struct {
-
-    Google_dataproc_job_hadoop_config_1679_id *string `lyra:"ignore"`
 
     Archive_uris *[]string
 
@@ -6764,7 +6466,7 @@ type Google_dataproc_job_hadoop_config_1679 struct {
 
     Jar_file_uris *[]string
 
-    Logging_config *Google_dataproc_job_hadoop_config_1679_logging_config_1680
+    Logging_config *[]Google_dataproc_job_hadoop_config_1679_logging_config_1680
 
     Main_class *string
 
@@ -6775,8 +6477,6 @@ type Google_dataproc_job_hadoop_config_1679 struct {
 }
 
 type Google_dataproc_job_hive_config_1681 struct {
-
-    Google_dataproc_job_hive_config_1681_id *string `lyra:"ignore"`
 
     Continue_on_failure *bool
 
@@ -6794,21 +6494,17 @@ type Google_dataproc_job_hive_config_1681 struct {
 
 type Google_dataproc_job_pig_config_1682_logging_config_1683 struct {
 
-    Google_dataproc_job_pig_config_1682_logging_config_1683_id *string `lyra:"ignore"`
-
     Driver_log_levels *map[string]string
 
 }
 
 type Google_dataproc_job_pig_config_1682 struct {
 
-    Google_dataproc_job_pig_config_1682_id *string `lyra:"ignore"`
-
     Continue_on_failure *bool
 
     Jar_file_uris *[]string
 
-    Logging_config *Google_dataproc_job_pig_config_1682_logging_config_1683
+    Logging_config *[]Google_dataproc_job_pig_config_1682_logging_config_1683
 
     Properties *map[string]string
 
@@ -6822,8 +6518,6 @@ type Google_dataproc_job_pig_config_1682 struct {
 
 type Google_dataproc_job_placement_1684 struct {
 
-    Google_dataproc_job_placement_1684_id *string `lyra:"ignore"`
-
     Cluster_name string
 
     Cluster_uuid *string
@@ -6832,15 +6526,11 @@ type Google_dataproc_job_placement_1684 struct {
 
 type Google_dataproc_job_pyspark_config_1685_logging_config_1686 struct {
 
-    Google_dataproc_job_pyspark_config_1685_logging_config_1686_id *string `lyra:"ignore"`
-
     Driver_log_levels *map[string]string
 
 }
 
 type Google_dataproc_job_pyspark_config_1685 struct {
-
-    Google_dataproc_job_pyspark_config_1685_id *string `lyra:"ignore"`
 
     Archive_uris *[]string
 
@@ -6850,7 +6540,7 @@ type Google_dataproc_job_pyspark_config_1685 struct {
 
     Jar_file_uris *[]string
 
-    Logging_config *Google_dataproc_job_pyspark_config_1685_logging_config_1686
+    Logging_config *[]Google_dataproc_job_pyspark_config_1685_logging_config_1686
 
     Main_python_file_uri string
 
@@ -6862,15 +6552,11 @@ type Google_dataproc_job_pyspark_config_1685 struct {
 
 type Google_dataproc_job_reference_1687 struct {
 
-    Google_dataproc_job_reference_1687_id *string `lyra:"ignore"`
-
     Job_id *string
 
 }
 
 type Google_dataproc_job_scheduling_1688 struct {
-
-    Google_dataproc_job_scheduling_1688_id *string `lyra:"ignore"`
 
     Max_failures_per_hour *int
 
@@ -6878,15 +6564,11 @@ type Google_dataproc_job_scheduling_1688 struct {
 
 type Google_dataproc_job_spark_config_1689_logging_config_1690 struct {
 
-    Google_dataproc_job_spark_config_1689_logging_config_1690_id *string `lyra:"ignore"`
-
     Driver_log_levels *map[string]string
 
 }
 
 type Google_dataproc_job_spark_config_1689 struct {
-
-    Google_dataproc_job_spark_config_1689_id *string `lyra:"ignore"`
 
     Archive_uris *[]string
 
@@ -6896,7 +6578,7 @@ type Google_dataproc_job_spark_config_1689 struct {
 
     Jar_file_uris *[]string
 
-    Logging_config *Google_dataproc_job_spark_config_1689_logging_config_1690
+    Logging_config *[]Google_dataproc_job_spark_config_1689_logging_config_1690
 
     Main_class *string
 
@@ -6908,19 +6590,15 @@ type Google_dataproc_job_spark_config_1689 struct {
 
 type Google_dataproc_job_sparksql_config_1691_logging_config_1692 struct {
 
-    Google_dataproc_job_sparksql_config_1691_logging_config_1692_id *string `lyra:"ignore"`
-
     Driver_log_levels *map[string]string
 
 }
 
 type Google_dataproc_job_sparksql_config_1691 struct {
 
-    Google_dataproc_job_sparksql_config_1691_id *string `lyra:"ignore"`
-
     Jar_file_uris *[]string
 
-    Logging_config *Google_dataproc_job_sparksql_config_1691_logging_config_1692
+    Logging_config *[]Google_dataproc_job_sparksql_config_1691_logging_config_1692
 
     Properties *map[string]string
 
@@ -6933,8 +6611,6 @@ type Google_dataproc_job_sparksql_config_1691 struct {
 }
 
 type Google_dataproc_job_status_1693 struct {
-
-    Google_dataproc_job_status_1693_id *string `lyra:"ignore"`
 
     Details *string
 
@@ -6956,31 +6632,31 @@ type Google_dataproc_job struct {
 
     Force_delete *bool
 
-    Hadoop_config *Google_dataproc_job_hadoop_config_1679
+    Hadoop_config *[]Google_dataproc_job_hadoop_config_1679
 
-    Hive_config *Google_dataproc_job_hive_config_1681
+    Hive_config *[]Google_dataproc_job_hive_config_1681
 
     Labels *map[string]string
 
-    Pig_config *Google_dataproc_job_pig_config_1682
+    Pig_config *[]Google_dataproc_job_pig_config_1682
 
-    Placement Google_dataproc_job_placement_1684
+    Placement []Google_dataproc_job_placement_1684
 
     Project *string
 
-    Pyspark_config *Google_dataproc_job_pyspark_config_1685
+    Pyspark_config *[]Google_dataproc_job_pyspark_config_1685
 
-    Reference *Google_dataproc_job_reference_1687
+    Reference *[]Google_dataproc_job_reference_1687
 
     Region *string
 
-    Scheduling *Google_dataproc_job_scheduling_1688
+    Scheduling *[]Google_dataproc_job_scheduling_1688
 
-    Spark_config *Google_dataproc_job_spark_config_1689
+    Spark_config *[]Google_dataproc_job_spark_config_1689
 
-    Sparksql_config *Google_dataproc_job_sparksql_config_1691
+    Sparksql_config *[]Google_dataproc_job_sparksql_config_1691
 
-    Status *Google_dataproc_job_status_1693
+    Status *[]Google_dataproc_job_status_1693
 
 }
 
@@ -7133,8 +6809,6 @@ func (h *Google_dns_record_setHandler) Delete(externalID string) error {
 
 type Google_endpoints_service_apis_1694_methods_1695 struct {
 
-    Google_endpoints_service_apis_1694_methods_1695_id *string `lyra:"ignore"`
-
     Name *string
 
     Request_type *string
@@ -7147,9 +6821,7 @@ type Google_endpoints_service_apis_1694_methods_1695 struct {
 
 type Google_endpoints_service_apis_1694 struct {
 
-    Google_endpoints_service_apis_1694_id *string `lyra:"ignore"`
-
-    Methods *Google_endpoints_service_apis_1694_methods_1695
+    Methods *[]Google_endpoints_service_apis_1694_methods_1695
 
     Name *string
 
@@ -7161,8 +6833,6 @@ type Google_endpoints_service_apis_1694 struct {
 
 type Google_endpoints_service_endpoints_1696 struct {
 
-    Google_endpoints_service_endpoints_1696_id *string `lyra:"ignore"`
-
     Address *string
 
     Name *string
@@ -7173,13 +6843,13 @@ type Google_endpoints_service struct {
 
     Google_endpoints_service_id *string `lyra:"ignore"`
 
-    Apis *Google_endpoints_service_apis_1694
+    Apis *[]Google_endpoints_service_apis_1694
 
     Config_id *string
 
     Dns_address *string
 
-    Endpoints *Google_endpoints_service_endpoints_1696
+    Endpoints *[]Google_endpoints_service_endpoints_1696
 
     Grpc_config *string
 
@@ -7234,8 +6904,6 @@ func (h *Google_endpoints_serviceHandler) Delete(externalID string) error {
 
 type Google_filestore_instance_file_shares_1697 struct {
 
-    Google_filestore_instance_file_shares_1697_id *string `lyra:"ignore"`
-
     Capacity_gb int
 
     Name string
@@ -7243,8 +6911,6 @@ type Google_filestore_instance_file_shares_1697 struct {
 }
 
 type Google_filestore_instance_networks_1698 struct {
-
-    Google_filestore_instance_networks_1698_id *string `lyra:"ignore"`
 
     Ip_addresses *[]string
 
@@ -7266,13 +6932,13 @@ type Google_filestore_instance struct {
 
     Etag *string
 
-    File_shares Google_filestore_instance_file_shares_1697
+    File_shares []Google_filestore_instance_file_shares_1697
 
     Labels *map[string]string
 
     Name string
 
-    Networks Google_filestore_instance_networks_1698
+    Networks []Google_filestore_instance_networks_1698
 
     Project *string
 
@@ -7525,15 +7191,11 @@ func (h *Google_folder_iam_policyHandler) Delete(externalID string) error {
 
 type Google_folder_organization_policy_boolean_policy_1699 struct {
 
-    Google_folder_organization_policy_boolean_policy_1699_id *string `lyra:"ignore"`
-
     Enforced bool
 
 }
 
 type Google_folder_organization_policy_list_policy_1700_allow_1701 struct {
-
-    Google_folder_organization_policy_list_policy_1700_allow_1701_id *string `lyra:"ignore"`
 
     All *bool
 
@@ -7543,8 +7205,6 @@ type Google_folder_organization_policy_list_policy_1700_allow_1701 struct {
 
 type Google_folder_organization_policy_list_policy_1700_deny_1702 struct {
 
-    Google_folder_organization_policy_list_policy_1700_deny_1702_id *string `lyra:"ignore"`
-
     All *bool
 
     Values *[]string
@@ -7553,19 +7213,15 @@ type Google_folder_organization_policy_list_policy_1700_deny_1702 struct {
 
 type Google_folder_organization_policy_list_policy_1700 struct {
 
-    Google_folder_organization_policy_list_policy_1700_id *string `lyra:"ignore"`
+    Allow *[]Google_folder_organization_policy_list_policy_1700_allow_1701
 
-    Allow *Google_folder_organization_policy_list_policy_1700_allow_1701
-
-    Deny *Google_folder_organization_policy_list_policy_1700_deny_1702
+    Deny *[]Google_folder_organization_policy_list_policy_1700_deny_1702
 
     Suggested_value *string
 
 }
 
 type Google_folder_organization_policy_restore_policy_1703 struct {
-
-    Google_folder_organization_policy_restore_policy_1703_id *string `lyra:"ignore"`
 
     Default bool
 
@@ -7575,7 +7231,7 @@ type Google_folder_organization_policy struct {
 
     Google_folder_organization_policy_id *string `lyra:"ignore"`
 
-    Boolean_policy *Google_folder_organization_policy_boolean_policy_1699
+    Boolean_policy *[]Google_folder_organization_policy_boolean_policy_1699
 
     Constraint string
 
@@ -7583,9 +7239,9 @@ type Google_folder_organization_policy struct {
 
     Folder string
 
-    List_policy *Google_folder_organization_policy_list_policy_1700
+    List_policy *[]Google_folder_organization_policy_list_policy_1700
 
-    Restore_policy *Google_folder_organization_policy_restore_policy_1703
+    Restore_policy *[]Google_folder_organization_policy_restore_policy_1703
 
     Update_time *string
 
@@ -8417,8 +8073,6 @@ func (h *Google_logging_project_sinkHandler) Delete(externalID string) error {
 
 type Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706_id *string `lyra:"ignore"`
-
     Alignment_period *string
 
     Cross_series_reducer *string
@@ -8431,8 +8085,6 @@ type Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggreg
 
 type Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707_id *string `lyra:"ignore"`
-
     Count *int
 
     Percent *float64
@@ -8441,21 +8093,17 @@ type Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigge
 
 type Google_monitoring_alert_policy_conditions_1704_condition_absent_1705 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_id *string `lyra:"ignore"`
-
-    Aggregations *Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706
+    Aggregations *[]Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706
 
     Duration string
 
     Filter *string
 
-    Trigger *Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707
+    Trigger *[]Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707
 
 }
 
 type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709 struct {
-
-    Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709_id *string `lyra:"ignore"`
 
     Alignment_period *string
 
@@ -8469,8 +8117,6 @@ type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_agg
 
 type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710_id *string `lyra:"ignore"`
-
     Alignment_period *string
 
     Cross_series_reducer *string
@@ -8483,8 +8129,6 @@ type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_den
 
 type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711_id *string `lyra:"ignore"`
-
     Count *int
 
     Percent *float64
@@ -8493,13 +8137,11 @@ type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_tri
 
 type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_id *string `lyra:"ignore"`
-
-    Aggregations *Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709
+    Aggregations *[]Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709
 
     Comparison string
 
-    Denominator_aggregations *Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710
+    Denominator_aggregations *[]Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710
 
     Denominator_filter *string
 
@@ -8509,17 +8151,15 @@ type Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708 str
 
     Threshold_value *float64
 
-    Trigger *Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711
+    Trigger *[]Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711
 
 }
 
 type Google_monitoring_alert_policy_conditions_1704 struct {
 
-    Google_monitoring_alert_policy_conditions_1704_id *string `lyra:"ignore"`
+    Condition_absent *[]Google_monitoring_alert_policy_conditions_1704_condition_absent_1705
 
-    Condition_absent *Google_monitoring_alert_policy_conditions_1704_condition_absent_1705
-
-    Condition_threshold *Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708
+    Condition_threshold *[]Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708
 
     Display_name string
 
@@ -8528,8 +8168,6 @@ type Google_monitoring_alert_policy_conditions_1704 struct {
 }
 
 type Google_monitoring_alert_policy_creation_record_1712 struct {
-
-    Google_monitoring_alert_policy_creation_record_1712_id *string `lyra:"ignore"`
 
     Mutate_time *string
 
@@ -8543,9 +8181,9 @@ type Google_monitoring_alert_policy struct {
 
     Combiner string
 
-    Conditions Google_monitoring_alert_policy_conditions_1704
+    Conditions []Google_monitoring_alert_policy_conditions_1704
 
-    Creation_record *Google_monitoring_alert_policy_creation_record_1712
+    Creation_record *[]Google_monitoring_alert_policy_creation_record_1712
 
     Display_name string
 
@@ -8716,15 +8354,11 @@ func (h *Google_monitoring_notification_channelHandler) Delete(externalID string
 
 type Google_monitoring_uptime_check_config_content_matchers_1713 struct {
 
-    Google_monitoring_uptime_check_config_content_matchers_1713_id *string `lyra:"ignore"`
-
     Content *string
 
 }
 
 type Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715 struct {
-
-    Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715_id *string `lyra:"ignore"`
 
     Password *string
 
@@ -8734,9 +8368,7 @@ type Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715 struct
 
 type Google_monitoring_uptime_check_config_http_check_1714 struct {
 
-    Google_monitoring_uptime_check_config_http_check_1714_id *string `lyra:"ignore"`
-
-    Auth_info *Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715
+    Auth_info *[]Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715
 
     Headers *map[string]string
 
@@ -8752,8 +8384,6 @@ type Google_monitoring_uptime_check_config_http_check_1714 struct {
 
 type Google_monitoring_uptime_check_config_internal_checkers_1716 struct {
 
-    Google_monitoring_uptime_check_config_internal_checkers_1716_id *string `lyra:"ignore"`
-
     Display_name *string
 
     Gcp_zone *string
@@ -8768,8 +8398,6 @@ type Google_monitoring_uptime_check_config_internal_checkers_1716 struct {
 
 type Google_monitoring_uptime_check_config_monitored_resource_1717 struct {
 
-    Google_monitoring_uptime_check_config_monitored_resource_1717_id *string `lyra:"ignore"`
-
     Labels map[string]string
 
     Type string
@@ -8777,8 +8405,6 @@ type Google_monitoring_uptime_check_config_monitored_resource_1717 struct {
 }
 
 type Google_monitoring_uptime_check_config_resource_group_1718 struct {
-
-    Google_monitoring_uptime_check_config_resource_group_1718_id *string `lyra:"ignore"`
 
     Group_id *string
 
@@ -8788,8 +8414,6 @@ type Google_monitoring_uptime_check_config_resource_group_1718 struct {
 
 type Google_monitoring_uptime_check_config_tcp_check_1719 struct {
 
-    Google_monitoring_uptime_check_config_tcp_check_1719_id *string `lyra:"ignore"`
-
     Port int
 
 }
@@ -8798,17 +8422,17 @@ type Google_monitoring_uptime_check_config struct {
 
     Google_monitoring_uptime_check_config_id *string `lyra:"ignore"`
 
-    Content_matchers *Google_monitoring_uptime_check_config_content_matchers_1713
+    Content_matchers *[]Google_monitoring_uptime_check_config_content_matchers_1713
 
     Display_name string
 
-    Http_check *Google_monitoring_uptime_check_config_http_check_1714
+    Http_check *[]Google_monitoring_uptime_check_config_http_check_1714
 
-    Internal_checkers *Google_monitoring_uptime_check_config_internal_checkers_1716
+    Internal_checkers *[]Google_monitoring_uptime_check_config_internal_checkers_1716
 
     Is_internal *bool
 
-    Monitored_resource *Google_monitoring_uptime_check_config_monitored_resource_1717
+    Monitored_resource *[]Google_monitoring_uptime_check_config_monitored_resource_1717
 
     Name *string
 
@@ -8816,11 +8440,11 @@ type Google_monitoring_uptime_check_config struct {
 
     Project *string
 
-    Resource_group *Google_monitoring_uptime_check_config_resource_group_1718
+    Resource_group *[]Google_monitoring_uptime_check_config_resource_group_1718
 
     Selected_regions *[]string
 
-    Tcp_check *Google_monitoring_uptime_check_config_tcp_check_1719
+    Tcp_check *[]Google_monitoring_uptime_check_config_tcp_check_1719
 
     Timeout string
 
@@ -9073,15 +8697,11 @@ func (h *Google_organization_iam_policyHandler) Delete(externalID string) error 
 
 type Google_organization_policy_boolean_policy_1720 struct {
 
-    Google_organization_policy_boolean_policy_1720_id *string `lyra:"ignore"`
-
     Enforced bool
 
 }
 
 type Google_organization_policy_list_policy_1721_allow_1722 struct {
-
-    Google_organization_policy_list_policy_1721_allow_1722_id *string `lyra:"ignore"`
 
     All *bool
 
@@ -9091,8 +8711,6 @@ type Google_organization_policy_list_policy_1721_allow_1722 struct {
 
 type Google_organization_policy_list_policy_1721_deny_1723 struct {
 
-    Google_organization_policy_list_policy_1721_deny_1723_id *string `lyra:"ignore"`
-
     All *bool
 
     Values *[]string
@@ -9101,19 +8719,15 @@ type Google_organization_policy_list_policy_1721_deny_1723 struct {
 
 type Google_organization_policy_list_policy_1721 struct {
 
-    Google_organization_policy_list_policy_1721_id *string `lyra:"ignore"`
+    Allow *[]Google_organization_policy_list_policy_1721_allow_1722
 
-    Allow *Google_organization_policy_list_policy_1721_allow_1722
-
-    Deny *Google_organization_policy_list_policy_1721_deny_1723
+    Deny *[]Google_organization_policy_list_policy_1721_deny_1723
 
     Suggested_value *string
 
 }
 
 type Google_organization_policy_restore_policy_1724 struct {
-
-    Google_organization_policy_restore_policy_1724_id *string `lyra:"ignore"`
 
     Default bool
 
@@ -9123,17 +8737,17 @@ type Google_organization_policy struct {
 
     Google_organization_policy_id *string `lyra:"ignore"`
 
-    Boolean_policy *Google_organization_policy_boolean_policy_1720
+    Boolean_policy *[]Google_organization_policy_boolean_policy_1720
 
     Constraint string
 
     Etag *string
 
-    List_policy *Google_organization_policy_list_policy_1721
+    List_policy *[]Google_organization_policy_list_policy_1721
 
     Org_id string
 
-    Restore_policy *Google_organization_policy_restore_policy_1724
+    Restore_policy *[]Google_organization_policy_restore_policy_1724
 
     Update_time *string
 
@@ -9180,15 +8794,11 @@ func (h *Google_organization_policyHandler) Delete(externalID string) error {
 
 type Google_project_app_engine_1725_feature_settings_1726 struct {
 
-    Google_project_app_engine_1725_feature_settings_1726_id *string `lyra:"ignore"`
-
     Split_health_checks *bool
 
 }
 
 type Google_project_app_engine_1725_url_dispatch_rule_1727 struct {
-
-    Google_project_app_engine_1725_url_dispatch_rule_1727_id *string `lyra:"ignore"`
 
     Domain *string
 
@@ -9200,8 +8810,6 @@ type Google_project_app_engine_1725_url_dispatch_rule_1727 struct {
 
 type Google_project_app_engine_1725 struct {
 
-    Google_project_app_engine_1725_id *string `lyra:"ignore"`
-
     Auth_domain *string
 
     Code_bucket *string
@@ -9210,7 +8818,7 @@ type Google_project_app_engine_1725 struct {
 
     Default_hostname *string
 
-    Feature_settings *Google_project_app_engine_1725_feature_settings_1726
+    Feature_settings *[]Google_project_app_engine_1725_feature_settings_1726
 
     Gcr_domain *string
 
@@ -9220,7 +8828,7 @@ type Google_project_app_engine_1725 struct {
 
     Serving_status *string
 
-    Url_dispatch_rule *Google_project_app_engine_1725_url_dispatch_rule_1727
+    Url_dispatch_rule *[]Google_project_app_engine_1725_url_dispatch_rule_1727
 
 }
 
@@ -9228,7 +8836,7 @@ type Google_project struct {
 
     Google_project_id *string `lyra:"ignore"`
 
-    App_engine *Google_project_app_engine_1725
+    App_engine *[]Google_project_app_engine_1725
 
     Auto_create_network *bool
 
@@ -9507,15 +9115,11 @@ func (h *Google_project_iam_policyHandler) Delete(externalID string) error {
 
 type Google_project_organization_policy_boolean_policy_1728 struct {
 
-    Google_project_organization_policy_boolean_policy_1728_id *string `lyra:"ignore"`
-
     Enforced bool
 
 }
 
 type Google_project_organization_policy_list_policy_1729_allow_1730 struct {
-
-    Google_project_organization_policy_list_policy_1729_allow_1730_id *string `lyra:"ignore"`
 
     All *bool
 
@@ -9525,8 +9129,6 @@ type Google_project_organization_policy_list_policy_1729_allow_1730 struct {
 
 type Google_project_organization_policy_list_policy_1729_deny_1731 struct {
 
-    Google_project_organization_policy_list_policy_1729_deny_1731_id *string `lyra:"ignore"`
-
     All *bool
 
     Values *[]string
@@ -9535,19 +9137,15 @@ type Google_project_organization_policy_list_policy_1729_deny_1731 struct {
 
 type Google_project_organization_policy_list_policy_1729 struct {
 
-    Google_project_organization_policy_list_policy_1729_id *string `lyra:"ignore"`
+    Allow *[]Google_project_organization_policy_list_policy_1729_allow_1730
 
-    Allow *Google_project_organization_policy_list_policy_1729_allow_1730
-
-    Deny *Google_project_organization_policy_list_policy_1729_deny_1731
+    Deny *[]Google_project_organization_policy_list_policy_1729_deny_1731
 
     Suggested_value *string
 
 }
 
 type Google_project_organization_policy_restore_policy_1732 struct {
-
-    Google_project_organization_policy_restore_policy_1732_id *string `lyra:"ignore"`
 
     Default bool
 
@@ -9557,17 +9155,17 @@ type Google_project_organization_policy struct {
 
     Google_project_organization_policy_id *string `lyra:"ignore"`
 
-    Boolean_policy *Google_project_organization_policy_boolean_policy_1728
+    Boolean_policy *[]Google_project_organization_policy_boolean_policy_1728
 
     Constraint string
 
     Etag *string
 
-    List_policy *Google_project_organization_policy_list_policy_1729
+    List_policy *[]Google_project_organization_policy_list_policy_1729
 
     Project string
 
-    Restore_policy *Google_project_organization_policy_restore_policy_1732
+    Restore_policy *[]Google_project_organization_policy_restore_policy_1732
 
     Update_time *string
 
@@ -9761,8 +9359,6 @@ func (h *Google_project_usage_export_bucketHandler) Delete(externalID string) er
 
 type Google_pubsub_subscription_push_config_1733 struct {
 
-    Google_pubsub_subscription_push_config_1733_id *string `lyra:"ignore"`
-
     Attributes *map[string]string
 
     Push_endpoint string
@@ -9781,7 +9377,7 @@ type Google_pubsub_subscription struct {
 
     Project *string
 
-    Push_config *Google_pubsub_subscription_push_config_1733
+    Push_config *[]Google_pubsub_subscription_push_config_1733
 
     Topic string
 
@@ -11234,8 +10830,6 @@ func (h *Google_sql_databaseHandler) Delete(externalID string) error {
 
 type Google_sql_database_instance_ip_address_1734 struct {
 
-    Google_sql_database_instance_ip_address_1734_id *string `lyra:"ignore"`
-
     Ip_address *string
 
     Time_to_retire *string
@@ -11243,8 +10837,6 @@ type Google_sql_database_instance_ip_address_1734 struct {
 }
 
 type Google_sql_database_instance_replica_configuration_1735 struct {
-
-    Google_sql_database_instance_replica_configuration_1735_id *string `lyra:"ignore"`
 
     Ca_certificate *string
 
@@ -11272,8 +10864,6 @@ type Google_sql_database_instance_replica_configuration_1735 struct {
 
 type Google_sql_database_instance_server_ca_cert_1736 struct {
 
-    Google_sql_database_instance_server_ca_cert_1736_id *string `lyra:"ignore"`
-
     Cert *string
 
     Common_name *string
@@ -11288,8 +10878,6 @@ type Google_sql_database_instance_server_ca_cert_1736 struct {
 
 type Google_sql_database_instance_settings_1737_backup_configuration_1738 struct {
 
-    Google_sql_database_instance_settings_1737_backup_configuration_1738_id *string `lyra:"ignore"`
-
     Binary_log_enabled *bool
 
     Enabled *bool
@@ -11300,8 +10888,6 @@ type Google_sql_database_instance_settings_1737_backup_configuration_1738 struct
 
 type Google_sql_database_instance_settings_1737_database_flags_1739 struct {
 
-    Google_sql_database_instance_settings_1737_database_flags_1739_id *string `lyra:"ignore"`
-
     Name *string
 
     Value *string
@@ -11309,8 +10895,6 @@ type Google_sql_database_instance_settings_1737_database_flags_1739 struct {
 }
 
 type Google_sql_database_instance_settings_1737_ip_configuration_1740_authorized_networks_1741 struct {
-
-    Google_sql_database_instance_settings_1737_ip_configuration_1740_authorized_networks_1741_id *string `lyra:"ignore"`
 
     Expiration_time *string
 
@@ -11321,8 +10905,6 @@ type Google_sql_database_instance_settings_1737_ip_configuration_1740_authorized
 }
 
 type Google_sql_database_instance_settings_1737_ip_configuration_1740 struct {
-
-    Google_sql_database_instance_settings_1737_ip_configuration_1740_id *string `lyra:"ignore"`
 
     Authorized_networks *Google_sql_database_instance_settings_1737_ip_configuration_1740_authorized_networks_1741
 
@@ -11336,8 +10918,6 @@ type Google_sql_database_instance_settings_1737_ip_configuration_1740 struct {
 
 type Google_sql_database_instance_settings_1737_location_preference_1742 struct {
 
-    Google_sql_database_instance_settings_1737_location_preference_1742_id *string `lyra:"ignore"`
-
     Follow_gae_application *string
 
     Zone *string
@@ -11345,8 +10925,6 @@ type Google_sql_database_instance_settings_1737_location_preference_1742 struct 
 }
 
 type Google_sql_database_instance_settings_1737_maintenance_window_1743 struct {
-
-    Google_sql_database_instance_settings_1737_maintenance_window_1743_id *string `lyra:"ignore"`
 
     Day *int
 
@@ -11358,19 +10936,17 @@ type Google_sql_database_instance_settings_1737_maintenance_window_1743 struct {
 
 type Google_sql_database_instance_settings_1737 struct {
 
-    Google_sql_database_instance_settings_1737_id *string `lyra:"ignore"`
-
     Activation_policy *string
 
     Authorized_gae_applications *[]string
 
     Availability_type *string
 
-    Backup_configuration *Google_sql_database_instance_settings_1737_backup_configuration_1738
+    Backup_configuration *[]Google_sql_database_instance_settings_1737_backup_configuration_1738
 
     Crash_safe_replication *bool
 
-    Database_flags *Google_sql_database_instance_settings_1737_database_flags_1739
+    Database_flags *[]Google_sql_database_instance_settings_1737_database_flags_1739
 
     Disk_autoresize *bool
 
@@ -11378,11 +10954,11 @@ type Google_sql_database_instance_settings_1737 struct {
 
     Disk_type *string
 
-    Ip_configuration *Google_sql_database_instance_settings_1737_ip_configuration_1740
+    Ip_configuration *[]Google_sql_database_instance_settings_1737_ip_configuration_1740
 
-    Location_preference *Google_sql_database_instance_settings_1737_location_preference_1742
+    Location_preference *[]Google_sql_database_instance_settings_1737_location_preference_1742
 
-    Maintenance_window *Google_sql_database_instance_settings_1737_maintenance_window_1743
+    Maintenance_window *[]Google_sql_database_instance_settings_1737_maintenance_window_1743
 
     Pricing_plan *string
 
@@ -11406,7 +10982,7 @@ type Google_sql_database_instance struct {
 
     First_ip_address *string
 
-    Ip_address *Google_sql_database_instance_ip_address_1734
+    Ip_address *[]Google_sql_database_instance_ip_address_1734
 
     Master_instance_name *string
 
@@ -11416,15 +10992,15 @@ type Google_sql_database_instance struct {
 
     Region *string
 
-    Replica_configuration *Google_sql_database_instance_replica_configuration_1735
+    Replica_configuration *[]Google_sql_database_instance_replica_configuration_1735
 
     Self_link *string
 
-    Server_ca_cert *Google_sql_database_instance_server_ca_cert_1736
+    Server_ca_cert *[]Google_sql_database_instance_server_ca_cert_1736
 
     Service_account_email_address *string
 
-    Settings Google_sql_database_instance_settings_1737
+    Settings []Google_sql_database_instance_settings_1737
 
 }
 
@@ -11581,8 +11157,6 @@ func (h *Google_sql_userHandler) Delete(externalID string) error {
 
 type Google_storage_bucket_cors_1744 struct {
 
-    Google_storage_bucket_cors_1744_id *string `lyra:"ignore"`
-
     Max_age_seconds *int
 
     Method *[]string
@@ -11595,15 +11169,11 @@ type Google_storage_bucket_cors_1744 struct {
 
 type Google_storage_bucket_encryption_1745 struct {
 
-    Google_storage_bucket_encryption_1745_id *string `lyra:"ignore"`
-
     Default_kms_key_name string
 
 }
 
 type Google_storage_bucket_lifecycle_rule_1746_action_1747 struct {
-
-    Google_storage_bucket_lifecycle_rule_1746_action_1747_id *string `lyra:"ignore"`
 
     Storage_class *string
 
@@ -11612,8 +11182,6 @@ type Google_storage_bucket_lifecycle_rule_1746_action_1747 struct {
 }
 
 type Google_storage_bucket_lifecycle_rule_1746_condition_1748 struct {
-
-    Google_storage_bucket_lifecycle_rule_1746_condition_1748_id *string `lyra:"ignore"`
 
     Age *int
 
@@ -11629,8 +11197,6 @@ type Google_storage_bucket_lifecycle_rule_1746_condition_1748 struct {
 
 type Google_storage_bucket_lifecycle_rule_1746 struct {
 
-    Google_storage_bucket_lifecycle_rule_1746_id *string `lyra:"ignore"`
-
     Action Google_storage_bucket_lifecycle_rule_1746_action_1747
 
     Condition Google_storage_bucket_lifecycle_rule_1746_condition_1748
@@ -11638,8 +11204,6 @@ type Google_storage_bucket_lifecycle_rule_1746 struct {
 }
 
 type Google_storage_bucket_logging_1749 struct {
-
-    Google_storage_bucket_logging_1749_id *string `lyra:"ignore"`
 
     Log_bucket string
 
@@ -11649,15 +11213,11 @@ type Google_storage_bucket_logging_1749 struct {
 
 type Google_storage_bucket_versioning_1750 struct {
 
-    Google_storage_bucket_versioning_1750_id *string `lyra:"ignore"`
-
     Enabled *bool
 
 }
 
 type Google_storage_bucket_website_1751 struct {
-
-    Google_storage_bucket_website_1751_id *string `lyra:"ignore"`
 
     Main_page_suffix *string
 
@@ -11669,19 +11229,19 @@ type Google_storage_bucket struct {
 
     Google_storage_bucket_id *string `lyra:"ignore"`
 
-    Cors *Google_storage_bucket_cors_1744
+    Cors *[]Google_storage_bucket_cors_1744
 
-    Encryption *Google_storage_bucket_encryption_1745
+    Encryption *[]Google_storage_bucket_encryption_1745
 
     Force_destroy *bool
 
     Labels *map[string]string
 
-    Lifecycle_rule *Google_storage_bucket_lifecycle_rule_1746
+    Lifecycle_rule *[]Google_storage_bucket_lifecycle_rule_1746
 
     Location *string
 
-    Logging *Google_storage_bucket_logging_1749
+    Logging *[]Google_storage_bucket_logging_1749
 
     Name string
 
@@ -11695,9 +11255,9 @@ type Google_storage_bucket struct {
 
     Url *string
 
-    Versioning *Google_storage_bucket_versioning_1750
+    Versioning *[]Google_storage_bucket_versioning_1750
 
-    Website *Google_storage_bucket_website_1751
+    Website *[]Google_storage_bucket_website_1751
 
 }
 
@@ -12013,8 +11573,6 @@ func (h *Google_storage_bucket_objectHandler) Delete(externalID string) error {
 
 type Google_storage_default_object_access_control_project_team_1752 struct {
 
-    Google_storage_default_object_access_control_project_team_1752_id *string `lyra:"ignore"`
-
     Project_number *string
 
     Team *string
@@ -12039,7 +11597,7 @@ type Google_storage_default_object_access_control struct {
 
     Object *string
 
-    Project_team *Google_storage_default_object_access_control_project_team_1752
+    Project_team *[]Google_storage_default_object_access_control_project_team_1752
 
     Role string
 
@@ -12188,8 +11746,6 @@ func (h *Google_storage_notificationHandler) Delete(externalID string) error {
 
 type Google_storage_object_access_control_project_team_1753 struct {
 
-    Google_storage_object_access_control_project_team_1753_id *string `lyra:"ignore"`
-
     Project_number *string
 
     Team *string
@@ -12214,7 +11770,7 @@ type Google_storage_object_access_control struct {
 
     Object string
 
-    Project_team *Google_storage_object_access_control_project_team_1753
+    Project_team *[]Google_storage_object_access_control_project_team_1753
 
     Role string
 

--- a/cmd/goplugin-tf-kubernetes/generated/generated.go
+++ b/cmd/goplugin-tf-kubernetes/generated/generated.go
@@ -58,8 +58,6 @@ func Initialize(sb *service.ServerBuilder, p *schema.Provider) {
 
 type Kubernetes_cluster_role_binding_metadata_589 struct {
 
-    Kubernetes_cluster_role_binding_metadata_589_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generation *int
@@ -78,8 +76,6 @@ type Kubernetes_cluster_role_binding_metadata_589 struct {
 
 type Kubernetes_cluster_role_binding_subject_590 struct {
 
-    Kubernetes_cluster_role_binding_subject_590_id *string `lyra:"ignore"`
-
     Api_group *string
 
     Kind string
@@ -94,11 +90,11 @@ type Kubernetes_cluster_role_binding struct {
 
     Kubernetes_cluster_role_binding_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_cluster_role_binding_metadata_589
+    Metadata []Kubernetes_cluster_role_binding_metadata_589
 
     Role_ref map[string]string
 
-    Subject Kubernetes_cluster_role_binding_subject_590
+    Subject []Kubernetes_cluster_role_binding_subject_590
 
 }
 
@@ -141,8 +137,6 @@ func (h *Kubernetes_cluster_role_bindingHandler) Delete(externalID string) error
 
 type Kubernetes_config_map_metadata_591 struct {
 
-    Kubernetes_config_map_metadata_591_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -169,7 +163,7 @@ type Kubernetes_config_map struct {
 
     Data *map[string]string
 
-    Metadata Kubernetes_config_map_metadata_591
+    Metadata []Kubernetes_config_map_metadata_591
 
 }
 
@@ -212,8 +206,6 @@ func (h *Kubernetes_config_mapHandler) Delete(externalID string) error {
 
 type Kubernetes_deployment_metadata_592 struct {
 
-    Kubernetes_deployment_metadata_592_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -236,8 +228,6 @@ type Kubernetes_deployment_metadata_592 struct {
 
 type Kubernetes_deployment_spec_593_selector_594_match_expressions_595 struct {
 
-    Kubernetes_deployment_spec_593_selector_594_match_expressions_595_id *string `lyra:"ignore"`
-
     Key *string
 
     Operator *string
@@ -248,17 +238,13 @@ type Kubernetes_deployment_spec_593_selector_594_match_expressions_595 struct {
 
 type Kubernetes_deployment_spec_593_selector_594 struct {
 
-    Kubernetes_deployment_spec_593_selector_594_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_deployment_spec_593_selector_594_match_expressions_595
+    Match_expressions *[]Kubernetes_deployment_spec_593_selector_594_match_expressions_595
 
     Match_labels *map[string]string
 
 }
 
 type Kubernetes_deployment_spec_593_strategy_596_rolling_update_597 struct {
-
-    Kubernetes_deployment_spec_593_strategy_596_rolling_update_597_id *string `lyra:"ignore"`
 
     Max_surge *string
 
@@ -268,17 +254,13 @@ type Kubernetes_deployment_spec_593_strategy_596_rolling_update_597 struct {
 
 type Kubernetes_deployment_spec_593_strategy_596 struct {
 
-    Kubernetes_deployment_spec_593_strategy_596_id *string `lyra:"ignore"`
-
-    Rolling_update *Kubernetes_deployment_spec_593_strategy_596_rolling_update_597
+    Rolling_update *[]Kubernetes_deployment_spec_593_strategy_596_rolling_update_597
 
     Type *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_metadata_599 struct {
-
-    Kubernetes_deployment_spec_593_template_598_metadata_599_id *string `lyra:"ignore"`
 
     Annotations *map[string]string
 
@@ -302,8 +284,6 @@ type Kubernetes_deployment_spec_593_template_598_metadata_599 struct {
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -311,8 +291,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -322,8 +300,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606_id *string `lyra:"ignore"`
-
     Container_name *string
 
     Resource string
@@ -331,8 +307,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -342,33 +316,27 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604
 
-    Config_map_key_ref *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604
+    Field_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605
 
-    Field_ref *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605
+    Resource_field_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606
 
-    Resource_field_ref *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606
-
-    Secret_key_ref *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607
+    Secret_key_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603
+    Value_from *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609_id *string `lyra:"ignore"`
 
     Name string
 
@@ -378,8 +346,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -388,27 +354,21 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609
+    Config_map_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609
 
     Prefix *string
 
-    Secret_ref *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610
+    Secret_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -418,11 +378,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycl
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615
 
     Path *string
 
@@ -434,35 +392,27 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycl
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613
 
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614
-
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -472,11 +422,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycl
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620
 
     Path *string
 
@@ -488,45 +436,35 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycl
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618
 
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619
-
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612
 
-    Post_start *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612
-
-    Pre_stop *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617
+    Pre_stop *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -536,11 +474,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625
 
     Path *string
 
@@ -552,21 +488,17 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624
 
     Initial_delay_seconds *int
 
@@ -574,15 +506,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -598,15 +528,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -616,11 +542,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readines
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631
 
     Path *string
 
@@ -632,21 +556,17 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readines
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630
 
     Initial_delay_seconds *int
 
@@ -654,15 +574,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readines
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -672,8 +590,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resource
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -682,17 +598,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resource
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634
 
-    Limits *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634
-
-    Requests *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635
+    Requests *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -701,8 +613,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -716,11 +626,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637
+    Capabilities *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637
 
     Privileged *bool
 
@@ -730,13 +638,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638
+    Se_linux_options *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -750,33 +656,31 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_m
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_container_601 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_container_601_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602
+    Env *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602
 
-    Env_from *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608
+    Env_from *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611
+    Lifecycle *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611
 
-    Liveness_probe *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622
+    Liveness_probe *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622
 
     Name string
 
-    Port *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627
+    Port *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627
 
-    Readiness_probe *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628
+    Readiness_probe *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628
 
-    Resources *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633
+    Resources *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633
 
-    Security_context *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636
+    Security_context *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636
 
     Stdin *bool
 
@@ -786,7 +690,7 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601 struct {
 
     Tty *bool
 
-    Volume_mount *Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639
+    Volume_mount *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639
 
     Working_dir *string
 
@@ -794,15 +698,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_container_601 struct {
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -812,8 +712,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Field_path *string
@@ -821,8 +719,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -832,8 +728,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -842,33 +736,27 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644
 
-    Config_map_key_ref *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644
+    Field_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645
 
-    Field_ref *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645
+    Resource_field_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646
 
-    Resource_field_ref *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646
-
-    Secret_key_ref *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647
+    Secret_key_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643
+    Value_from *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649_id *string `lyra:"ignore"`
 
     Name string
 
@@ -878,8 +766,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -888,27 +774,21 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649
+    Config_map_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649
 
     Prefix *string
 
-    Secret_ref *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650
+    Secret_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -918,11 +798,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lif
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655
 
     Path *string
 
@@ -934,35 +812,27 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lif
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653
 
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654
-
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -972,11 +842,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lif
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660
 
     Path *string
 
@@ -988,45 +856,35 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lif
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658
 
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659
-
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652
 
-    Post_start *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652
-
-    Pre_stop *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657
+    Pre_stop *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -1036,11 +894,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liv
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665
 
     Path *string
 
@@ -1052,21 +908,17 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liv
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664
 
     Initial_delay_seconds *int
 
@@ -1074,15 +926,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liv
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -1098,15 +948,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_por
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -1116,11 +962,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_rea
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671
+    Http_header *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671
 
     Path *string
 
@@ -1132,21 +976,17 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_rea
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669
+    Exec *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670
+    Http_get *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670
 
     Initial_delay_seconds *int
 
@@ -1154,15 +994,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_rea
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672
+    Tcp_socket *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -1172,8 +1010,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_res
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -1182,17 +1018,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_res
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674
 
-    Limits *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674
-
-    Requests *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675
+    Requests *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -1201,8 +1033,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_sec
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -1216,11 +1046,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_sec
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677
+    Capabilities *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677
 
     Privileged *bool
 
@@ -1230,13 +1058,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_sec
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678
+    Se_linux_options *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -1250,33 +1076,31 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_vol
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642
+    Env *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642
 
-    Env_from *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648
+    Env_from *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651
+    Lifecycle *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651
 
-    Liveness_probe *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662
+    Liveness_probe *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662
 
     Name string
 
-    Port *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667
+    Port *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667
 
-    Readiness_probe *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668
+    Readiness_probe *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668
 
-    Resources *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673
+    Resources *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673
 
-    Security_context *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676
+    Security_context *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676
 
     Stdin *bool
 
@@ -1286,15 +1110,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641 str
 
     Tty *bool
 
-    Volume_mount *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679
+    Volume_mount *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679
 
     Working_dir *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -1308,23 +1130,19 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_s
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_id *string `lyra:"ignore"`
-
     Fs_group *int
 
     Run_as_non_root *bool
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681
+    Se_linux_options *[]Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681
 
     Supplemental_groups *[]int
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -1337,8 +1155,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684_id *string `lyra:"ignore"`
 
     Caching_mode string
 
@@ -1354,8 +1170,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685_id *string `lyra:"ignore"`
-
     Read_only *bool
 
     Secret_name string
@@ -1366,15 +1180,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_id *string `lyra:"ignore"`
 
     Monitors []string
 
@@ -1384,15 +1194,13 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686
 
     Secret_file *string
 
-    Secret_ref *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687
+    Secret_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687
 
     User *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -1404,8 +1212,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688 
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690_id *string `lyra:"ignore"`
-
     Key *string
 
     Mode *int
@@ -1416,19 +1222,15 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690
+    Items *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690
 
     Name *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -1437,8 +1239,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_ap
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694_id *string `lyra:"ignore"`
 
     Container_name string
 
@@ -1450,39 +1250,31 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_ap
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_id *string `lyra:"ignore"`
-
-    Field_ref Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693
+    Field_ref []Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693
 
     Mode *int
 
     Path string
 
-    Resource_field_ref *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694
+    Resource_field_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692
+    Items *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695_id *string `lyra:"ignore"`
 
     Medium *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -1496,15 +1288,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696 stru
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_id *string `lyra:"ignore"`
 
     Driver string
 
@@ -1514,13 +1302,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698
+    Secret_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699_id *string `lyra:"ignore"`
 
     Dataset_name *string
 
@@ -1529,8 +1315,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -1544,8 +1328,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persist
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701_id *string `lyra:"ignore"`
-
     Directory *string
 
     Repository *string
@@ -1555,8 +1337,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_70
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702_id *string `lyra:"ignore"`
 
     Endpoints_name string
 
@@ -1568,15 +1348,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_7
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -1594,15 +1370,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704 s
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706_id *string `lyra:"ignore"`
 
     Path string
 
@@ -1614,8 +1386,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706 str
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707_id *string `lyra:"ignore"`
-
     Claim_name *string
 
     Read_only *bool
@@ -1624,8 +1394,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Pd_id string
@@ -1633,8 +1401,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_pers
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709_id *string `lyra:"ignore"`
 
     Group *string
 
@@ -1650,15 +1416,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_id *string `lyra:"ignore"`
 
     Ceph_monitors []string
 
@@ -1674,13 +1436,11 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710 str
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711
+    Secret_ref *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713 struct {
-
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -1692,11 +1452,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713
+    Items *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713
 
     Optional *bool
 
@@ -1706,8 +1464,6 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712 
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Volume_path string
@@ -1716,67 +1472,63 @@ type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_vol
 
 type Kubernetes_deployment_spec_593_template_598_spec_600_volume_682 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_id *string `lyra:"ignore"`
+    Aws_elastic_block_store *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683
 
-    Aws_elastic_block_store *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683
+    Azure_disk *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684
 
-    Azure_disk *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684
+    Azure_file *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685
 
-    Azure_file *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685
+    Ceph_fs *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686
 
-    Ceph_fs *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686
+    Cinder *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688
 
-    Cinder *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688
+    Config_map *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689
 
-    Config_map *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689
+    Downward_api *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691
 
-    Downward_api *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691
+    Empty_dir *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695
 
-    Empty_dir *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695
+    Fc *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696
 
-    Fc *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696
+    Flex_volume *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697
 
-    Flex_volume *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697
+    Flocker *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699
 
-    Flocker *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699
+    Gce_persistent_disk *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700
 
-    Gce_persistent_disk *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700
+    Git_repo *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701
 
-    Git_repo *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701
+    Glusterfs *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702
 
-    Glusterfs *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702
+    Host_path *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703
 
-    Host_path *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703
+    Iscsi *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704
 
-    Iscsi *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704
-
-    Local *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705
+    Local *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705
 
     Name *string
 
-    Nfs *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706
+    Nfs *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706
 
-    Persistent_volume_claim *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707
+    Persistent_volume_claim *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707
 
-    Photon_persistent_disk *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708
+    Photon_persistent_disk *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708
 
-    Quobyte *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709
+    Quobyte *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709
 
-    Rbd *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710
+    Rbd *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710
 
-    Secret *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712
+    Secret *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712
 
-    Vsphere_volume *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714
+    Vsphere_volume *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714
 
 }
 
 type Kubernetes_deployment_spec_593_template_598_spec_600 struct {
 
-    Kubernetes_deployment_spec_593_template_598_spec_600_id *string `lyra:"ignore"`
-
     Active_deadline_seconds *int
 
-    Container *Kubernetes_deployment_spec_593_template_598_spec_600_container_601
+    Container *[]Kubernetes_deployment_spec_593_template_598_spec_600_container_601
 
     Dns_policy *string
 
@@ -1788,9 +1540,9 @@ type Kubernetes_deployment_spec_593_template_598_spec_600 struct {
 
     Hostname *string
 
-    Image_pull_secrets *Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640
+    Image_pull_secrets *[]Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640
 
-    Init_container *Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641
+    Init_container *[]Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641
 
     Node_name *string
 
@@ -1798,7 +1550,7 @@ type Kubernetes_deployment_spec_593_template_598_spec_600 struct {
 
     Restart_policy *string
 
-    Security_context *Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680
+    Security_context *[]Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680
 
     Service_account_name *string
 
@@ -1806,23 +1558,19 @@ type Kubernetes_deployment_spec_593_template_598_spec_600 struct {
 
     Termination_grace_period_seconds *int
 
-    Volume *Kubernetes_deployment_spec_593_template_598_spec_600_volume_682
+    Volume *[]Kubernetes_deployment_spec_593_template_598_spec_600_volume_682
 
 }
 
 type Kubernetes_deployment_spec_593_template_598 struct {
 
-    Kubernetes_deployment_spec_593_template_598_id *string `lyra:"ignore"`
+    Metadata []Kubernetes_deployment_spec_593_template_598_metadata_599
 
-    Metadata Kubernetes_deployment_spec_593_template_598_metadata_599
-
-    Spec Kubernetes_deployment_spec_593_template_598_spec_600
+    Spec []Kubernetes_deployment_spec_593_template_598_spec_600
 
 }
 
 type Kubernetes_deployment_spec_593 struct {
-
-    Kubernetes_deployment_spec_593_id *string `lyra:"ignore"`
 
     Min_ready_seconds *int
 
@@ -1834,11 +1582,11 @@ type Kubernetes_deployment_spec_593 struct {
 
     Revision_history_limit *int
 
-    Selector *Kubernetes_deployment_spec_593_selector_594
+    Selector *[]Kubernetes_deployment_spec_593_selector_594
 
-    Strategy *Kubernetes_deployment_spec_593_strategy_596
+    Strategy *[]Kubernetes_deployment_spec_593_strategy_596
 
-    Template Kubernetes_deployment_spec_593_template_598
+    Template []Kubernetes_deployment_spec_593_template_598
 
 }
 
@@ -1846,9 +1594,9 @@ type Kubernetes_deployment struct {
 
     Kubernetes_deployment_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_deployment_metadata_592
+    Metadata []Kubernetes_deployment_metadata_592
 
-    Spec Kubernetes_deployment_spec_593
+    Spec []Kubernetes_deployment_spec_593
 
 }
 
@@ -1891,8 +1639,6 @@ func (h *Kubernetes_deploymentHandler) Delete(externalID string) error {
 
 type Kubernetes_horizontal_pod_autoscaler_metadata_715 struct {
 
-    Kubernetes_horizontal_pod_autoscaler_metadata_715_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -1915,8 +1661,6 @@ type Kubernetes_horizontal_pod_autoscaler_metadata_715 struct {
 
 type Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717 struct {
 
-    Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Kind string
@@ -1927,13 +1671,11 @@ type Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717 struct {
 
 type Kubernetes_horizontal_pod_autoscaler_spec_716 struct {
 
-    Kubernetes_horizontal_pod_autoscaler_spec_716_id *string `lyra:"ignore"`
-
     Max_replicas int
 
     Min_replicas *int
 
-    Scale_target_ref Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717
+    Scale_target_ref []Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717
 
     Target_cpu_utilization_percentage *int
 
@@ -1943,9 +1685,9 @@ type Kubernetes_horizontal_pod_autoscaler struct {
 
     Kubernetes_horizontal_pod_autoscaler_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_horizontal_pod_autoscaler_metadata_715
+    Metadata []Kubernetes_horizontal_pod_autoscaler_metadata_715
 
-    Spec Kubernetes_horizontal_pod_autoscaler_spec_716
+    Spec []Kubernetes_horizontal_pod_autoscaler_spec_716
 
 }
 
@@ -1988,8 +1730,6 @@ func (h *Kubernetes_horizontal_pod_autoscalerHandler) Delete(externalID string) 
 
 type Kubernetes_limit_range_metadata_718 struct {
 
-    Kubernetes_limit_range_metadata_718_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -2012,8 +1752,6 @@ type Kubernetes_limit_range_metadata_718 struct {
 
 type Kubernetes_limit_range_spec_719_limit_720 struct {
 
-    Kubernetes_limit_range_spec_719_limit_720_id *string `lyra:"ignore"`
-
     Default *map[string]string
 
     Default_request *map[string]string
@@ -2030,9 +1768,7 @@ type Kubernetes_limit_range_spec_719_limit_720 struct {
 
 type Kubernetes_limit_range_spec_719 struct {
 
-    Kubernetes_limit_range_spec_719_id *string `lyra:"ignore"`
-
-    Limit *Kubernetes_limit_range_spec_719_limit_720
+    Limit *[]Kubernetes_limit_range_spec_719_limit_720
 
 }
 
@@ -2040,9 +1776,9 @@ type Kubernetes_limit_range struct {
 
     Kubernetes_limit_range_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_limit_range_metadata_718
+    Metadata []Kubernetes_limit_range_metadata_718
 
-    Spec *Kubernetes_limit_range_spec_719
+    Spec *[]Kubernetes_limit_range_spec_719
 
 }
 
@@ -2085,8 +1821,6 @@ func (h *Kubernetes_limit_rangeHandler) Delete(externalID string) error {
 
 type Kubernetes_namespace_metadata_721 struct {
 
-    Kubernetes_namespace_metadata_721_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -2109,7 +1843,7 @@ type Kubernetes_namespace struct {
 
     Kubernetes_namespace_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_namespace_metadata_721
+    Metadata []Kubernetes_namespace_metadata_721
 
 }
 
@@ -2152,8 +1886,6 @@ func (h *Kubernetes_namespaceHandler) Delete(externalID string) error {
 
 type Kubernetes_network_policy_metadata_722 struct {
 
-    Kubernetes_network_policy_metadata_722_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -2176,8 +1908,6 @@ type Kubernetes_network_policy_metadata_722 struct {
 
 type Kubernetes_network_policy_spec_723_egress_724_ports_725 struct {
 
-    Kubernetes_network_policy_spec_723_egress_724_ports_725_id *string `lyra:"ignore"`
-
     Port *string
 
     Protocol *string
@@ -2186,8 +1916,6 @@ type Kubernetes_network_policy_spec_723_egress_724_ports_725 struct {
 
 type Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727 struct {
 
-    Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727_id *string `lyra:"ignore"`
-
     Cidr *string
 
     Except *[]string
@@ -2195,8 +1923,6 @@ type Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727 struct {
 }
 
 type Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729 struct {
-
-    Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2208,17 +1934,13 @@ type Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728
 
 type Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728 struct {
 
-    Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729
+    Match_expressions *[]Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729
 
     Match_labels *map[string]string
 
 }
 
 type Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731 struct {
-
-    Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2230,9 +1952,7 @@ type Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match
 
 type Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730 struct {
 
-    Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731
+    Match_expressions *[]Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731
 
     Match_labels *map[string]string
 
@@ -2240,29 +1960,23 @@ type Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730 struc
 
 type Kubernetes_network_policy_spec_723_egress_724_to_726 struct {
 
-    Kubernetes_network_policy_spec_723_egress_724_to_726_id *string `lyra:"ignore"`
+    Ip_block *[]Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727
 
-    Ip_block *Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727
+    Namespace_selector *[]Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728
 
-    Namespace_selector *Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728
-
-    Pod_selector *Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730
+    Pod_selector *[]Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730
 
 }
 
 type Kubernetes_network_policy_spec_723_egress_724 struct {
 
-    Kubernetes_network_policy_spec_723_egress_724_id *string `lyra:"ignore"`
+    Ports *[]Kubernetes_network_policy_spec_723_egress_724_ports_725
 
-    Ports *Kubernetes_network_policy_spec_723_egress_724_ports_725
-
-    To *Kubernetes_network_policy_spec_723_egress_724_to_726
+    To *[]Kubernetes_network_policy_spec_723_egress_724_to_726
 
 }
 
 type Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734 struct {
-
-    Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734_id *string `lyra:"ignore"`
 
     Cidr *string
 
@@ -2271,8 +1985,6 @@ type Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734 struct
 }
 
 type Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736 struct {
-
-    Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2284,17 +1996,13 @@ type Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_
 
 type Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735 struct {
 
-    Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736
+    Match_expressions *[]Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736
 
     Match_labels *map[string]string
 
 }
 
 type Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738 struct {
-
-    Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2306,9 +2014,7 @@ type Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_ma
 
 type Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737 struct {
 
-    Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738
+    Match_expressions *[]Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738
 
     Match_labels *map[string]string
 
@@ -2316,19 +2022,15 @@ type Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737 st
 
 type Kubernetes_network_policy_spec_723_ingress_732_from_733 struct {
 
-    Kubernetes_network_policy_spec_723_ingress_732_from_733_id *string `lyra:"ignore"`
+    Ip_block *[]Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734
 
-    Ip_block *Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734
+    Namespace_selector *[]Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735
 
-    Namespace_selector *Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735
-
-    Pod_selector *Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737
+    Pod_selector *[]Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737
 
 }
 
 type Kubernetes_network_policy_spec_723_ingress_732_ports_739 struct {
-
-    Kubernetes_network_policy_spec_723_ingress_732_ports_739_id *string `lyra:"ignore"`
 
     Port *string
 
@@ -2338,17 +2040,13 @@ type Kubernetes_network_policy_spec_723_ingress_732_ports_739 struct {
 
 type Kubernetes_network_policy_spec_723_ingress_732 struct {
 
-    Kubernetes_network_policy_spec_723_ingress_732_id *string `lyra:"ignore"`
+    From *[]Kubernetes_network_policy_spec_723_ingress_732_from_733
 
-    From *Kubernetes_network_policy_spec_723_ingress_732_from_733
-
-    Ports *Kubernetes_network_policy_spec_723_ingress_732_ports_739
+    Ports *[]Kubernetes_network_policy_spec_723_ingress_732_ports_739
 
 }
 
 type Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741 struct {
-
-    Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2360,9 +2058,7 @@ type Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741 s
 
 type Kubernetes_network_policy_spec_723_pod_selector_740 struct {
 
-    Kubernetes_network_policy_spec_723_pod_selector_740_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741
+    Match_expressions *[]Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741
 
     Match_labels *map[string]string
 
@@ -2370,13 +2066,11 @@ type Kubernetes_network_policy_spec_723_pod_selector_740 struct {
 
 type Kubernetes_network_policy_spec_723 struct {
 
-    Kubernetes_network_policy_spec_723_id *string `lyra:"ignore"`
+    Egress *[]Kubernetes_network_policy_spec_723_egress_724
 
-    Egress *Kubernetes_network_policy_spec_723_egress_724
+    Ingress *[]Kubernetes_network_policy_spec_723_ingress_732
 
-    Ingress *Kubernetes_network_policy_spec_723_ingress_732
-
-    Pod_selector Kubernetes_network_policy_spec_723_pod_selector_740
+    Pod_selector []Kubernetes_network_policy_spec_723_pod_selector_740
 
     Policy_types []string
 
@@ -2386,9 +2080,9 @@ type Kubernetes_network_policy struct {
 
     Kubernetes_network_policy_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_network_policy_metadata_722
+    Metadata []Kubernetes_network_policy_metadata_722
 
-    Spec Kubernetes_network_policy_spec_723
+    Spec []Kubernetes_network_policy_spec_723
 
 }
 
@@ -2431,8 +2125,6 @@ func (h *Kubernetes_network_policyHandler) Delete(externalID string) error {
 
 type Kubernetes_persistent_volume_metadata_742 struct {
 
-    Kubernetes_persistent_volume_metadata_742_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generation *int
@@ -2451,8 +2143,6 @@ type Kubernetes_persistent_volume_metadata_742 struct {
 
 type Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747 struct {
 
-    Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747_id *string `lyra:"ignore"`
-
     Key *string
 
     Operator *string
@@ -2462,8 +2152,6 @@ type Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_s
 }
 
 type Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748 struct {
-
-    Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2475,33 +2163,25 @@ type Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_s
 
 type Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746 struct {
 
-    Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_id *string `lyra:"ignore"`
+    Match_expressions *[]Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747
 
-    Match_expressions *Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747
-
-    Match_fields *Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748
+    Match_fields *[]Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748
 
 }
 
 type Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745 struct {
 
-    Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_id *string `lyra:"ignore"`
-
-    Node_selector_term *Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746
+    Node_selector_term *[]Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746
 
 }
 
 type Kubernetes_persistent_volume_spec_743_node_affinity_744 struct {
 
-    Kubernetes_persistent_volume_spec_743_node_affinity_744_id *string `lyra:"ignore"`
-
-    Required *Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745
+    Required *[]Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -2514,8 +2194,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elas
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751_id *string `lyra:"ignore"`
 
     Caching_mode string
 
@@ -2531,8 +2209,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_di
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752_id *string `lyra:"ignore"`
-
     Read_only *bool
 
     Secret_name string
@@ -2543,15 +2219,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_fi
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_id *string `lyra:"ignore"`
 
     Monitors []string
 
@@ -2561,15 +2233,13 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_
 
     Secret_file *string
 
-    Secret_ref *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754
+    Secret_ref *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754
 
     User *string
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -2580,8 +2250,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_7
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -2595,15 +2263,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756 s
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_id *string `lyra:"ignore"`
 
     Driver string
 
@@ -2613,13 +2277,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_vol
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758
+    Secret_ref *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759_id *string `lyra:"ignore"`
 
     Dataset_name *string
 
@@ -2628,8 +2290,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -2643,8 +2303,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_pers
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761_id *string `lyra:"ignore"`
-
     Endpoints_name string
 
     Path string
@@ -2655,15 +2313,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterf
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -2681,15 +2335,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_76
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765_id *string `lyra:"ignore"`
 
     Path string
 
@@ -2701,8 +2351,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765 
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Pd_id string
@@ -2710,8 +2358,6 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_p
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767_id *string `lyra:"ignore"`
 
     Group *string
 
@@ -2727,15 +2373,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_id *string `lyra:"ignore"`
 
     Ceph_monitors []string
 
@@ -2751,13 +2393,11 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768 
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769
+    Secret_ref *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769
 
 }
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770 struct {
-
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -2767,59 +2407,55 @@ type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_
 
 type Kubernetes_persistent_volume_spec_743_persistent_volume_source_749 struct {
 
-    Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_id *string `lyra:"ignore"`
+    Aws_elastic_block_store *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750
 
-    Aws_elastic_block_store *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750
+    Azure_disk *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751
 
-    Azure_disk *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751
+    Azure_file *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752
 
-    Azure_file *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752
+    Ceph_fs *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753
 
-    Ceph_fs *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753
+    Cinder *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755
 
-    Cinder *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755
+    Fc *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756
 
-    Fc *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756
+    Flex_volume *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757
 
-    Flex_volume *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757
+    Flocker *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759
 
-    Flocker *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759
+    Gce_persistent_disk *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760
 
-    Gce_persistent_disk *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760
+    Glusterfs *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761
 
-    Glusterfs *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761
+    Host_path *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762
 
-    Host_path *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762
+    Iscsi *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763
 
-    Iscsi *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763
+    Local *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764
 
-    Local *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764
+    Nfs *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765
 
-    Nfs *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765
+    Photon_persistent_disk *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766
 
-    Photon_persistent_disk *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766
+    Quobyte *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767
 
-    Quobyte *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767
+    Rbd *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768
 
-    Rbd *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768
-
-    Vsphere_volume *Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770
+    Vsphere_volume *[]Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770
 
 }
 
 type Kubernetes_persistent_volume_spec_743 struct {
 
-    Kubernetes_persistent_volume_spec_743_id *string `lyra:"ignore"`
-
     Access_modes []string
 
     Capacity map[string]string
 
-    Node_affinity *Kubernetes_persistent_volume_spec_743_node_affinity_744
+    Node_affinity *[]Kubernetes_persistent_volume_spec_743_node_affinity_744
 
     Persistent_volume_reclaim_policy *string
 
-    Persistent_volume_source Kubernetes_persistent_volume_spec_743_persistent_volume_source_749
+    Persistent_volume_source []Kubernetes_persistent_volume_spec_743_persistent_volume_source_749
 
     Storage_class_name *string
 
@@ -2829,9 +2465,9 @@ type Kubernetes_persistent_volume struct {
 
     Kubernetes_persistent_volume_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_persistent_volume_metadata_742
+    Metadata []Kubernetes_persistent_volume_metadata_742
 
-    Spec Kubernetes_persistent_volume_spec_743
+    Spec []Kubernetes_persistent_volume_spec_743
 
 }
 
@@ -2874,8 +2510,6 @@ func (h *Kubernetes_persistent_volumeHandler) Delete(externalID string) error {
 
 type Kubernetes_persistent_volume_claim_metadata_771 struct {
 
-    Kubernetes_persistent_volume_claim_metadata_771_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -2898,8 +2532,6 @@ type Kubernetes_persistent_volume_claim_metadata_771 struct {
 
 type Kubernetes_persistent_volume_claim_spec_772_resources_773 struct {
 
-    Kubernetes_persistent_volume_claim_spec_772_resources_773_id *string `lyra:"ignore"`
-
     Limits *map[string]string
 
     Requests *map[string]string
@@ -2907,8 +2539,6 @@ type Kubernetes_persistent_volume_claim_spec_772_resources_773 struct {
 }
 
 type Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775 struct {
-
-    Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -2920,9 +2550,7 @@ type Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_
 
 type Kubernetes_persistent_volume_claim_spec_772_selector_774 struct {
 
-    Kubernetes_persistent_volume_claim_spec_772_selector_774_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775
+    Match_expressions *[]Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775
 
     Match_labels *map[string]string
 
@@ -2930,13 +2558,11 @@ type Kubernetes_persistent_volume_claim_spec_772_selector_774 struct {
 
 type Kubernetes_persistent_volume_claim_spec_772 struct {
 
-    Kubernetes_persistent_volume_claim_spec_772_id *string `lyra:"ignore"`
-
     Access_modes []string
 
-    Resources Kubernetes_persistent_volume_claim_spec_772_resources_773
+    Resources []Kubernetes_persistent_volume_claim_spec_772_resources_773
 
-    Selector *Kubernetes_persistent_volume_claim_spec_772_selector_774
+    Selector *[]Kubernetes_persistent_volume_claim_spec_772_selector_774
 
     Storage_class_name *string
 
@@ -2948,9 +2574,9 @@ type Kubernetes_persistent_volume_claim struct {
 
     Kubernetes_persistent_volume_claim_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_persistent_volume_claim_metadata_771
+    Metadata []Kubernetes_persistent_volume_claim_metadata_771
 
-    Spec Kubernetes_persistent_volume_claim_spec_772
+    Spec []Kubernetes_persistent_volume_claim_spec_772
 
     Wait_until_bound *bool
 
@@ -2995,8 +2621,6 @@ func (h *Kubernetes_persistent_volume_claimHandler) Delete(externalID string) er
 
 type Kubernetes_pod_metadata_776 struct {
 
-    Kubernetes_pod_metadata_776_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -3019,8 +2643,6 @@ type Kubernetes_pod_metadata_776 struct {
 
 type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781 struct {
 
-    Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -3028,8 +2650,6 @@ type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key
 }
 
 type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782 struct {
-
-    Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -3039,8 +2659,6 @@ type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782 
 
 type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783 struct {
 
-    Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783_id *string `lyra:"ignore"`
-
     Container_name *string
 
     Resource string
@@ -3048,8 +2666,6 @@ type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field
 }
 
 type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784 struct {
-
-    Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -3059,33 +2675,27 @@ type Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref
 
 type Kubernetes_pod_spec_777_container_778_env_779_value_from_780 struct {
 
-    Kubernetes_pod_spec_777_container_778_env_779_value_from_780_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781
 
-    Config_map_key_ref *Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781
+    Field_ref *[]Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782
 
-    Field_ref *Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782
+    Resource_field_ref *[]Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783
 
-    Resource_field_ref *Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783
-
-    Secret_key_ref *Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784
+    Secret_key_ref *[]Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784
 
 }
 
 type Kubernetes_pod_spec_777_container_778_env_779 struct {
 
-    Kubernetes_pod_spec_777_container_778_env_779_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_pod_spec_777_container_778_env_779_value_from_780
+    Value_from *[]Kubernetes_pod_spec_777_container_778_env_779_value_from_780
 
 }
 
 type Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786 struct {
-
-    Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786_id *string `lyra:"ignore"`
 
     Name string
 
@@ -3095,8 +2705,6 @@ type Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786 struc
 
 type Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787 struct {
 
-    Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -3105,27 +2713,21 @@ type Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787 struct {
 
 type Kubernetes_pod_spec_777_container_778_env_from_785 struct {
 
-    Kubernetes_pod_spec_777_container_778_env_from_785_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786
+    Config_map_ref *[]Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786
 
     Prefix *string
 
-    Secret_ref *Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787
+    Secret_ref *[]Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790 struct {
-
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792 struct {
-
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3135,11 +2737,9 @@ type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792
+    Http_header *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792
 
     Path *string
 
@@ -3151,35 +2751,27 @@ type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790
 
-    Exec *Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790
+    Http_get *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791
 
-    Http_get *Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791
-
-    Tcp_socket *Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793
+    Tcp_socket *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795 struct {
-
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797 struct {
-
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3189,11 +2781,9 @@ type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_7
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797
+    Http_header *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797
 
     Path *string
 
@@ -3205,45 +2795,35 @@ type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_7
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795
 
-    Exec *Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795
+    Http_get *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796
 
-    Http_get *Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796
-
-    Tcp_socket *Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798
+    Tcp_socket *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798
 
 }
 
 type Kubernetes_pod_spec_777_container_778_lifecycle_788 struct {
 
-    Kubernetes_pod_spec_777_container_778_lifecycle_788_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789
 
-    Post_start *Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789
-
-    Pre_stop *Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794
+    Pre_stop *[]Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794
 
 }
 
 type Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800 struct {
-
-    Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802 struct {
-
-    Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3253,11 +2833,9 @@ type Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_
 
 type Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801 struct {
 
-    Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802
+    Http_header *[]Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802
 
     Path *string
 
@@ -3269,21 +2847,17 @@ type Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801 struc
 
 type Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803 struct {
 
-    Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_liveness_probe_799 struct {
 
-    Kubernetes_pod_spec_777_container_778_liveness_probe_799_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800
+    Exec *[]Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801
+    Http_get *[]Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801
 
     Initial_delay_seconds *int
 
@@ -3291,15 +2865,13 @@ type Kubernetes_pod_spec_777_container_778_liveness_probe_799 struct {
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803
+    Tcp_socket *[]Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_pod_spec_777_container_778_port_804 struct {
-
-    Kubernetes_pod_spec_777_container_778_port_804_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -3315,15 +2887,11 @@ type Kubernetes_pod_spec_777_container_778_port_804 struct {
 
 type Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806 struct {
 
-    Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808 struct {
-
-    Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3333,11 +2901,9 @@ type Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http
 
 type Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807 struct {
 
-    Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808
+    Http_header *[]Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808
 
     Path *string
 
@@ -3349,21 +2915,17 @@ type Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807 stru
 
 type Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809 struct {
 
-    Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_container_778_readiness_probe_805 struct {
 
-    Kubernetes_pod_spec_777_container_778_readiness_probe_805_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806
+    Exec *[]Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807
+    Http_get *[]Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807
 
     Initial_delay_seconds *int
 
@@ -3371,15 +2933,13 @@ type Kubernetes_pod_spec_777_container_778_readiness_probe_805 struct {
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809
+    Tcp_socket *[]Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_pod_spec_777_container_778_resources_810_limits_811 struct {
-
-    Kubernetes_pod_spec_777_container_778_resources_810_limits_811_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -3389,8 +2949,6 @@ type Kubernetes_pod_spec_777_container_778_resources_810_limits_811 struct {
 
 type Kubernetes_pod_spec_777_container_778_resources_810_requests_812 struct {
 
-    Kubernetes_pod_spec_777_container_778_resources_810_requests_812_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -3399,17 +2957,13 @@ type Kubernetes_pod_spec_777_container_778_resources_810_requests_812 struct {
 
 type Kubernetes_pod_spec_777_container_778_resources_810 struct {
 
-    Kubernetes_pod_spec_777_container_778_resources_810_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_pod_spec_777_container_778_resources_810_limits_811
 
-    Limits *Kubernetes_pod_spec_777_container_778_resources_810_limits_811
-
-    Requests *Kubernetes_pod_spec_777_container_778_resources_810_requests_812
+    Requests *[]Kubernetes_pod_spec_777_container_778_resources_810_requests_812
 
 }
 
 type Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814 struct {
-
-    Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -3418,8 +2972,6 @@ type Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814
 }
 
 type Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815 struct {
-
-    Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -3433,11 +2985,9 @@ type Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options
 
 type Kubernetes_pod_spec_777_container_778_security_context_813 struct {
 
-    Kubernetes_pod_spec_777_container_778_security_context_813_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814
+    Capabilities *[]Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814
 
     Privileged *bool
 
@@ -3447,13 +2997,11 @@ type Kubernetes_pod_spec_777_container_778_security_context_813 struct {
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815
+    Se_linux_options *[]Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815
 
 }
 
 type Kubernetes_pod_spec_777_container_778_volume_mount_816 struct {
-
-    Kubernetes_pod_spec_777_container_778_volume_mount_816_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -3467,33 +3015,31 @@ type Kubernetes_pod_spec_777_container_778_volume_mount_816 struct {
 
 type Kubernetes_pod_spec_777_container_778 struct {
 
-    Kubernetes_pod_spec_777_container_778_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_pod_spec_777_container_778_env_779
+    Env *[]Kubernetes_pod_spec_777_container_778_env_779
 
-    Env_from *Kubernetes_pod_spec_777_container_778_env_from_785
+    Env_from *[]Kubernetes_pod_spec_777_container_778_env_from_785
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_pod_spec_777_container_778_lifecycle_788
+    Lifecycle *[]Kubernetes_pod_spec_777_container_778_lifecycle_788
 
-    Liveness_probe *Kubernetes_pod_spec_777_container_778_liveness_probe_799
+    Liveness_probe *[]Kubernetes_pod_spec_777_container_778_liveness_probe_799
 
     Name string
 
-    Port *Kubernetes_pod_spec_777_container_778_port_804
+    Port *[]Kubernetes_pod_spec_777_container_778_port_804
 
-    Readiness_probe *Kubernetes_pod_spec_777_container_778_readiness_probe_805
+    Readiness_probe *[]Kubernetes_pod_spec_777_container_778_readiness_probe_805
 
-    Resources *Kubernetes_pod_spec_777_container_778_resources_810
+    Resources *[]Kubernetes_pod_spec_777_container_778_resources_810
 
-    Security_context *Kubernetes_pod_spec_777_container_778_security_context_813
+    Security_context *[]Kubernetes_pod_spec_777_container_778_security_context_813
 
     Stdin *bool
 
@@ -3503,7 +3049,7 @@ type Kubernetes_pod_spec_777_container_778 struct {
 
     Tty *bool
 
-    Volume_mount *Kubernetes_pod_spec_777_container_778_volume_mount_816
+    Volume_mount *[]Kubernetes_pod_spec_777_container_778_volume_mount_816
 
     Working_dir *string
 
@@ -3511,15 +3057,11 @@ type Kubernetes_pod_spec_777_container_778 struct {
 
 type Kubernetes_pod_spec_777_image_pull_secrets_817 struct {
 
-    Kubernetes_pod_spec_777_image_pull_secrets_817_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -3529,8 +3071,6 @@ type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_ma
 
 type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Field_path *string
@@ -3538,8 +3078,6 @@ type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref
 }
 
 type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -3549,8 +3087,6 @@ type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_
 
 type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -3559,33 +3095,27 @@ type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_ke
 
 type Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821
 
-    Config_map_key_ref *Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821
+    Field_ref *[]Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822
 
-    Field_ref *Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822
+    Resource_field_ref *[]Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823
 
-    Resource_field_ref *Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823
-
-    Secret_key_ref *Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824
+    Secret_key_ref *[]Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_env_819 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_env_819_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820
+    Value_from *[]Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826_id *string `lyra:"ignore"`
 
     Name string
 
@@ -3595,8 +3125,6 @@ type Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826 
 
 type Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -3605,27 +3133,21 @@ type Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827 stru
 
 type Kubernetes_pod_spec_777_init_container_818_env_from_825 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_env_from_825_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826
+    Config_map_ref *[]Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826
 
     Prefix *string
 
-    Secret_ref *Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827
+    Secret_ref *[]Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3635,11 +3157,9 @@ type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_htt
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832
+    Http_header *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832
 
     Path *string
 
@@ -3651,35 +3171,27 @@ type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_htt
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830
 
-    Exec *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830
+    Http_get *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831
 
-    Http_get *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831
-
-    Tcp_socket *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833
+    Tcp_socket *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3689,11 +3201,9 @@ type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837
+    Http_header *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837
 
     Path *string
 
@@ -3705,45 +3215,35 @@ type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835
 
-    Exec *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835
+    Http_get *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836
 
-    Http_get *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836
-
-    Tcp_socket *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838
+    Tcp_socket *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_lifecycle_828 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_lifecycle_828_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829
 
-    Post_start *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829
-
-    Pre_stop *Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834
+    Pre_stop *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3753,11 +3253,9 @@ type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_
 
 type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842
+    Http_header *[]Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842
 
     Path *string
 
@@ -3769,21 +3267,17 @@ type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841 
 
 type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840
+    Exec *[]Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841
+    Http_get *[]Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841
 
     Initial_delay_seconds *int
 
@@ -3791,15 +3285,13 @@ type Kubernetes_pod_spec_777_init_container_818_liveness_probe_839 struct {
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843
+    Tcp_socket *[]Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_port_844 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_port_844_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -3815,15 +3307,11 @@ type Kubernetes_pod_spec_777_init_container_818_port_844 struct {
 
 type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -3833,11 +3321,9 @@ type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847
 
 type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848
+    Http_header *[]Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848
 
     Path *string
 
@@ -3849,21 +3335,17 @@ type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847
 
 type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846
+    Exec *[]Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847
+    Http_get *[]Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847
 
     Initial_delay_seconds *int
 
@@ -3871,15 +3353,13 @@ type Kubernetes_pod_spec_777_init_container_818_readiness_probe_845 struct {
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849
+    Tcp_socket *[]Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -3889,8 +3369,6 @@ type Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851 struct 
 
 type Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -3899,17 +3377,13 @@ type Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852 struc
 
 type Kubernetes_pod_spec_777_init_container_818_resources_850 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_resources_850_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851
 
-    Limits *Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851
-
-    Requests *Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852
+    Requests *[]Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -3918,8 +3392,6 @@ type Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilitie
 }
 
 type Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -3933,11 +3405,9 @@ type Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_op
 
 type Kubernetes_pod_spec_777_init_container_818_security_context_853 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_security_context_853_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854
+    Capabilities *[]Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854
 
     Privileged *bool
 
@@ -3947,13 +3417,11 @@ type Kubernetes_pod_spec_777_init_container_818_security_context_853 struct {
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855
+    Se_linux_options *[]Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855
 
 }
 
 type Kubernetes_pod_spec_777_init_container_818_volume_mount_856 struct {
-
-    Kubernetes_pod_spec_777_init_container_818_volume_mount_856_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -3967,33 +3435,31 @@ type Kubernetes_pod_spec_777_init_container_818_volume_mount_856 struct {
 
 type Kubernetes_pod_spec_777_init_container_818 struct {
 
-    Kubernetes_pod_spec_777_init_container_818_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_pod_spec_777_init_container_818_env_819
+    Env *[]Kubernetes_pod_spec_777_init_container_818_env_819
 
-    Env_from *Kubernetes_pod_spec_777_init_container_818_env_from_825
+    Env_from *[]Kubernetes_pod_spec_777_init_container_818_env_from_825
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_pod_spec_777_init_container_818_lifecycle_828
+    Lifecycle *[]Kubernetes_pod_spec_777_init_container_818_lifecycle_828
 
-    Liveness_probe *Kubernetes_pod_spec_777_init_container_818_liveness_probe_839
+    Liveness_probe *[]Kubernetes_pod_spec_777_init_container_818_liveness_probe_839
 
     Name string
 
-    Port *Kubernetes_pod_spec_777_init_container_818_port_844
+    Port *[]Kubernetes_pod_spec_777_init_container_818_port_844
 
-    Readiness_probe *Kubernetes_pod_spec_777_init_container_818_readiness_probe_845
+    Readiness_probe *[]Kubernetes_pod_spec_777_init_container_818_readiness_probe_845
 
-    Resources *Kubernetes_pod_spec_777_init_container_818_resources_850
+    Resources *[]Kubernetes_pod_spec_777_init_container_818_resources_850
 
-    Security_context *Kubernetes_pod_spec_777_init_container_818_security_context_853
+    Security_context *[]Kubernetes_pod_spec_777_init_container_818_security_context_853
 
     Stdin *bool
 
@@ -4003,15 +3469,13 @@ type Kubernetes_pod_spec_777_init_container_818 struct {
 
     Tty *bool
 
-    Volume_mount *Kubernetes_pod_spec_777_init_container_818_volume_mount_856
+    Volume_mount *[]Kubernetes_pod_spec_777_init_container_818_volume_mount_856
 
     Working_dir *string
 
 }
 
 type Kubernetes_pod_spec_777_security_context_857_se_linux_options_858 struct {
-
-    Kubernetes_pod_spec_777_security_context_857_se_linux_options_858_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -4025,23 +3489,19 @@ type Kubernetes_pod_spec_777_security_context_857_se_linux_options_858 struct {
 
 type Kubernetes_pod_spec_777_security_context_857 struct {
 
-    Kubernetes_pod_spec_777_security_context_857_id *string `lyra:"ignore"`
-
     Fs_group *int
 
     Run_as_non_root *bool
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_pod_spec_777_security_context_857_se_linux_options_858
+    Se_linux_options *[]Kubernetes_pod_spec_777_security_context_857_se_linux_options_858
 
     Supplemental_groups *[]int
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860 struct {
-
-    Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -4054,8 +3514,6 @@ type Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860 struct {
 }
 
 type Kubernetes_pod_spec_777_volume_859_azure_disk_861 struct {
-
-    Kubernetes_pod_spec_777_volume_859_azure_disk_861_id *string `lyra:"ignore"`
 
     Caching_mode string
 
@@ -4071,8 +3529,6 @@ type Kubernetes_pod_spec_777_volume_859_azure_disk_861 struct {
 
 type Kubernetes_pod_spec_777_volume_859_azure_file_862 struct {
 
-    Kubernetes_pod_spec_777_volume_859_azure_file_862_id *string `lyra:"ignore"`
-
     Read_only *bool
 
     Secret_name string
@@ -4083,15 +3539,11 @@ type Kubernetes_pod_spec_777_volume_859_azure_file_862 struct {
 
 type Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864 struct {
 
-    Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_ceph_fs_863 struct {
-
-    Kubernetes_pod_spec_777_volume_859_ceph_fs_863_id *string `lyra:"ignore"`
 
     Monitors []string
 
@@ -4101,15 +3553,13 @@ type Kubernetes_pod_spec_777_volume_859_ceph_fs_863 struct {
 
     Secret_file *string
 
-    Secret_ref *Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864
+    Secret_ref *[]Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864
 
     User *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_cinder_865 struct {
-
-    Kubernetes_pod_spec_777_volume_859_cinder_865_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -4121,8 +3571,6 @@ type Kubernetes_pod_spec_777_volume_859_cinder_865 struct {
 
 type Kubernetes_pod_spec_777_volume_859_config_map_866_items_867 struct {
 
-    Kubernetes_pod_spec_777_volume_859_config_map_866_items_867_id *string `lyra:"ignore"`
-
     Key *string
 
     Mode *int
@@ -4133,19 +3581,15 @@ type Kubernetes_pod_spec_777_volume_859_config_map_866_items_867 struct {
 
 type Kubernetes_pod_spec_777_volume_859_config_map_866 struct {
 
-    Kubernetes_pod_spec_777_volume_859_config_map_866_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_pod_spec_777_volume_859_config_map_866_items_867
+    Items *[]Kubernetes_pod_spec_777_volume_859_config_map_866_items_867
 
     Name *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870 struct {
-
-    Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -4154,8 +3598,6 @@ type Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870
 }
 
 type Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871 struct {
-
-    Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871_id *string `lyra:"ignore"`
 
     Container_name string
 
@@ -4167,39 +3609,31 @@ type Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_fiel
 
 type Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869 struct {
 
-    Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_id *string `lyra:"ignore"`
-
-    Field_ref Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870
+    Field_ref []Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870
 
     Mode *int
 
     Path string
 
-    Resource_field_ref *Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871
+    Resource_field_ref *[]Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_downward_api_868 struct {
 
-    Kubernetes_pod_spec_777_volume_859_downward_api_868_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869
+    Items *[]Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_empty_dir_872 struct {
-
-    Kubernetes_pod_spec_777_volume_859_empty_dir_872_id *string `lyra:"ignore"`
 
     Medium *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_fc_873 struct {
-
-    Kubernetes_pod_spec_777_volume_859_fc_873_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -4213,15 +3647,11 @@ type Kubernetes_pod_spec_777_volume_859_fc_873 struct {
 
 type Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875 struct {
 
-    Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_flex_volume_874 struct {
-
-    Kubernetes_pod_spec_777_volume_859_flex_volume_874_id *string `lyra:"ignore"`
 
     Driver string
 
@@ -4231,13 +3661,11 @@ type Kubernetes_pod_spec_777_volume_859_flex_volume_874 struct {
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875
+    Secret_ref *[]Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_flocker_876 struct {
-
-    Kubernetes_pod_spec_777_volume_859_flocker_876_id *string `lyra:"ignore"`
 
     Dataset_name *string
 
@@ -4246,8 +3674,6 @@ type Kubernetes_pod_spec_777_volume_859_flocker_876 struct {
 }
 
 type Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877 struct {
-
-    Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -4261,8 +3687,6 @@ type Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877 struct {
 
 type Kubernetes_pod_spec_777_volume_859_git_repo_878 struct {
 
-    Kubernetes_pod_spec_777_volume_859_git_repo_878_id *string `lyra:"ignore"`
-
     Directory *string
 
     Repository *string
@@ -4272,8 +3696,6 @@ type Kubernetes_pod_spec_777_volume_859_git_repo_878 struct {
 }
 
 type Kubernetes_pod_spec_777_volume_859_glusterfs_879 struct {
-
-    Kubernetes_pod_spec_777_volume_859_glusterfs_879_id *string `lyra:"ignore"`
 
     Endpoints_name string
 
@@ -4285,15 +3707,11 @@ type Kubernetes_pod_spec_777_volume_859_glusterfs_879 struct {
 
 type Kubernetes_pod_spec_777_volume_859_host_path_880 struct {
 
-    Kubernetes_pod_spec_777_volume_859_host_path_880_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_iscsi_881 struct {
-
-    Kubernetes_pod_spec_777_volume_859_iscsi_881_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -4311,15 +3729,11 @@ type Kubernetes_pod_spec_777_volume_859_iscsi_881 struct {
 
 type Kubernetes_pod_spec_777_volume_859_local_882 struct {
 
-    Kubernetes_pod_spec_777_volume_859_local_882_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_nfs_883 struct {
-
-    Kubernetes_pod_spec_777_volume_859_nfs_883_id *string `lyra:"ignore"`
 
     Path string
 
@@ -4331,8 +3745,6 @@ type Kubernetes_pod_spec_777_volume_859_nfs_883 struct {
 
 type Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884 struct {
 
-    Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884_id *string `lyra:"ignore"`
-
     Claim_name *string
 
     Read_only *bool
@@ -4341,8 +3753,6 @@ type Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884 struct {
 
 type Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885 struct {
 
-    Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Pd_id string
@@ -4350,8 +3760,6 @@ type Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885 struct {
 }
 
 type Kubernetes_pod_spec_777_volume_859_quobyte_886 struct {
-
-    Kubernetes_pod_spec_777_volume_859_quobyte_886_id *string `lyra:"ignore"`
 
     Group *string
 
@@ -4367,15 +3775,11 @@ type Kubernetes_pod_spec_777_volume_859_quobyte_886 struct {
 
 type Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888 struct {
 
-    Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_rbd_887 struct {
-
-    Kubernetes_pod_spec_777_volume_859_rbd_887_id *string `lyra:"ignore"`
 
     Ceph_monitors []string
 
@@ -4391,13 +3795,11 @@ type Kubernetes_pod_spec_777_volume_859_rbd_887 struct {
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888
+    Secret_ref *[]Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888
 
 }
 
 type Kubernetes_pod_spec_777_volume_859_secret_889_items_890 struct {
-
-    Kubernetes_pod_spec_777_volume_859_secret_889_items_890_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -4409,11 +3811,9 @@ type Kubernetes_pod_spec_777_volume_859_secret_889_items_890 struct {
 
 type Kubernetes_pod_spec_777_volume_859_secret_889 struct {
 
-    Kubernetes_pod_spec_777_volume_859_secret_889_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_pod_spec_777_volume_859_secret_889_items_890
+    Items *[]Kubernetes_pod_spec_777_volume_859_secret_889_items_890
 
     Optional *bool
 
@@ -4423,8 +3823,6 @@ type Kubernetes_pod_spec_777_volume_859_secret_889 struct {
 
 type Kubernetes_pod_spec_777_volume_859_vsphere_volume_891 struct {
 
-    Kubernetes_pod_spec_777_volume_859_vsphere_volume_891_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Volume_path string
@@ -4433,67 +3831,63 @@ type Kubernetes_pod_spec_777_volume_859_vsphere_volume_891 struct {
 
 type Kubernetes_pod_spec_777_volume_859 struct {
 
-    Kubernetes_pod_spec_777_volume_859_id *string `lyra:"ignore"`
+    Aws_elastic_block_store *[]Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860
 
-    Aws_elastic_block_store *Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860
+    Azure_disk *[]Kubernetes_pod_spec_777_volume_859_azure_disk_861
 
-    Azure_disk *Kubernetes_pod_spec_777_volume_859_azure_disk_861
+    Azure_file *[]Kubernetes_pod_spec_777_volume_859_azure_file_862
 
-    Azure_file *Kubernetes_pod_spec_777_volume_859_azure_file_862
+    Ceph_fs *[]Kubernetes_pod_spec_777_volume_859_ceph_fs_863
 
-    Ceph_fs *Kubernetes_pod_spec_777_volume_859_ceph_fs_863
+    Cinder *[]Kubernetes_pod_spec_777_volume_859_cinder_865
 
-    Cinder *Kubernetes_pod_spec_777_volume_859_cinder_865
+    Config_map *[]Kubernetes_pod_spec_777_volume_859_config_map_866
 
-    Config_map *Kubernetes_pod_spec_777_volume_859_config_map_866
+    Downward_api *[]Kubernetes_pod_spec_777_volume_859_downward_api_868
 
-    Downward_api *Kubernetes_pod_spec_777_volume_859_downward_api_868
+    Empty_dir *[]Kubernetes_pod_spec_777_volume_859_empty_dir_872
 
-    Empty_dir *Kubernetes_pod_spec_777_volume_859_empty_dir_872
+    Fc *[]Kubernetes_pod_spec_777_volume_859_fc_873
 
-    Fc *Kubernetes_pod_spec_777_volume_859_fc_873
+    Flex_volume *[]Kubernetes_pod_spec_777_volume_859_flex_volume_874
 
-    Flex_volume *Kubernetes_pod_spec_777_volume_859_flex_volume_874
+    Flocker *[]Kubernetes_pod_spec_777_volume_859_flocker_876
 
-    Flocker *Kubernetes_pod_spec_777_volume_859_flocker_876
+    Gce_persistent_disk *[]Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877
 
-    Gce_persistent_disk *Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877
+    Git_repo *[]Kubernetes_pod_spec_777_volume_859_git_repo_878
 
-    Git_repo *Kubernetes_pod_spec_777_volume_859_git_repo_878
+    Glusterfs *[]Kubernetes_pod_spec_777_volume_859_glusterfs_879
 
-    Glusterfs *Kubernetes_pod_spec_777_volume_859_glusterfs_879
+    Host_path *[]Kubernetes_pod_spec_777_volume_859_host_path_880
 
-    Host_path *Kubernetes_pod_spec_777_volume_859_host_path_880
+    Iscsi *[]Kubernetes_pod_spec_777_volume_859_iscsi_881
 
-    Iscsi *Kubernetes_pod_spec_777_volume_859_iscsi_881
-
-    Local *Kubernetes_pod_spec_777_volume_859_local_882
+    Local *[]Kubernetes_pod_spec_777_volume_859_local_882
 
     Name *string
 
-    Nfs *Kubernetes_pod_spec_777_volume_859_nfs_883
+    Nfs *[]Kubernetes_pod_spec_777_volume_859_nfs_883
 
-    Persistent_volume_claim *Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884
+    Persistent_volume_claim *[]Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884
 
-    Photon_persistent_disk *Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885
+    Photon_persistent_disk *[]Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885
 
-    Quobyte *Kubernetes_pod_spec_777_volume_859_quobyte_886
+    Quobyte *[]Kubernetes_pod_spec_777_volume_859_quobyte_886
 
-    Rbd *Kubernetes_pod_spec_777_volume_859_rbd_887
+    Rbd *[]Kubernetes_pod_spec_777_volume_859_rbd_887
 
-    Secret *Kubernetes_pod_spec_777_volume_859_secret_889
+    Secret *[]Kubernetes_pod_spec_777_volume_859_secret_889
 
-    Vsphere_volume *Kubernetes_pod_spec_777_volume_859_vsphere_volume_891
+    Vsphere_volume *[]Kubernetes_pod_spec_777_volume_859_vsphere_volume_891
 
 }
 
 type Kubernetes_pod_spec_777 struct {
 
-    Kubernetes_pod_spec_777_id *string `lyra:"ignore"`
-
     Active_deadline_seconds *int
 
-    Container *Kubernetes_pod_spec_777_container_778
+    Container *[]Kubernetes_pod_spec_777_container_778
 
     Dns_policy *string
 
@@ -4505,9 +3899,9 @@ type Kubernetes_pod_spec_777 struct {
 
     Hostname *string
 
-    Image_pull_secrets *Kubernetes_pod_spec_777_image_pull_secrets_817
+    Image_pull_secrets *[]Kubernetes_pod_spec_777_image_pull_secrets_817
 
-    Init_container *Kubernetes_pod_spec_777_init_container_818
+    Init_container *[]Kubernetes_pod_spec_777_init_container_818
 
     Node_name *string
 
@@ -4515,7 +3909,7 @@ type Kubernetes_pod_spec_777 struct {
 
     Restart_policy *string
 
-    Security_context *Kubernetes_pod_spec_777_security_context_857
+    Security_context *[]Kubernetes_pod_spec_777_security_context_857
 
     Service_account_name *string
 
@@ -4523,7 +3917,7 @@ type Kubernetes_pod_spec_777 struct {
 
     Termination_grace_period_seconds *int
 
-    Volume *Kubernetes_pod_spec_777_volume_859
+    Volume *[]Kubernetes_pod_spec_777_volume_859
 
 }
 
@@ -4531,9 +3925,9 @@ type Kubernetes_pod struct {
 
     Kubernetes_pod_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_pod_metadata_776
+    Metadata []Kubernetes_pod_metadata_776
 
-    Spec Kubernetes_pod_spec_777
+    Spec []Kubernetes_pod_spec_777
 
 }
 
@@ -4576,8 +3970,6 @@ func (h *Kubernetes_podHandler) Delete(externalID string) error {
 
 type Kubernetes_replication_controller_metadata_892 struct {
 
-    Kubernetes_replication_controller_metadata_892_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -4600,8 +3992,6 @@ type Kubernetes_replication_controller_metadata_892 struct {
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -4609,8 +3999,6 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_env_8
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -4620,8 +4008,6 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_env_8
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900_id *string `lyra:"ignore"`
-
     Container_name *string
 
     Resource string
@@ -4629,8 +4015,6 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_env_8
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -4640,33 +4024,27 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_env_8
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898
 
-    Config_map_key_ref *Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898
+    Field_ref *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899
 
-    Field_ref *Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899
+    Resource_field_ref *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900
 
-    Resource_field_ref *Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900
-
-    Secret_key_ref *Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901
+    Secret_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_896 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897
+    Value_from *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903_id *string `lyra:"ignore"`
 
     Name string
 
@@ -4676,8 +4054,6 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_env_f
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -4686,27 +4062,21 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_env_f
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903
+    Config_map_ref *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903
 
     Prefix *string
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -4716,11 +4086,9 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_lifec
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909
 
     Path *string
 
@@ -4732,35 +4100,27 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_lifec
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -4770,11 +4130,9 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_lifec
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914
 
     Path *string
 
@@ -4786,45 +4144,35 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_lifec
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906
 
-    Post_start *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906
-
-    Pre_stop *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911
+    Pre_stop *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -4834,11 +4182,9 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_liven
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919
 
     Path *string
 
@@ -4850,21 +4196,17 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_liven
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918
 
     Initial_delay_seconds *int
 
@@ -4872,15 +4214,13 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_liven
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_port_921 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_port_921_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -4896,15 +4236,11 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_port_
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -4914,11 +4250,9 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_readi
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925
 
     Path *string
 
@@ -4930,21 +4264,17 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_readi
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924
 
     Initial_delay_seconds *int
 
@@ -4952,15 +4282,13 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_readi
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -4970,8 +4298,6 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_resou
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -4980,17 +4306,13 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_resou
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928
 
-    Limits *Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928
-
-    Requests *Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929
+    Requests *[]Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -4999,8 +4321,6 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_secur
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -5014,11 +4334,9 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_secur
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931
+    Capabilities *[]Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931
 
     Privileged *bool
 
@@ -5028,13 +4346,11 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_secur
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932
+    Se_linux_options *[]Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -5048,33 +4364,31 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895_volum
 
 type Kubernetes_replication_controller_spec_893_template_894_container_895 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_container_895_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_replication_controller_spec_893_template_894_container_895_env_896
+    Env *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_896
 
-    Env_from *Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902
+    Env_from *[]Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905
+    Lifecycle *[]Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905
 
-    Liveness_probe *Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916
+    Liveness_probe *[]Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916
 
     Name string
 
-    Port *Kubernetes_replication_controller_spec_893_template_894_container_895_port_921
+    Port *[]Kubernetes_replication_controller_spec_893_template_894_container_895_port_921
 
-    Readiness_probe *Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922
+    Readiness_probe *[]Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922
 
-    Resources *Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927
+    Resources *[]Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927
 
-    Security_context *Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930
+    Security_context *[]Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930
 
     Stdin *bool
 
@@ -5084,7 +4398,7 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895 struc
 
     Tty *bool
 
-    Volume_mount *Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933
+    Volume_mount *[]Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933
 
     Working_dir *string
 
@@ -5092,15 +4406,11 @@ type Kubernetes_replication_controller_spec_893_template_894_container_895 struc
 
 type Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -5110,8 +4420,6 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Field_path *string
@@ -5119,8 +4427,6 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -5130,8 +4436,6 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -5140,33 +4444,27 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938
 
-    Config_map_key_ref *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938
+    Field_ref *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939
 
-    Field_ref *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939
+    Resource_field_ref *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940
 
-    Resource_field_ref *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940
-
-    Secret_key_ref *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941
+    Secret_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937
+    Value_from *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943_id *string `lyra:"ignore"`
 
     Name string
 
@@ -5176,8 +4474,6 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -5186,27 +4482,21 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943
+    Config_map_ref *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943
 
     Prefix *string
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5216,11 +4506,9 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949
 
     Path *string
 
@@ -5232,35 +4520,27 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5270,11 +4550,9 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954
 
     Path *string
 
@@ -5286,45 +4564,35 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946
 
-    Post_start *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946
-
-    Pre_stop *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951
+    Pre_stop *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5334,11 +4602,9 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959
 
     Path *string
 
@@ -5350,21 +4616,17 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958
 
     Initial_delay_seconds *int
 
@@ -5372,15 +4634,13 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -5396,15 +4656,11 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5414,11 +4670,9 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965
 
     Path *string
 
@@ -5430,21 +4684,17 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964
 
     Initial_delay_seconds *int
 
@@ -5452,15 +4702,13 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -5470,8 +4718,6 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -5480,17 +4726,13 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968
 
-    Limits *Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968
-
-    Requests *Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969
+    Requests *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -5499,8 +4741,6 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -5514,11 +4754,9 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971
+    Capabilities *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971
 
     Privileged *bool
 
@@ -5528,13 +4766,11 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972
+    Se_linux_options *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -5548,33 +4784,31 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935_
 
 type Kubernetes_replication_controller_spec_893_template_894_init_container_935 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_init_container_935_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936
+    Env *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936
 
-    Env_from *Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942
+    Env_from *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945
+    Lifecycle *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945
 
-    Liveness_probe *Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956
+    Liveness_probe *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956
 
     Name string
 
-    Port *Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961
+    Port *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961
 
-    Readiness_probe *Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962
+    Readiness_probe *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962
 
-    Resources *Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967
+    Resources *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967
 
-    Security_context *Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970
+    Security_context *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970
 
     Stdin *bool
 
@@ -5584,15 +4818,13 @@ type Kubernetes_replication_controller_spec_893_template_894_init_container_935 
 
     Tty *bool
 
-    Volume_mount *Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973
+    Volume_mount *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973
 
     Working_dir *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_metadata_974 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_metadata_974_id *string `lyra:"ignore"`
 
     Annotations *map[string]string
 
@@ -5616,8 +4848,6 @@ type Kubernetes_replication_controller_spec_893_template_894_metadata_974 struct
 
 type Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976_id *string `lyra:"ignore"`
-
     Level *string
 
     Role *string
@@ -5630,23 +4860,19 @@ type Kubernetes_replication_controller_spec_893_template_894_security_context_97
 
 type Kubernetes_replication_controller_spec_893_template_894_security_context_975 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_security_context_975_id *string `lyra:"ignore"`
-
     Fs_group *int
 
     Run_as_non_root *bool
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976
+    Se_linux_options *[]Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976
 
     Supplemental_groups *[]int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -5656,8 +4882,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Field_path *string
@@ -5665,8 +4889,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -5676,8 +4898,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -5686,33 +4906,27 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981
 
-    Config_map_key_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981
+    Field_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982
 
-    Field_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982
+    Resource_field_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983
 
-    Resource_field_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983
-
-    Secret_key_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984
+    Secret_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980
+    Value_from *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986_id *string `lyra:"ignore"`
 
     Name string
 
@@ -5722,8 +4936,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -5732,27 +4944,21 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986
+    Config_map_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986
 
     Prefix *string
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5762,11 +4968,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992
 
     Path *string
 
@@ -5778,35 +4982,27 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5816,11 +5012,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997
 
     Path *string
 
@@ -5832,45 +5026,35 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989
 
-    Post_start *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989
-
-    Pre_stop *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994
+    Pre_stop *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5880,11 +5064,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002
 
     Path *string
 
@@ -5896,21 +5078,17 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001
 
     Initial_delay_seconds *int
 
@@ -5918,15 +5096,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -5942,15 +5118,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -5960,11 +5132,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008
 
     Path *string
 
@@ -5976,21 +5146,17 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007
 
     Initial_delay_seconds *int
 
@@ -5998,15 +5164,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -6016,8 +5180,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -6026,17 +5188,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011
 
-    Limits *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011
-
-    Requests *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012
+    Requests *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -6045,8 +5203,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -6060,11 +5216,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014
+    Capabilities *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014
 
     Privileged *bool
 
@@ -6074,13 +5228,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015
+    Se_linux_options *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -6094,33 +5246,31 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979
+    Env *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979
 
-    Env_from *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985
+    Env_from *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988
+    Lifecycle *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988
 
-    Liveness_probe *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999
+    Liveness_probe *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999
 
     Name string
 
-    Port *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004
+    Port *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004
 
-    Readiness_probe *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005
+    Readiness_probe *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005
 
-    Resources *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010
+    Resources *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010
 
-    Security_context *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013
+    Security_context *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013
 
     Stdin *bool
 
@@ -6130,7 +5280,7 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
     Tty *bool
 
-    Volume_mount *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016
+    Volume_mount *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016
 
     Working_dir *string
 
@@ -6138,15 +5288,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_container_
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -6156,8 +5302,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Field_path *string
@@ -6165,8 +5309,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -6176,8 +5318,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -6186,33 +5326,27 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021
 
-    Config_map_key_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021
+    Field_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022
 
-    Field_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022
+    Resource_field_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023
 
-    Resource_field_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023
-
-    Secret_key_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024
+    Secret_key_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020
+    Value_from *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026_id *string `lyra:"ignore"`
 
     Name string
 
@@ -6222,8 +5356,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -6232,27 +5364,21 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026
+    Config_map_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026
 
     Prefix *string
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -6262,11 +5388,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032
 
     Path *string
 
@@ -6278,35 +5402,27 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -6316,11 +5432,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037
 
     Path *string
 
@@ -6332,45 +5446,35 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035
 
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036
-
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029
 
-    Post_start *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029
-
-    Pre_stop *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034
+    Pre_stop *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -6380,11 +5484,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042
 
     Path *string
 
@@ -6396,21 +5498,17 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041
 
     Initial_delay_seconds *int
 
@@ -6418,15 +5516,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -6442,15 +5538,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -6460,11 +5552,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048
+    Http_header *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048
 
     Path *string
 
@@ -6476,21 +5566,17 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046
+    Exec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047
+    Http_get *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047
 
     Initial_delay_seconds *int
 
@@ -6498,15 +5584,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049
+    Tcp_socket *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -6516,8 +5600,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -6526,17 +5608,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051
 
-    Limits *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051
-
-    Requests *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052
+    Requests *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -6545,8 +5623,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -6560,11 +5636,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054
+    Capabilities *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054
 
     Privileged *bool
 
@@ -6574,13 +5648,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055
+    Se_linux_options *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -6594,33 +5666,31 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019
+    Env *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019
 
-    Env_from *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025
+    Env_from *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028
+    Lifecycle *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028
 
-    Liveness_probe *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039
+    Liveness_probe *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039
 
     Name string
 
-    Port *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044
+    Port *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044
 
-    Readiness_probe *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045
+    Readiness_probe *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045
 
-    Resources *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050
+    Resources *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050
 
-    Security_context *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053
+    Security_context *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053
 
     Stdin *bool
 
@@ -6630,15 +5700,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_init_conta
 
     Tty *bool
 
-    Volume_mount *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056
+    Volume_mount *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056
 
     Working_dir *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -6652,23 +5720,19 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_security_c
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_id *string `lyra:"ignore"`
-
     Fs_group *int
 
     Run_as_non_root *bool
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058
+    Se_linux_options *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058
 
     Supplemental_groups *[]int
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -6681,8 +5745,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061_id *string `lyra:"ignore"`
 
     Caching_mode string
 
@@ -6698,8 +5760,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062_id *string `lyra:"ignore"`
-
     Read_only *bool
 
     Secret_name string
@@ -6710,15 +5770,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_id *string `lyra:"ignore"`
 
     Monitors []string
 
@@ -6728,15 +5784,13 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
     Secret_file *string
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064
 
     User *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -6748,8 +5802,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067_id *string `lyra:"ignore"`
-
     Key *string
 
     Mode *int
@@ -6760,19 +5812,15 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067
+    Items *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067
 
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -6781,8 +5829,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071_id *string `lyra:"ignore"`
 
     Container_name string
 
@@ -6794,39 +5840,31 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_id *string `lyra:"ignore"`
-
-    Field_ref Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070
+    Field_ref []Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070
 
     Mode *int
 
     Path string
 
-    Resource_field_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071
+    Resource_field_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069
+    Items *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072_id *string `lyra:"ignore"`
 
     Medium *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -6840,15 +5878,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_id *string `lyra:"ignore"`
 
     Driver string
 
@@ -6858,13 +5892,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076_id *string `lyra:"ignore"`
 
     Dataset_name *string
 
@@ -6873,8 +5905,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -6888,8 +5918,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078_id *string `lyra:"ignore"`
-
     Directory *string
 
     Repository *string
@@ -6899,8 +5927,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079_id *string `lyra:"ignore"`
 
     Endpoints_name string
 
@@ -6912,15 +5938,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -6938,15 +5960,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083_id *string `lyra:"ignore"`
 
     Path string
 
@@ -6958,8 +5976,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084_id *string `lyra:"ignore"`
-
     Claim_name *string
 
     Read_only *bool
@@ -6968,8 +5984,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Pd_id string
@@ -6977,8 +5991,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086_id *string `lyra:"ignore"`
 
     Group *string
 
@@ -6994,15 +6006,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_id *string `lyra:"ignore"`
 
     Ceph_monitors []string
 
@@ -7018,13 +6026,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -7036,11 +6042,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090
+    Items *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090
 
     Optional *bool
 
@@ -7050,8 +6054,6 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Volume_path string
@@ -7060,67 +6062,63 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_105
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_id *string `lyra:"ignore"`
+    Aws_elastic_block_store *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060
 
-    Aws_elastic_block_store *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060
+    Azure_disk *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061
 
-    Azure_disk *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061
+    Azure_file *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062
 
-    Azure_file *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062
+    Ceph_fs *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063
 
-    Ceph_fs *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063
+    Cinder *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065
 
-    Cinder *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065
+    Config_map *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066
 
-    Config_map *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066
+    Downward_api *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068
 
-    Downward_api *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068
+    Empty_dir *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072
 
-    Empty_dir *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072
+    Fc *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073
 
-    Fc *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073
+    Flex_volume *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074
 
-    Flex_volume *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074
+    Flocker *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076
 
-    Flocker *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076
+    Gce_persistent_disk *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077
 
-    Gce_persistent_disk *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077
+    Git_repo *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078
 
-    Git_repo *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078
+    Glusterfs *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079
 
-    Glusterfs *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079
+    Host_path *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080
 
-    Host_path *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080
+    Iscsi *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081
 
-    Iscsi *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081
-
-    Local *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082
+    Local *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082
 
     Name *string
 
-    Nfs *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083
+    Nfs *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083
 
-    Persistent_volume_claim *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084
+    Persistent_volume_claim *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084
 
-    Photon_persistent_disk *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085
+    Photon_persistent_disk *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085
 
-    Quobyte *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086
+    Quobyte *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086
 
-    Rbd *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087
+    Rbd *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087
 
-    Secret *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089
+    Secret *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089
 
-    Vsphere_volume *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091
+    Vsphere_volume *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_spec_977 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_spec_977_id *string `lyra:"ignore"`
-
     Active_deadline_seconds *int
 
-    Container *Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978
+    Container *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978
 
     Dns_policy *string
 
@@ -7132,9 +6130,9 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977 struct {
 
     Hostname *string
 
-    Image_pull_secrets *Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017
+    Image_pull_secrets *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017
 
-    Init_container *Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018
+    Init_container *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018
 
     Node_name *string
 
@@ -7142,7 +6140,7 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977 struct {
 
     Restart_policy *string
 
-    Security_context *Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057
+    Security_context *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057
 
     Service_account_name *string
 
@@ -7150,13 +6148,11 @@ type Kubernetes_replication_controller_spec_893_template_894_spec_977 struct {
 
     Termination_grace_period_seconds *int
 
-    Volume *Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059
+    Volume *[]Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -7169,8 +6165,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_ela
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094_id *string `lyra:"ignore"`
 
     Caching_mode string
 
@@ -7186,8 +6180,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_d
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095_id *string `lyra:"ignore"`
-
     Read_only *bool
 
     Secret_name string
@@ -7198,15 +6190,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_f
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_id *string `lyra:"ignore"`
 
     Monitors []string
 
@@ -7216,15 +6204,13 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs
 
     Secret_file *string
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097
 
     User *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -7236,8 +6222,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100_id *string `lyra:"ignore"`
-
     Key *string
 
     Mode *int
@@ -7248,19 +6232,15 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100
+    Items *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100
 
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -7269,8 +6249,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_downwar
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104_id *string `lyra:"ignore"`
 
     Container_name string
 
@@ -7282,39 +6260,31 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_downwar
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_id *string `lyra:"ignore"`
-
-    Field_ref Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103
+    Field_ref []Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103
 
     Mode *int
 
     Path string
 
-    Resource_field_ref *Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104
+    Resource_field_ref *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102
+    Items *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105_id *string `lyra:"ignore"`
 
     Medium *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -7328,15 +6298,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_id *string `lyra:"ignore"`
 
     Driver string
 
@@ -7346,13 +6312,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_vo
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109_id *string `lyra:"ignore"`
 
     Dataset_name *string
 
@@ -7361,8 +6325,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -7376,8 +6338,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_per
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111_id *string `lyra:"ignore"`
-
     Directory *string
 
     Repository *string
@@ -7387,8 +6347,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_rep
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112_id *string `lyra:"ignore"`
 
     Endpoints_name string
 
@@ -7400,15 +6358,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_gluster
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -7426,15 +6380,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116_id *string `lyra:"ignore"`
 
     Path string
 
@@ -7446,8 +6396,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_111
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117_id *string `lyra:"ignore"`
-
     Claim_name *string
 
     Read_only *bool
@@ -7456,8 +6404,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_persist
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Pd_id string
@@ -7465,8 +6411,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119_id *string `lyra:"ignore"`
 
     Group *string
 
@@ -7482,15 +6426,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_id *string `lyra:"ignore"`
 
     Ceph_monitors []string
 
@@ -7506,13 +6446,11 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_112
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121
+    Secret_ref *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123 struct {
-
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -7524,11 +6462,9 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123
+    Items *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123
 
     Optional *bool
 
@@ -7538,8 +6474,6 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Volume_path string
@@ -7548,67 +6482,63 @@ type Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere
 
 type Kubernetes_replication_controller_spec_893_template_894_volume_1092 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_volume_1092_id *string `lyra:"ignore"`
+    Aws_elastic_block_store *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093
 
-    Aws_elastic_block_store *Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093
+    Azure_disk *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094
 
-    Azure_disk *Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094
+    Azure_file *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095
 
-    Azure_file *Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095
+    Ceph_fs *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096
 
-    Ceph_fs *Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096
+    Cinder *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098
 
-    Cinder *Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098
+    Config_map *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099
 
-    Config_map *Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099
+    Downward_api *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101
 
-    Downward_api *Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101
+    Empty_dir *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105
 
-    Empty_dir *Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105
+    Fc *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106
 
-    Fc *Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106
+    Flex_volume *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107
 
-    Flex_volume *Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107
+    Flocker *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109
 
-    Flocker *Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109
+    Gce_persistent_disk *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110
 
-    Gce_persistent_disk *Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110
+    Git_repo *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111
 
-    Git_repo *Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111
+    Glusterfs *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112
 
-    Glusterfs *Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112
+    Host_path *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113
 
-    Host_path *Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113
+    Iscsi *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114
 
-    Iscsi *Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114
-
-    Local *Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115
+    Local *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115
 
     Name *string
 
-    Nfs *Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116
+    Nfs *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116
 
-    Persistent_volume_claim *Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117
+    Persistent_volume_claim *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117
 
-    Photon_persistent_disk *Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118
+    Photon_persistent_disk *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118
 
-    Quobyte *Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119
+    Quobyte *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119
 
-    Rbd *Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120
+    Rbd *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120
 
-    Secret *Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122
+    Secret *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122
 
-    Vsphere_volume *Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124
+    Vsphere_volume *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124
 
 }
 
 type Kubernetes_replication_controller_spec_893_template_894 struct {
 
-    Kubernetes_replication_controller_spec_893_template_894_id *string `lyra:"ignore"`
-
     Active_deadline_seconds *int
 
-    Container *Kubernetes_replication_controller_spec_893_template_894_container_895
+    Container *[]Kubernetes_replication_controller_spec_893_template_894_container_895
 
     Dns_policy *string
 
@@ -7620,11 +6550,11 @@ type Kubernetes_replication_controller_spec_893_template_894 struct {
 
     Hostname *string
 
-    Image_pull_secrets *Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934
+    Image_pull_secrets *[]Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934
 
-    Init_container *Kubernetes_replication_controller_spec_893_template_894_init_container_935
+    Init_container *[]Kubernetes_replication_controller_spec_893_template_894_init_container_935
 
-    Metadata *Kubernetes_replication_controller_spec_893_template_894_metadata_974
+    Metadata *[]Kubernetes_replication_controller_spec_893_template_894_metadata_974
 
     Node_name *string
 
@@ -7632,23 +6562,21 @@ type Kubernetes_replication_controller_spec_893_template_894 struct {
 
     Restart_policy *string
 
-    Security_context *Kubernetes_replication_controller_spec_893_template_894_security_context_975
+    Security_context *[]Kubernetes_replication_controller_spec_893_template_894_security_context_975
 
     Service_account_name *string
 
-    Spec *Kubernetes_replication_controller_spec_893_template_894_spec_977
+    Spec *[]Kubernetes_replication_controller_spec_893_template_894_spec_977
 
     Subdomain *string
 
     Termination_grace_period_seconds *int
 
-    Volume *Kubernetes_replication_controller_spec_893_template_894_volume_1092
+    Volume *[]Kubernetes_replication_controller_spec_893_template_894_volume_1092
 
 }
 
 type Kubernetes_replication_controller_spec_893 struct {
-
-    Kubernetes_replication_controller_spec_893_id *string `lyra:"ignore"`
 
     Min_ready_seconds *int
 
@@ -7656,7 +6584,7 @@ type Kubernetes_replication_controller_spec_893 struct {
 
     Selector map[string]string
 
-    Template Kubernetes_replication_controller_spec_893_template_894
+    Template []Kubernetes_replication_controller_spec_893_template_894
 
 }
 
@@ -7664,9 +6592,9 @@ type Kubernetes_replication_controller struct {
 
     Kubernetes_replication_controller_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_replication_controller_metadata_892
+    Metadata []Kubernetes_replication_controller_metadata_892
 
-    Spec Kubernetes_replication_controller_spec_893
+    Spec []Kubernetes_replication_controller_spec_893
 
 }
 
@@ -7709,8 +6637,6 @@ func (h *Kubernetes_replication_controllerHandler) Delete(externalID string) err
 
 type Kubernetes_resource_quota_metadata_1125 struct {
 
-    Kubernetes_resource_quota_metadata_1125_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -7733,8 +6659,6 @@ type Kubernetes_resource_quota_metadata_1125 struct {
 
 type Kubernetes_resource_quota_spec_1126 struct {
 
-    Kubernetes_resource_quota_spec_1126_id *string `lyra:"ignore"`
-
     Hard *map[string]string
 
     Scopes *[]string
@@ -7745,9 +6669,9 @@ type Kubernetes_resource_quota struct {
 
     Kubernetes_resource_quota_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_resource_quota_metadata_1125
+    Metadata []Kubernetes_resource_quota_metadata_1125
 
-    Spec *Kubernetes_resource_quota_spec_1126
+    Spec *[]Kubernetes_resource_quota_spec_1126
 
 }
 
@@ -7790,8 +6714,6 @@ func (h *Kubernetes_resource_quotaHandler) Delete(externalID string) error {
 
 type Kubernetes_role_metadata_1127 struct {
 
-    Kubernetes_role_metadata_1127_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -7814,8 +6736,6 @@ type Kubernetes_role_metadata_1127 struct {
 
 type Kubernetes_role_rule_1128 struct {
 
-    Kubernetes_role_rule_1128_id *string `lyra:"ignore"`
-
     Api_groups []string
 
     Resource_names *[]string
@@ -7830,9 +6750,9 @@ type Kubernetes_role struct {
 
     Kubernetes_role_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_role_metadata_1127
+    Metadata []Kubernetes_role_metadata_1127
 
-    Rule Kubernetes_role_rule_1128
+    Rule []Kubernetes_role_rule_1128
 
 }
 
@@ -7875,8 +6795,6 @@ func (h *Kubernetes_roleHandler) Delete(externalID string) error {
 
 type Kubernetes_role_binding_metadata_1129 struct {
 
-    Kubernetes_role_binding_metadata_1129_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generation *int
@@ -7897,8 +6815,6 @@ type Kubernetes_role_binding_metadata_1129 struct {
 
 type Kubernetes_role_binding_subject_1130 struct {
 
-    Kubernetes_role_binding_subject_1130_id *string `lyra:"ignore"`
-
     Api_group *string
 
     Kind string
@@ -7913,11 +6829,11 @@ type Kubernetes_role_binding struct {
 
     Kubernetes_role_binding_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_role_binding_metadata_1129
+    Metadata []Kubernetes_role_binding_metadata_1129
 
     Role_ref map[string]string
 
-    Subject Kubernetes_role_binding_subject_1130
+    Subject []Kubernetes_role_binding_subject_1130
 
 }
 
@@ -7960,8 +6876,6 @@ func (h *Kubernetes_role_bindingHandler) Delete(externalID string) error {
 
 type Kubernetes_secret_metadata_1131 struct {
 
-    Kubernetes_secret_metadata_1131_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -7988,7 +6902,7 @@ type Kubernetes_secret struct {
 
     Data *map[string]string
 
-    Metadata Kubernetes_secret_metadata_1131
+    Metadata []Kubernetes_secret_metadata_1131
 
     Type *string
 
@@ -8033,8 +6947,6 @@ func (h *Kubernetes_secretHandler) Delete(externalID string) error {
 
 type Kubernetes_service_load_balancer_ingress_1132 struct {
 
-    Kubernetes_service_load_balancer_ingress_1132_id *string `lyra:"ignore"`
-
     Hostname *string
 
     Ip *string
@@ -8042,8 +6954,6 @@ type Kubernetes_service_load_balancer_ingress_1132 struct {
 }
 
 type Kubernetes_service_metadata_1133 struct {
-
-    Kubernetes_service_metadata_1133_id *string `lyra:"ignore"`
 
     Annotations *map[string]string
 
@@ -8067,8 +6977,6 @@ type Kubernetes_service_metadata_1133 struct {
 
 type Kubernetes_service_spec_1134_port_1135 struct {
 
-    Kubernetes_service_spec_1134_port_1135_id *string `lyra:"ignore"`
-
     Name *string
 
     Node_port *int
@@ -8083,8 +6991,6 @@ type Kubernetes_service_spec_1134_port_1135 struct {
 
 type Kubernetes_service_spec_1134 struct {
 
-    Kubernetes_service_spec_1134_id *string `lyra:"ignore"`
-
     Cluster_ip *string
 
     External_ips *[]string
@@ -8095,7 +7001,7 @@ type Kubernetes_service_spec_1134 struct {
 
     Load_balancer_source_ranges *[]string
 
-    Port *Kubernetes_service_spec_1134_port_1135
+    Port *[]Kubernetes_service_spec_1134_port_1135
 
     Selector *map[string]string
 
@@ -8109,11 +7015,11 @@ type Kubernetes_service struct {
 
     Kubernetes_service_id *string `lyra:"ignore"`
 
-    Load_balancer_ingress *Kubernetes_service_load_balancer_ingress_1132
+    Load_balancer_ingress *[]Kubernetes_service_load_balancer_ingress_1132
 
-    Metadata Kubernetes_service_metadata_1133
+    Metadata []Kubernetes_service_metadata_1133
 
-    Spec Kubernetes_service_spec_1134
+    Spec []Kubernetes_service_spec_1134
 
 }
 
@@ -8156,15 +7062,11 @@ func (h *Kubernetes_serviceHandler) Delete(externalID string) error {
 
 type Kubernetes_service_account_image_pull_secret_1136 struct {
 
-    Kubernetes_service_account_image_pull_secret_1136_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_service_account_metadata_1137 struct {
-
-    Kubernetes_service_account_metadata_1137_id *string `lyra:"ignore"`
 
     Annotations *map[string]string
 
@@ -8188,8 +7090,6 @@ type Kubernetes_service_account_metadata_1137 struct {
 
 type Kubernetes_service_account_secret_1138 struct {
 
-    Kubernetes_service_account_secret_1138_id *string `lyra:"ignore"`
-
     Name *string
 
 }
@@ -8204,7 +7104,7 @@ type Kubernetes_service_account struct {
 
     Image_pull_secret *Kubernetes_service_account_image_pull_secret_1136
 
-    Metadata Kubernetes_service_account_metadata_1137
+    Metadata []Kubernetes_service_account_metadata_1137
 
     Secret *Kubernetes_service_account_secret_1138
 
@@ -8249,8 +7149,6 @@ func (h *Kubernetes_service_accountHandler) Delete(externalID string) error {
 
 type Kubernetes_stateful_set_metadata_1139 struct {
 
-    Kubernetes_stateful_set_metadata_1139_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -8273,8 +7171,6 @@ type Kubernetes_stateful_set_metadata_1139 struct {
 
 type Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142 struct {
 
-    Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142_id *string `lyra:"ignore"`
-
     Key *string
 
     Operator *string
@@ -8285,17 +7181,13 @@ type Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142 stru
 
 type Kubernetes_stateful_set_spec_1140_selector_1141 struct {
 
-    Kubernetes_stateful_set_spec_1140_selector_1141_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142
+    Match_expressions *[]Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142
 
     Match_labels *map[string]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144_id *string `lyra:"ignore"`
 
     Annotations *map[string]string
 
@@ -8317,8 +7209,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144 struct {
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -8326,8 +7216,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_en
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -8337,8 +7225,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_en
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151_id *string `lyra:"ignore"`
-
     Container_name *string
 
     Resource string
@@ -8346,8 +7232,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_en
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -8357,33 +7241,27 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_en
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149
 
-    Config_map_key_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149
+    Field_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150
 
-    Field_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150
+    Resource_field_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151
 
-    Resource_field_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151
-
-    Secret_key_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152
+    Secret_key_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148
+    Value_from *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154_id *string `lyra:"ignore"`
 
     Name string
 
@@ -8393,8 +7271,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_en
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -8403,27 +7279,21 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_en
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154
+    Config_map_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154
 
     Prefix *string
 
-    Secret_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155
+    Secret_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -8433,11 +7303,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160
 
     Path *string
 
@@ -8449,35 +7317,27 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158
 
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159
-
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -8487,11 +7347,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165
 
     Path *string
 
@@ -8503,45 +7361,35 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163
 
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164
-
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157
 
-    Post_start *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157
-
-    Pre_stop *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162
+    Pre_stop *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -8551,11 +7399,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170
 
     Path *string
 
@@ -8567,21 +7413,17 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169
 
     Initial_delay_seconds *int
 
@@ -8589,15 +7431,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_li
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -8613,15 +7453,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_po
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -8631,11 +7467,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_re
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176
 
     Path *string
 
@@ -8647,21 +7481,17 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_re
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175
 
     Initial_delay_seconds *int
 
@@ -8669,15 +7499,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_re
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -8687,8 +7515,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_re
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -8697,17 +7523,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_re
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179
 
-    Limits *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179
-
-    Requests *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180
+    Requests *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -8716,8 +7538,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_se
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -8731,11 +7551,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_se
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182
+    Capabilities *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182
 
     Privileged *bool
 
@@ -8745,13 +7563,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_se
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183
+    Se_linux_options *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -8765,33 +7581,31 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_vo
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147
+    Env *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147
 
-    Env_from *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153
+    Env_from *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156
+    Lifecycle *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156
 
-    Liveness_probe *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167
+    Liveness_probe *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167
 
     Name string
 
-    Port *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172
+    Port *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172
 
-    Readiness_probe *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173
+    Readiness_probe *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173
 
-    Resources *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178
+    Resources *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178
 
-    Security_context *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181
+    Security_context *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181
 
     Stdin *bool
 
@@ -8801,7 +7615,7 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146 st
 
     Tty *bool
 
-    Volume_mount *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184
+    Volume_mount *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184
 
     Working_dir *string
 
@@ -8809,15 +7623,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146 st
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185_id *string `lyra:"ignore"`
-
     Name string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -8827,8 +7637,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190_id *string `lyra:"ignore"`
-
     Api_version *string
 
     Field_path *string
@@ -8836,8 +7644,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191_id *string `lyra:"ignore"`
 
     Container_name *string
 
@@ -8847,8 +7653,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192_id *string `lyra:"ignore"`
-
     Key *string
 
     Name *string
@@ -8857,33 +7661,27 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_id *string `lyra:"ignore"`
+    Config_map_key_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189
 
-    Config_map_key_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189
+    Field_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190
 
-    Field_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190
+    Resource_field_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191
 
-    Resource_field_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191
-
-    Secret_key_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192
+    Secret_key_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_id *string `lyra:"ignore"`
-
     Name string
 
     Value *string
 
-    Value_from *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188
+    Value_from *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194_id *string `lyra:"ignore"`
 
     Name string
 
@@ -8893,8 +7691,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195_id *string `lyra:"ignore"`
-
     Name string
 
     Optional *bool
@@ -8903,27 +7699,21 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_id *string `lyra:"ignore"`
-
-    Config_map_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194
+    Config_map_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194
 
     Prefix *string
 
-    Secret_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195
+    Secret_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -8933,11 +7723,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200
 
     Path *string
 
@@ -8949,35 +7737,27 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198
 
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199
-
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -8987,11 +7767,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205
 
     Path *string
 
@@ -9003,45 +7781,35 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_id *string `lyra:"ignore"`
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203
 
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204
-
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_id *string `lyra:"ignore"`
+    Post_start *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197
 
-    Post_start *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197
-
-    Pre_stop *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202
+    Pre_stop *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208_id *string `lyra:"ignore"`
 
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -9051,11 +7819,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210
 
     Path *string
 
@@ -9067,21 +7833,17 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209
 
     Initial_delay_seconds *int
 
@@ -9089,15 +7851,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212_id *string `lyra:"ignore"`
 
     Container_port int
 
@@ -9113,15 +7873,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214_id *string `lyra:"ignore"`
-
     Command *[]string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216_id *string `lyra:"ignore"`
 
     Name *string
 
@@ -9131,11 +7887,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_id *string `lyra:"ignore"`
-
     Host *string
 
-    Http_header *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216
+    Http_header *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216
 
     Path *string
 
@@ -9147,21 +7901,17 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217_id *string `lyra:"ignore"`
-
     Port string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_id *string `lyra:"ignore"`
-
-    Exec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214
+    Exec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214
 
     Failure_threshold *int
 
-    Http_get *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215
+    Http_get *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215
 
     Initial_delay_seconds *int
 
@@ -9169,15 +7919,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
     Success_threshold *int
 
-    Tcp_socket *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217
+    Tcp_socket *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217
 
     Timeout_seconds *int
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219_id *string `lyra:"ignore"`
 
     Cpu *string
 
@@ -9187,8 +7935,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220_id *string `lyra:"ignore"`
-
     Cpu *string
 
     Memory *string
@@ -9197,17 +7943,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_id *string `lyra:"ignore"`
+    Limits *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219
 
-    Limits *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219
-
-    Requests *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220
+    Requests *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222_id *string `lyra:"ignore"`
 
     Add *[]string
 
@@ -9216,8 +7958,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -9231,11 +7971,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_id *string `lyra:"ignore"`
-
     Allow_privilege_escalation *bool
 
-    Capabilities *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222
+    Capabilities *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222
 
     Privileged *bool
 
@@ -9245,13 +7983,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223
+    Se_linux_options *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224_id *string `lyra:"ignore"`
 
     Mount_path string
 
@@ -9265,33 +8001,31 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_id *string `lyra:"ignore"`
-
     Args *[]string
 
     Command *[]string
 
-    Env *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187
+    Env *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187
 
-    Env_from *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193
+    Env_from *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193
 
     Image *string
 
     Image_pull_policy *string
 
-    Lifecycle *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196
+    Lifecycle *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196
 
-    Liveness_probe *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207
+    Liveness_probe *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207
 
     Name string
 
-    Port *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212
+    Port *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212
 
-    Readiness_probe *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213
+    Readiness_probe *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213
 
-    Resources *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218
+    Resources *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218
 
-    Security_context *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221
+    Security_context *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221
 
     Stdin *bool
 
@@ -9301,15 +8035,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_11
 
     Tty *bool
 
-    Volume_mount *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224
+    Volume_mount *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224
 
     Working_dir *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226_id *string `lyra:"ignore"`
 
     Level *string
 
@@ -9323,23 +8055,19 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_id *string `lyra:"ignore"`
-
     Fs_group *int
 
     Run_as_non_root *bool
 
     Run_as_user *int
 
-    Se_linux_options *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226
+    Se_linux_options *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226
 
     Supplemental_groups *[]int
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -9352,8 +8080,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_e
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229_id *string `lyra:"ignore"`
 
     Caching_mode string
 
@@ -9369,8 +8095,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230_id *string `lyra:"ignore"`
-
     Read_only *bool
 
     Secret_name string
@@ -9381,15 +8105,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_id *string `lyra:"ignore"`
 
     Monitors []string
 
@@ -9399,15 +8119,13 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_
 
     Secret_file *string
 
-    Secret_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232
+    Secret_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232
 
     User *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -9419,8 +8137,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinde
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235_id *string `lyra:"ignore"`
-
     Key *string
 
     Mode *int
@@ -9431,19 +8147,15 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_confi
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235
+    Items *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235
 
     Name *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238_id *string `lyra:"ignore"`
 
     Api_version *string
 
@@ -9452,8 +8164,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downw
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239_id *string `lyra:"ignore"`
 
     Container_name string
 
@@ -9465,39 +8175,31 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downw
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_id *string `lyra:"ignore"`
-
-    Field_ref Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238
+    Field_ref []Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238
 
     Mode *int
 
     Path string
 
-    Resource_field_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239
+    Resource_field_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237
+    Items *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240_id *string `lyra:"ignore"`
 
     Medium *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -9511,15 +8213,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_12
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_id *string `lyra:"ignore"`
 
     Driver string
 
@@ -9529,13 +8227,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243
+    Secret_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244_id *string `lyra:"ignore"`
 
     Dataset_name *string
 
@@ -9544,8 +8240,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flock
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -9559,8 +8253,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_p
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246_id *string `lyra:"ignore"`
-
     Directory *string
 
     Repository *string
@@ -9570,8 +8262,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_r
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247_id *string `lyra:"ignore"`
 
     Endpoints_name string
 
@@ -9583,15 +8273,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glust
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249_id *string `lyra:"ignore"`
 
     Fs_type *string
 
@@ -9609,15 +8295,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250_id *string `lyra:"ignore"`
-
     Path *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251_id *string `lyra:"ignore"`
 
     Path string
 
@@ -9629,8 +8311,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252_id *string `lyra:"ignore"`
-
     Claim_name *string
 
     Read_only *bool
@@ -9639,8 +8319,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persi
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Pd_id string
@@ -9648,8 +8326,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photo
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254_id *string `lyra:"ignore"`
 
     Group *string
 
@@ -9665,15 +8341,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quoby
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256_id *string `lyra:"ignore"`
-
     Name *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_id *string `lyra:"ignore"`
 
     Ceph_monitors []string
 
@@ -9689,13 +8361,11 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1
 
     Read_only *bool
 
-    Secret_ref *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256
+    Secret_ref *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258 struct {
-
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -9707,11 +8377,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secre
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_id *string `lyra:"ignore"`
-
     Default_mode *int
 
-    Items *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258
+    Items *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258
 
     Optional *bool
 
@@ -9721,8 +8389,6 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secre
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259_id *string `lyra:"ignore"`
-
     Fs_type *string
 
     Volume_path string
@@ -9731,67 +8397,63 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphe
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_id *string `lyra:"ignore"`
+    Aws_elastic_block_store *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228
 
-    Aws_elastic_block_store *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228
+    Azure_disk *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229
 
-    Azure_disk *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229
+    Azure_file *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230
 
-    Azure_file *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230
+    Ceph_fs *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231
 
-    Ceph_fs *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231
+    Cinder *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233
 
-    Cinder *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233
+    Config_map *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234
 
-    Config_map *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234
+    Downward_api *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236
 
-    Downward_api *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236
+    Empty_dir *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240
 
-    Empty_dir *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240
+    Fc *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241
 
-    Fc *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241
+    Flex_volume *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242
 
-    Flex_volume *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242
+    Flocker *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244
 
-    Flocker *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244
+    Gce_persistent_disk *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245
 
-    Gce_persistent_disk *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245
+    Git_repo *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246
 
-    Git_repo *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246
+    Glusterfs *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247
 
-    Glusterfs *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247
+    Host_path *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248
 
-    Host_path *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248
+    Iscsi *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249
 
-    Iscsi *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249
-
-    Local *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250
+    Local *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250
 
     Name *string
 
-    Nfs *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251
+    Nfs *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251
 
-    Persistent_volume_claim *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252
+    Persistent_volume_claim *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252
 
-    Photon_persistent_disk *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253
+    Photon_persistent_disk *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253
 
-    Quobyte *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254
+    Quobyte *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254
 
-    Rbd *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255
+    Rbd *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255
 
-    Secret *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257
+    Secret *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257
 
-    Vsphere_volume *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259
+    Vsphere_volume *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_id *string `lyra:"ignore"`
-
     Active_deadline_seconds *int
 
-    Container *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146
+    Container *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146
 
     Dns_policy *string
 
@@ -9803,9 +8465,9 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145 struct {
 
     Hostname *string
 
-    Image_pull_secrets *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185
+    Image_pull_secrets *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185
 
-    Init_container *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186
+    Init_container *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186
 
     Node_name *string
 
@@ -9813,7 +8475,7 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145 struct {
 
     Restart_policy *string
 
-    Security_context *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225
+    Security_context *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225
 
     Service_account_name *string
 
@@ -9821,23 +8483,19 @@ type Kubernetes_stateful_set_spec_1140_template_1143_spec_1145 struct {
 
     Termination_grace_period_seconds *int
 
-    Volume *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227
+    Volume *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227
 
 }
 
 type Kubernetes_stateful_set_spec_1140_template_1143 struct {
 
-    Kubernetes_stateful_set_spec_1140_template_1143_id *string `lyra:"ignore"`
+    Metadata []Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144
 
-    Metadata Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144
-
-    Spec *Kubernetes_stateful_set_spec_1140_template_1143_spec_1145
+    Spec *[]Kubernetes_stateful_set_spec_1140_template_1143_spec_1145
 
 }
 
 type Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261 struct {
-
-    Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261_id *string `lyra:"ignore"`
 
     Partition *int
 
@@ -9845,17 +8503,13 @@ type Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261 
 
 type Kubernetes_stateful_set_spec_1140_update_strategy_1260 struct {
 
-    Kubernetes_stateful_set_spec_1140_update_strategy_1260_id *string `lyra:"ignore"`
-
-    Rolling_update *Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261
+    Rolling_update *[]Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261
 
     Type *string
 
 }
 
 type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263 struct {
-
-    Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263_id *string `lyra:"ignore"`
 
     Annotations *map[string]string
 
@@ -9879,8 +8533,6 @@ type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263 
 
 type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265 struct {
 
-    Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265_id *string `lyra:"ignore"`
-
     Limits *map[string]string
 
     Requests *map[string]string
@@ -9888,8 +8540,6 @@ type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_reso
 }
 
 type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267 struct {
-
-    Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267_id *string `lyra:"ignore"`
 
     Key *string
 
@@ -9901,9 +8551,7 @@ type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_sele
 
 type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266 struct {
 
-    Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_id *string `lyra:"ignore"`
-
-    Match_expressions *Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267
+    Match_expressions *[]Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267
 
     Match_labels *map[string]string
 
@@ -9911,13 +8559,11 @@ type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_sele
 
 type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264 struct {
 
-    Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_id *string `lyra:"ignore"`
-
     Access_modes []string
 
-    Resources Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265
+    Resources []Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265
 
-    Selector *Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266
+    Selector *[]Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266
 
     Storage_class_name *string
 
@@ -9927,17 +8573,13 @@ type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264 stru
 
 type Kubernetes_stateful_set_spec_1140_volume_claim_template_1262 struct {
 
-    Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_id *string `lyra:"ignore"`
+    Metadata []Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263
 
-    Metadata Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263
-
-    Spec Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264
+    Spec []Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264
 
 }
 
 type Kubernetes_stateful_set_spec_1140 struct {
-
-    Kubernetes_stateful_set_spec_1140_id *string `lyra:"ignore"`
 
     Pod_management_policy *string
 
@@ -9945,15 +8587,15 @@ type Kubernetes_stateful_set_spec_1140 struct {
 
     Revision_history_limit *int
 
-    Selector Kubernetes_stateful_set_spec_1140_selector_1141
+    Selector []Kubernetes_stateful_set_spec_1140_selector_1141
 
     Service_name string
 
-    Template Kubernetes_stateful_set_spec_1140_template_1143
+    Template []Kubernetes_stateful_set_spec_1140_template_1143
 
-    Update_strategy *Kubernetes_stateful_set_spec_1140_update_strategy_1260
+    Update_strategy *[]Kubernetes_stateful_set_spec_1140_update_strategy_1260
 
-    Volume_claim_template *Kubernetes_stateful_set_spec_1140_volume_claim_template_1262
+    Volume_claim_template *[]Kubernetes_stateful_set_spec_1140_volume_claim_template_1262
 
 }
 
@@ -9961,9 +8603,9 @@ type Kubernetes_stateful_set struct {
 
     Kubernetes_stateful_set_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_stateful_set_metadata_1139
+    Metadata []Kubernetes_stateful_set_metadata_1139
 
-    Spec Kubernetes_stateful_set_spec_1140
+    Spec []Kubernetes_stateful_set_spec_1140
 
 }
 
@@ -10006,8 +8648,6 @@ func (h *Kubernetes_stateful_setHandler) Delete(externalID string) error {
 
 type Kubernetes_storage_class_metadata_1268 struct {
 
-    Kubernetes_storage_class_metadata_1268_id *string `lyra:"ignore"`
-
     Annotations *map[string]string
 
     Generate_name *string
@@ -10030,7 +8670,7 @@ type Kubernetes_storage_class struct {
 
     Kubernetes_storage_class_id *string `lyra:"ignore"`
 
-    Metadata Kubernetes_storage_class_metadata_1268
+    Metadata []Kubernetes_storage_class_metadata_1268
 
     Parameters *map[string]string
 

--- a/pkg/bridge/marshall_test.go
+++ b/pkg/bridge/marshall_test.go
@@ -1,10 +1,13 @@
 package bridge
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lyraproj/lyra/pkg/logger"
 )
 
 var original interface{}
@@ -51,13 +54,20 @@ type Person struct {
 	PetLlama  *Llama
 	Tags      map[string]string
 	PTags     *map[string]string
-	// List      []string
-	// PList     *[]string
+	List      []string
+	PList     *[]string
+	PPList    *[]*string
 	// ItemList  []Item
 	// PItemList *[]Item
 }
 
 func init() {
+	spec := logger.Spec{
+		Name:   "marshal-test",
+		Level:  "debug",
+		Output: os.Stderr,
+	}
+	logger.Initialise(spec)
 	three := 3
 	four := 4
 	smith := "Smith"
@@ -85,10 +95,11 @@ func init() {
 			Tail:   15,
 			Colour: &brown,
 		},
-		Tags:  map[string]string{"foo": "bar", "moo": "baa"},
-		PTags: &map[string]string{"foo2": "bar2", "moo2": "baa2"},
-		// List:      []string{"aa", "bb", "cc"},
-		// PList:     &[]string{"aa", "bb", "cc"},
+		Tags:   map[string]string{"foo": "bar", "moo": "baa"},
+		PTags:  &map[string]string{"foo2": "bar2", "moo2": "baa2"},
+		List:   []string{"aa", "bb", "cc"},
+		PList:  &[]string{"aa", "bb", "cc"},
+		PPList: &[]*string{&smith, &brown},
 		// ItemList:  []Item{Item{"aa"}, Item{"bb"}, Item{"cc"}},
 		// PItemList: &[]Item{Item{"aa"}, Item{"bb"}, Item{"cc"}},
 	}
@@ -113,8 +124,11 @@ func init() {
 			"tail":   "15",
 			"colour": "",
 		},
-		"tags":  map[string]interface{}{"foo": "bar", "moo": "baa"},
-		"ptags": map[string]interface{}{"foo2": "bar2", "moo2": "baa2"},
+		"tags":   map[string]interface{}{"foo": "bar", "moo": "baa"},
+		"ptags":  map[string]interface{}{"foo2": "bar2", "moo2": "baa2"},
+		"list":   []interface{}{"aa", "bb", "cc"},
+		"plist":  []interface{}{"aa", "bb", "cc"},
+		"pplist": []interface{}{"Smith", ""},
 	}
 }
 
@@ -122,6 +136,13 @@ func TestTerraformMarshal(t *testing.T) {
 	actual := TerraformMarshal(original)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Error("Unxpected marshaling")
+		fmt.Println("--------------------------------")
+		fmt.Println("Expected")
+		fmt.Println("--------------------------------")
+		spew.Dump(expected)
+		fmt.Println("--------------------------------")
+		fmt.Println("Actual")
+		fmt.Println("--------------------------------")
 		spew.Dump(actual)
 	}
 }
@@ -131,6 +152,13 @@ func TestTerraformUnmarshal(t *testing.T) {
 	TerraformUnmarshal(expected, actual)
 	if !reflect.DeepEqual(original, actual) {
 		t.Error("Unxpected unmarshaling")
+		fmt.Println("--------------------------------")
+		fmt.Println("Expected")
+		fmt.Println("--------------------------------")
+		spew.Dump(original)
+		fmt.Println("--------------------------------")
+		fmt.Println("Actual")
+		fmt.Println("--------------------------------")
 		spew.Dump(actual)
 	}
 }

--- a/plugins/aaa-terraform-aws.pp
+++ b/plugins/aaa-terraform-aws.pp
@@ -31,7 +31,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'domain_validation_options' => {
-          'type' => Optional[Aws_acm_certificate_domain_validation_options_1],
+          'type' => Optional[Array[Aws_acm_certificate_domain_validation_options_1]],
           'value' => undef
         },
         'private_key' => {
@@ -69,10 +69,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_acm_certificate_domain_validation_options_1 => {
       attributes => {
-        'aws_acm_certificate_domain_validation_options_1_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'domain_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -129,7 +125,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'certificate_authority_configuration' => Aws_acmpca_certificate_authority_certificate_authority_configuration_2,
+        'certificate_authority_configuration' => Array[Aws_acmpca_certificate_authority_certificate_authority_configuration_2],
         'certificate_chain' => {
           'type' => Optional[String],
           'value' => undef
@@ -151,7 +147,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'revocation_configuration' => {
-          'type' => Optional[Aws_acmpca_certificate_authority_revocation_configuration_4],
+          'type' => Optional[Array[Aws_acmpca_certificate_authority_revocation_configuration_4]],
           'value' => undef
         },
         'serial' => {
@@ -185,21 +181,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_acmpca_certificate_authority_certificate_authority_configuration_2 => {
       attributes => {
-        'aws_acmpca_certificate_authority_certificate_authority_configuration_2_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key_algorithm' => String,
         'signing_algorithm' => String,
-        'subject' => Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3
+        'subject' => Array[Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3]
       }
     },
     Aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3 => {
       attributes => {
-        'aws_acmpca_certificate_authority_certificate_authority_configuration_2_subject_3_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'common_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -256,22 +244,14 @@ type TerraformAws = TypeSet[{
     },
     Aws_acmpca_certificate_authority_revocation_configuration_4 => {
       attributes => {
-        'aws_acmpca_certificate_authority_revocation_configuration_4_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'crl_configuration' => {
-          'type' => Optional[Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5],
+          'type' => Optional[Array[Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5]],
           'value' => undef
         }
       }
     },
     Aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5 => {
       attributes => {
-        'aws_acmpca_certificate_authority_revocation_configuration_4_crl_configuration_5_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'custom_cname' => {
           'type' => Optional[String],
           'value' => undef
@@ -294,7 +274,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'access_logs' => {
-          'type' => Optional[Aws_alb_access_logs_6],
+          'type' => Optional[Array[Aws_alb_access_logs_6]],
           'value' => undef
         },
         'arn' => {
@@ -384,10 +364,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_access_logs_6 => {
       attributes => {
-        'aws_alb_access_logs_6_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => String,
         'enabled' => {
           'type' => Optional[Boolean],
@@ -413,7 +389,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'default_action' => Aws_alb_listener_default_action_8,
+        'default_action' => Array[Aws_alb_listener_default_action_8],
         'load_balancer_arn' => String,
         'port' => Integer,
         'protocol' => {
@@ -460,20 +436,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_default_action_8 => {
       attributes => {
-        'aws_alb_listener_default_action_8_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authenticate_cognito' => {
-          'type' => Optional[Aws_alb_listener_default_action_8_authenticate_cognito_9],
+          'type' => Optional[Array[Aws_alb_listener_default_action_8_authenticate_cognito_9]],
           'value' => undef
         },
         'authenticate_oidc' => {
-          'type' => Optional[Aws_alb_listener_default_action_8_authenticate_oidc_10],
+          'type' => Optional[Array[Aws_alb_listener_default_action_8_authenticate_oidc_10]],
           'value' => undef
         },
         'fixed_response' => {
-          'type' => Optional[Aws_alb_listener_default_action_8_fixed_response_11],
+          'type' => Optional[Array[Aws_alb_listener_default_action_8_fixed_response_11]],
           'value' => undef
         },
         'order' => {
@@ -481,7 +453,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'redirect' => {
-          'type' => Optional[Aws_alb_listener_default_action_8_redirect_12],
+          'type' => Optional[Array[Aws_alb_listener_default_action_8_redirect_12]],
           'value' => undef
         },
         'target_group_arn' => {
@@ -493,10 +465,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_default_action_8_authenticate_cognito_9 => {
       attributes => {
-        'aws_alb_listener_default_action_8_authenticate_cognito_9_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -524,10 +492,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_default_action_8_authenticate_oidc_10 => {
       attributes => {
-        'aws_alb_listener_default_action_8_authenticate_oidc_10_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -558,10 +522,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_default_action_8_fixed_response_11 => {
       attributes => {
-        'aws_alb_listener_default_action_8_fixed_response_11_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'content_type' => String,
         'message_body' => {
           'type' => Optional[String],
@@ -575,10 +535,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_default_action_8_redirect_12 => {
       attributes => {
-        'aws_alb_listener_default_action_8_redirect_12_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
@@ -608,7 +564,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'action' => Aws_alb_listener_rule_action_13,
+        'action' => Array[Aws_alb_listener_rule_action_13],
         'arn' => {
           'type' => Optional[String],
           'value' => undef
@@ -634,20 +590,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_rule_action_13 => {
       attributes => {
-        'aws_alb_listener_rule_action_13_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authenticate_cognito' => {
-          'type' => Optional[Aws_alb_listener_rule_action_13_authenticate_cognito_14],
+          'type' => Optional[Array[Aws_alb_listener_rule_action_13_authenticate_cognito_14]],
           'value' => undef
         },
         'authenticate_oidc' => {
-          'type' => Optional[Aws_alb_listener_rule_action_13_authenticate_oidc_15],
+          'type' => Optional[Array[Aws_alb_listener_rule_action_13_authenticate_oidc_15]],
           'value' => undef
         },
         'fixed_response' => {
-          'type' => Optional[Aws_alb_listener_rule_action_13_fixed_response_16],
+          'type' => Optional[Array[Aws_alb_listener_rule_action_13_fixed_response_16]],
           'value' => undef
         },
         'order' => {
@@ -655,7 +607,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'redirect' => {
-          'type' => Optional[Aws_alb_listener_rule_action_13_redirect_17],
+          'type' => Optional[Array[Aws_alb_listener_rule_action_13_redirect_17]],
           'value' => undef
         },
         'target_group_arn' => {
@@ -667,10 +619,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_rule_action_13_authenticate_cognito_14 => {
       attributes => {
-        'aws_alb_listener_rule_action_13_authenticate_cognito_14_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -698,10 +646,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_rule_action_13_authenticate_oidc_15 => {
       attributes => {
-        'aws_alb_listener_rule_action_13_authenticate_oidc_15_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -732,10 +676,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_rule_action_13_fixed_response_16 => {
       attributes => {
-        'aws_alb_listener_rule_action_13_fixed_response_16_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'content_type' => String,
         'message_body' => {
           'type' => Optional[String],
@@ -749,10 +689,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_rule_action_13_redirect_17 => {
       attributes => {
-        'aws_alb_listener_rule_action_13_redirect_17_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
@@ -778,10 +714,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_listener_rule_condition_18 => {
       attributes => {
-        'aws_alb_listener_rule_condition_18_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field' => {
           'type' => Optional[String],
           'value' => undef
@@ -794,10 +726,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_subnet_mapping_7 => {
       attributes => {
-        'aws_alb_subnet_mapping_7_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allocation_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -824,7 +752,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'health_check' => {
-          'type' => Optional[Aws_alb_target_group_health_check_19],
+          'type' => Optional[Array[Aws_alb_target_group_health_check_19]],
           'value' => undef
         },
         'name' => {
@@ -852,7 +780,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'stickiness' => {
-          'type' => Optional[Aws_alb_target_group_stickiness_20],
+          'type' => Optional[Array[Aws_alb_target_group_stickiness_20]],
           'value' => undef
         },
         'tags' => {
@@ -911,10 +839,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_target_group_health_check_19 => {
       attributes => {
-        'aws_alb_target_group_health_check_19_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'healthy_threshold' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -951,10 +875,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_alb_target_group_stickiness_20 => {
       attributes => {
-        'aws_alb_target_group_stickiness_20_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cookie_duration' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -1130,10 +1050,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ami_copy_ebs_block_device_23 => {
       attributes => {
-        'aws_ami_copy_ebs_block_device_23_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -1166,10 +1082,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ami_copy_ephemeral_block_device_24 => {
       attributes => {
-        'aws_ami_copy_ephemeral_block_device_24_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1182,10 +1094,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ami_ebs_block_device_21 => {
       attributes => {
-        'aws_ami_ebs_block_device_21_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -1215,10 +1123,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ami_ephemeral_block_device_22 => {
       attributes => {
-        'aws_ami_ephemeral_block_device_22_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => String,
         'virtual_name' => String
       }
@@ -1306,10 +1210,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ami_from_instance_ebs_block_device_25 => {
       attributes => {
-        'aws_ami_from_instance_ebs_block_device_25_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -1342,10 +1242,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ami_from_instance_ephemeral_block_device_26 => {
       attributes => {
-        'aws_ami_from_instance_ephemeral_block_device_26_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1388,7 +1284,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'throttle_settings' => {
-          'type' => Optional[Aws_api_gateway_account_throttle_settings_27],
+          'type' => Optional[Array[Aws_api_gateway_account_throttle_settings_27]],
           'value' => undef
         }
       }
@@ -1406,10 +1302,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_account_throttle_settings_27 => {
       attributes => {
-        'aws_api_gateway_account_throttle_settings_27_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'burst_limit' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -1466,10 +1358,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_api_key_stage_key_28 => {
       attributes => {
-        'aws_api_gateway_api_key_stage_key_28_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'rest_api_id' => String,
         'stage_name' => String
       }
@@ -1638,7 +1526,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'location' => Aws_api_gateway_documentation_part_location_29,
+        'location' => Array[Aws_api_gateway_documentation_part_location_29],
         'properties' => String,
         'rest_api_id' => String
       }
@@ -1656,10 +1544,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_documentation_part_location_29 => {
       attributes => {
-        'aws_api_gateway_documentation_part_location_29_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'method' => {
           'type' => Optional[String],
           'value' => undef
@@ -1744,7 +1628,7 @@ type TerraformAws = TypeSet[{
         },
         'domain_name' => String,
         'endpoint_configuration' => {
-          'type' => Optional[Aws_api_gateway_domain_name_endpoint_configuration_30],
+          'type' => Optional[Array[Aws_api_gateway_domain_name_endpoint_configuration_30]],
           'value' => undef
         },
         'regional_certificate_arn' => {
@@ -1778,10 +1662,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_domain_name_endpoint_configuration_30 => {
       attributes => {
-        'aws_api_gateway_domain_name_endpoint_configuration_30_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'types' => Array[String]
       }
     },
@@ -2030,7 +1910,7 @@ type TerraformAws = TypeSet[{
         },
         'method_path' => String,
         'rest_api_id' => String,
-        'settings' => Aws_api_gateway_method_settings_settings_31,
+        'settings' => Array[Aws_api_gateway_method_settings_settings_31],
         'stage_name' => String
       }
     },
@@ -2047,10 +1927,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_method_settings_settings_31 => {
       attributes => {
-        'aws_api_gateway_method_settings_settings_31_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cache_data_encrypted' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2205,7 +2081,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'endpoint_configuration' => {
-          'type' => Optional[Aws_api_gateway_rest_api_endpoint_configuration_32],
+          'type' => Optional[Array[Aws_api_gateway_rest_api_endpoint_configuration_32]],
           'value' => undef
         },
         'execution_arn' => {
@@ -2240,10 +2116,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_rest_api_endpoint_configuration_32 => {
       attributes => {
-        'aws_api_gateway_rest_api_endpoint_configuration_32_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'types' => Array[String]
       }
     },
@@ -2254,7 +2126,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'access_log_settings' => {
-          'type' => Optional[Aws_api_gateway_stage_access_log_settings_33],
+          'type' => Optional[Array[Aws_api_gateway_stage_access_log_settings_33]],
           'value' => undef
         },
         'cache_cluster_enabled' => {
@@ -2315,10 +2187,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_stage_access_log_settings_33 => {
       attributes => {
-        'aws_api_gateway_stage_access_log_settings_33_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'destination_arn' => String,
         'format' => String
       }
@@ -2330,7 +2198,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'api_stages' => {
-          'type' => Optional[Aws_api_gateway_usage_plan_api_stages_34],
+          'type' => Optional[Array[Aws_api_gateway_usage_plan_api_stages_34]],
           'value' => undef
         },
         'description' => {
@@ -2365,10 +2233,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_usage_plan_api_stages_34 => {
       attributes => {
-        'aws_api_gateway_usage_plan_api_stages_34_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_id' => String,
         'stage' => String
       }
@@ -2405,10 +2269,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_usage_plan_quota_settings_35 => {
       attributes => {
-        'aws_api_gateway_usage_plan_quota_settings_35_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limit' => Integer,
         'offset' => {
           'type' => Optional[Integer],
@@ -2419,10 +2279,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_api_gateway_usage_plan_throttle_settings_36 => {
       attributes => {
-        'aws_api_gateway_usage_plan_throttle_settings_36_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'burst_limit' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -2524,11 +2380,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'step_scaling_policy_configuration' => {
-          'type' => Optional[Aws_appautoscaling_policy_step_scaling_policy_configuration_38],
+          'type' => Optional[Array[Aws_appautoscaling_policy_step_scaling_policy_configuration_38]],
           'value' => undef
         },
         'target_tracking_scaling_policy_configuration' => {
-          'type' => Optional[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40],
+          'type' => Optional[Array[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40]],
           'value' => undef
         }
       }
@@ -2546,10 +2402,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_policy_step_adjustment_37 => {
       attributes => {
-        'aws_appautoscaling_policy_step_adjustment_37_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'metric_interval_lower_bound' => {
           'type' => Optional[String],
           'value' => undef
@@ -2563,10 +2415,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_policy_step_scaling_policy_configuration_38 => {
       attributes => {
-        'aws_appautoscaling_policy_step_scaling_policy_configuration_38_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'adjustment_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2591,10 +2439,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_policy_step_scaling_policy_configuration_38_step_adjustment_39 => {
       attributes => {
-        'aws_appautoscaling_policy_step_scaling_policy_configuration_38_step_adjustment_39_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'metric_interval_lower_bound' => {
           'type' => Optional[String],
           'value' => undef
@@ -2608,12 +2452,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40 => {
       attributes => {
-        'aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'customized_metric_specification' => {
-          'type' => Optional[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41],
+          'type' => Optional[Array[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41]],
           'value' => undef
         },
         'disable_scale_in' => {
@@ -2621,7 +2461,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'predefined_metric_specification' => {
-          'type' => Optional[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43],
+          'type' => Optional[Array[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43]],
           'value' => undef
         },
         'scale_in_cooldown' => {
@@ -2637,10 +2477,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41 => {
       attributes => {
-        'aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dimensions' => {
           'type' => Optional[Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_dimensions_42],
           'value' => undef
@@ -2656,20 +2492,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_dimensions_42 => {
       attributes => {
-        'aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_customized_metric_specification_41_dimensions_42_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
     },
     Aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43 => {
       attributes => {
-        'aws_appautoscaling_policy_target_tracking_scaling_policy_configuration_40_predefined_metric_specification_43_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'predefined_metric_type' => String,
         'resource_label' => {
           'type' => Optional[String],
@@ -2698,7 +2526,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'scalable_target_action' => {
-          'type' => Optional[Aws_appautoscaling_scheduled_action_scalable_target_action_44],
+          'type' => Optional[Array[Aws_appautoscaling_scheduled_action_scalable_target_action_44]],
           'value' => undef
         },
         'schedule' => {
@@ -2725,10 +2553,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appautoscaling_scheduled_action_scalable_target_action_44 => {
       attributes => {
-        'aws_appautoscaling_scheduled_action_scalable_target_action_44_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_capacity' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -2819,7 +2643,7 @@ type TerraformAws = TypeSet[{
         },
         'mesh_name' => String,
         'name' => String,
-        'spec' => Aws_appmesh_route_spec_45,
+        'spec' => Array[Aws_appmesh_route_spec_45],
         'virtual_router_name' => String
       }
     },
@@ -2836,51 +2660,31 @@ type TerraformAws = TypeSet[{
     },
     Aws_appmesh_route_spec_45 => {
       attributes => {
-        'aws_appmesh_route_spec_45_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'http_route' => {
-          'type' => Optional[Aws_appmesh_route_spec_45_http_route_46],
+          'type' => Optional[Array[Aws_appmesh_route_spec_45_http_route_46]],
           'value' => undef
         }
       }
     },
     Aws_appmesh_route_spec_45_http_route_46 => {
       attributes => {
-        'aws_appmesh_route_spec_45_http_route_46_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'action' => Aws_appmesh_route_spec_45_http_route_46_action_47,
-        'match' => Aws_appmesh_route_spec_45_http_route_46_match_49
+        'action' => Array[Aws_appmesh_route_spec_45_http_route_46_action_47],
+        'match' => Array[Aws_appmesh_route_spec_45_http_route_46_match_49]
       }
     },
     Aws_appmesh_route_spec_45_http_route_46_action_47 => {
       attributes => {
-        'aws_appmesh_route_spec_45_http_route_46_action_47_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'weighted_target' => Aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48
       }
     },
     Aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48 => {
       attributes => {
-        'aws_appmesh_route_spec_45_http_route_46_action_47_weighted_target_48_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'virtual_node' => String,
         'weight' => Integer
       }
     },
     Aws_appmesh_route_spec_45_http_route_46_match_49 => {
       attributes => {
-        'aws_appmesh_route_spec_45_http_route_46_match_49_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'prefix' => String
       }
     },
@@ -2904,7 +2708,7 @@ type TerraformAws = TypeSet[{
         },
         'mesh_name' => String,
         'name' => String,
-        'spec' => Aws_appmesh_virtual_node_spec_50
+        'spec' => Array[Aws_appmesh_virtual_node_spec_50]
       }
     },
     Aws_appmesh_virtual_nodeHandler => {
@@ -2920,10 +2724,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appmesh_virtual_node_spec_50 => {
       attributes => {
-        'aws_appmesh_virtual_node_spec_50_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'backends' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -2933,45 +2733,29 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'service_discovery' => {
-          'type' => Optional[Aws_appmesh_virtual_node_spec_50_service_discovery_53],
+          'type' => Optional[Array[Aws_appmesh_virtual_node_spec_50_service_discovery_53]],
           'value' => undef
         }
       }
     },
     Aws_appmesh_virtual_node_spec_50_listener_51 => {
       attributes => {
-        'aws_appmesh_virtual_node_spec_50_listener_51_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'port_mapping' => Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52
+        'port_mapping' => Array[Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52]
       }
     },
     Aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52 => {
       attributes => {
-        'aws_appmesh_virtual_node_spec_50_listener_51_port_mapping_52_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => Integer,
         'protocol' => String
       }
     },
     Aws_appmesh_virtual_node_spec_50_service_discovery_53 => {
       attributes => {
-        'aws_appmesh_virtual_node_spec_50_service_discovery_53_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'dns' => Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54
+        'dns' => Array[Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54]
       }
     },
     Aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54 => {
       attributes => {
-        'aws_appmesh_virtual_node_spec_50_service_discovery_53_dns_54_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'service_name' => String
       }
     },
@@ -2995,7 +2779,7 @@ type TerraformAws = TypeSet[{
         },
         'mesh_name' => String,
         'name' => String,
-        'spec' => Aws_appmesh_virtual_router_spec_55
+        'spec' => Array[Aws_appmesh_virtual_router_spec_55]
       }
     },
     Aws_appmesh_virtual_routerHandler => {
@@ -3011,10 +2795,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appmesh_virtual_router_spec_55 => {
       attributes => {
-        'aws_appmesh_virtual_router_spec_55_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'service_names' => Array[String]
       }
     },
@@ -3066,19 +2846,19 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'dynamodb_config' => {
-          'type' => Optional[Aws_appsync_datasource_dynamodb_config_56],
+          'type' => Optional[Array[Aws_appsync_datasource_dynamodb_config_56]],
           'value' => undef
         },
         'elasticsearch_config' => {
-          'type' => Optional[Aws_appsync_datasource_elasticsearch_config_57],
+          'type' => Optional[Array[Aws_appsync_datasource_elasticsearch_config_57]],
           'value' => undef
         },
         'http_config' => {
-          'type' => Optional[Aws_appsync_datasource_http_config_58],
+          'type' => Optional[Array[Aws_appsync_datasource_http_config_58]],
           'value' => undef
         },
         'lambda_config' => {
-          'type' => Optional[Aws_appsync_datasource_lambda_config_59],
+          'type' => Optional[Array[Aws_appsync_datasource_lambda_config_59]],
           'value' => undef
         },
         'name' => String,
@@ -3102,10 +2882,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appsync_datasource_dynamodb_config_56 => {
       attributes => {
-        'aws_appsync_datasource_dynamodb_config_56_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'region' => {
           'type' => Optional[String],
           'value' => undef
@@ -3119,10 +2895,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appsync_datasource_elasticsearch_config_57 => {
       attributes => {
-        'aws_appsync_datasource_elasticsearch_config_57_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoint' => String,
         'region' => {
           'type' => Optional[String],
@@ -3132,19 +2904,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_appsync_datasource_http_config_58 => {
       attributes => {
-        'aws_appsync_datasource_http_config_58_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoint' => String
       }
     },
     Aws_appsync_datasource_lambda_config_59 => {
       attributes => {
-        'aws_appsync_datasource_lambda_config_59_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'function_arn' => String
       }
     },
@@ -3160,12 +2924,12 @@ type TerraformAws = TypeSet[{
         },
         'authentication_type' => String,
         'log_config' => {
-          'type' => Optional[Aws_appsync_graphql_api_log_config_60],
+          'type' => Optional[Array[Aws_appsync_graphql_api_log_config_60]],
           'value' => undef
         },
         'name' => String,
         'openid_connect_config' => {
-          'type' => Optional[Aws_appsync_graphql_api_openid_connect_config_61],
+          'type' => Optional[Array[Aws_appsync_graphql_api_openid_connect_config_61]],
           'value' => undef
         },
         'uris' => {
@@ -3173,7 +2937,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'user_pool_config' => {
-          'type' => Optional[Aws_appsync_graphql_api_user_pool_config_62],
+          'type' => Optional[Array[Aws_appsync_graphql_api_user_pool_config_62]],
           'value' => undef
         }
       }
@@ -3191,20 +2955,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_appsync_graphql_api_log_config_60 => {
       attributes => {
-        'aws_appsync_graphql_api_log_config_60_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cloudwatch_logs_role_arn' => String,
         'field_log_level' => String
       }
     },
     Aws_appsync_graphql_api_openid_connect_config_61 => {
       attributes => {
-        'aws_appsync_graphql_api_openid_connect_config_61_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auth_ttl' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -3222,10 +2978,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_appsync_graphql_api_user_pool_config_62 => {
       attributes => {
-        'aws_appsync_graphql_api_user_pool_config_62_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'app_id_client_regex' => {
           'type' => Optional[String],
           'value' => undef
@@ -3246,7 +2998,7 @@ type TerraformAws = TypeSet[{
         },
         'bucket' => String,
         'encryption_configuration' => {
-          'type' => Optional[Aws_athena_database_encryption_configuration_63],
+          'type' => Optional[Array[Aws_athena_database_encryption_configuration_63]],
           'value' => undef
         },
         'force_destroy' => {
@@ -3269,10 +3021,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_athena_database_encryption_configuration_63 => {
       attributes => {
-        'aws_athena_database_encryption_configuration_63_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'encryption_option' => String,
         'kms_key' => {
           'type' => Optional[String],
@@ -3381,7 +3129,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'launch_template' => {
-          'type' => Optional[Aws_autoscaling_group_launch_template_65],
+          'type' => Optional[Array[Aws_autoscaling_group_launch_template_65]],
           'value' => undef
         },
         'load_balancers' => {
@@ -3399,7 +3147,7 @@ type TerraformAws = TypeSet[{
         },
         'min_size' => Integer,
         'mixed_instances_policy' => {
-          'type' => Optional[Aws_autoscaling_group_mixed_instances_policy_66],
+          'type' => Optional[Array[Aws_autoscaling_group_mixed_instances_policy_66]],
           'value' => undef
         },
         'name' => {
@@ -3469,10 +3217,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_group_initial_lifecycle_hook_64 => {
       attributes => {
-        'aws_autoscaling_group_initial_lifecycle_hook_64_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_result' => {
           'type' => Optional[String],
           'value' => undef
@@ -3499,10 +3243,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_group_launch_template_65 => {
       attributes => {
-        'aws_autoscaling_group_launch_template_65_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => {
           'type' => Optional[String],
           'value' => undef
@@ -3519,23 +3259,15 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_group_mixed_instances_policy_66 => {
       attributes => {
-        'aws_autoscaling_group_mixed_instances_policy_66_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'instances_distribution' => {
-          'type' => Optional[Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67],
+          'type' => Optional[Array[Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67]],
           'value' => undef
         },
-        'launch_template' => Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68
+        'launch_template' => Array[Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68]
       }
     },
     Aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67 => {
       attributes => {
-        'aws_autoscaling_group_mixed_instances_policy_66_instances_distribution_67_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'on_demand_allocation_strategy' => {
           'type' => Optional[String],
           'value' => undef
@@ -3564,23 +3296,15 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68 => {
       attributes => {
-        'aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'launch_template_specification' => Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69,
+        'launch_template_specification' => Array[Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69],
         'override' => {
-          'type' => Optional[Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70],
+          'type' => Optional[Array[Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70]],
           'value' => undef
         }
       }
     },
     Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69 => {
       attributes => {
-        'aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_launch_template_specification_69_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'launch_template_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -3597,10 +3321,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70 => {
       attributes => {
-        'aws_autoscaling_group_mixed_instances_policy_66_launch_template_68_override_70_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'instance_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -3609,10 +3329,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_group_tag_71 => {
       attributes => {
-        'aws_autoscaling_group_tag_71_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'propagate_at_launch' => Boolean,
         'value' => String
@@ -3731,7 +3447,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'target_tracking_configuration' => {
-          'type' => Optional[Aws_autoscaling_policy_target_tracking_configuration_73],
+          'type' => Optional[Array[Aws_autoscaling_policy_target_tracking_configuration_73]],
           'value' => undef
         }
       }
@@ -3749,10 +3465,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_policy_step_adjustment_72 => {
       attributes => {
-        'aws_autoscaling_policy_step_adjustment_72_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'metric_interval_lower_bound' => {
           'type' => Optional[String],
           'value' => undef
@@ -3766,12 +3478,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_policy_target_tracking_configuration_73 => {
       attributes => {
-        'aws_autoscaling_policy_target_tracking_configuration_73_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'customized_metric_specification' => {
-          'type' => Optional[Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74],
+          'type' => Optional[Array[Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74]],
           'value' => undef
         },
         'disable_scale_in' => {
@@ -3779,7 +3487,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'predefined_metric_specification' => {
-          'type' => Optional[Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76],
+          'type' => Optional[Array[Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76]],
           'value' => undef
         },
         'target_value' => Float
@@ -3787,12 +3495,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74 => {
       attributes => {
-        'aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'metric_dimension' => {
-          'type' => Optional[Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75],
+          'type' => Optional[Array[Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75]],
           'value' => undef
         },
         'metric_name' => String,
@@ -3806,20 +3510,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75 => {
       attributes => {
-        'aws_autoscaling_policy_target_tracking_configuration_73_customized_metric_specification_74_metric_dimension_75_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
     },
     Aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76 => {
       attributes => {
-        'aws_autoscaling_policy_target_tracking_configuration_73_predefined_metric_specification_76_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'predefined_metric_type' => String,
         'resource_label' => {
           'type' => Optional[String],
@@ -3888,7 +3584,7 @@ type TerraformAws = TypeSet[{
         },
         'compute_environment_name' => String,
         'compute_resources' => {
-          'type' => Optional[Aws_batch_compute_environment_compute_resources_77],
+          'type' => Optional[Array[Aws_batch_compute_environment_compute_resources_77]],
           'value' => undef
         },
         'ecc_cluster_arn' => {
@@ -3928,10 +3624,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_batch_compute_environment_compute_resources_77 => {
       attributes => {
-        'aws_batch_compute_environment_compute_resources_77_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bid_percentage' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -3985,7 +3677,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'retry_strategy' => {
-          'type' => Optional[Aws_batch_job_definition_retry_strategy_78],
+          'type' => Optional[Array[Aws_batch_job_definition_retry_strategy_78]],
           'value' => undef
         },
         'revision' => {
@@ -3993,7 +3685,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'timeout' => {
-          'type' => Optional[Aws_batch_job_definition_timeout_79],
+          'type' => Optional[Array[Aws_batch_job_definition_timeout_79]],
           'value' => undef
         },
         'type' => String
@@ -4012,10 +3704,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_batch_job_definition_retry_strategy_78 => {
       attributes => {
-        'aws_batch_job_definition_retry_strategy_78_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'attempts' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -4024,10 +3712,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_batch_job_definition_timeout_79 => {
       attributes => {
-        'aws_batch_job_definition_timeout_79_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'attempt_duration_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -4077,7 +3761,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cost_types' => {
-          'type' => Optional[Aws_budgets_budget_cost_types_80],
+          'type' => Optional[Array[Aws_budgets_budget_cost_types_80]],
           'value' => undef
         },
         'limit_amount' => String,
@@ -4111,10 +3795,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_budgets_budget_cost_types_80 => {
       attributes => {
-        'aws_budgets_budget_cost_types_80_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'include_credit' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -4351,7 +4031,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ordered_cache_behavior' => {
-          'type' => Optional[Aws_cloudfront_distribution_ordered_cache_behavior_91],
+          'type' => Optional[Array[Aws_cloudfront_distribution_ordered_cache_behavior_91]],
           'value' => undef
         },
         'origin' => Aws_cloudfront_distribution_origin_95,
@@ -4392,10 +4072,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_cache_behavior_81 => {
       attributes => {
-        'aws_cloudfront_distribution_cache_behavior_81_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allowed_methods' => Array[String],
         'cached_methods' => Array[String],
         'compress' => {
@@ -4438,10 +4114,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82 => {
       attributes => {
-        'aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cookies' => Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_83,
         'headers' => {
           'type' => Optional[Array[String]],
@@ -4456,10 +4128,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_83 => {
       attributes => {
-        'aws_cloudfront_distribution_cache_behavior_81_forwarded_values_82_cookies_83_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'forward' => String,
         'whitelisted_names' => {
           'type' => Optional[Array[String]],
@@ -4469,10 +4137,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_cache_behavior_81_lambda_function_association_84 => {
       attributes => {
-        'aws_cloudfront_distribution_cache_behavior_81_lambda_function_association_84_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'event_type' => String,
         'include_body' => {
           'type' => Optional[Boolean],
@@ -4483,10 +4147,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_custom_error_response_85 => {
       attributes => {
-        'aws_cloudfront_distribution_custom_error_response_85_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'error_caching_min_ttl' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -4504,10 +4164,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_default_cache_behavior_86 => {
       attributes => {
-        'aws_cloudfront_distribution_default_cache_behavior_86_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allowed_methods' => Array[String],
         'cached_methods' => Array[String],
         'compress' => {
@@ -4549,10 +4205,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87 => {
       attributes => {
-        'aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cookies' => Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_cookies_88,
         'headers' => {
           'type' => Optional[Array[String]],
@@ -4567,10 +4219,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_cookies_88 => {
       attributes => {
-        'aws_cloudfront_distribution_default_cache_behavior_86_forwarded_values_87_cookies_88_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'forward' => String,
         'whitelisted_names' => {
           'type' => Optional[Array[String]],
@@ -4580,10 +4228,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_default_cache_behavior_86_lambda_function_association_89 => {
       attributes => {
-        'aws_cloudfront_distribution_default_cache_behavior_86_lambda_function_association_89_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'event_type' => String,
         'include_body' => {
           'type' => Optional[Boolean],
@@ -4594,10 +4238,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_logging_config_90 => {
       attributes => {
-        'aws_cloudfront_distribution_logging_config_90_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => String,
         'include_cookies' => {
           'type' => Optional[Boolean],
@@ -4611,10 +4251,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_ordered_cache_behavior_91 => {
       attributes => {
-        'aws_cloudfront_distribution_ordered_cache_behavior_91_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allowed_methods' => Array[String],
         'cached_methods' => Array[String],
         'compress' => {
@@ -4657,10 +4293,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92 => {
       attributes => {
-        'aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cookies' => Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_cookies_93,
         'headers' => {
           'type' => Optional[Array[String]],
@@ -4675,10 +4307,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_cookies_93 => {
       attributes => {
-        'aws_cloudfront_distribution_ordered_cache_behavior_91_forwarded_values_92_cookies_93_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'forward' => String,
         'whitelisted_names' => {
           'type' => Optional[Array[String]],
@@ -4688,10 +4316,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_ordered_cache_behavior_91_lambda_function_association_94 => {
       attributes => {
-        'aws_cloudfront_distribution_ordered_cache_behavior_91_lambda_function_association_94_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'event_type' => String,
         'include_body' => {
           'type' => Optional[Boolean],
@@ -4702,10 +4326,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_origin_95 => {
       attributes => {
-        'aws_cloudfront_distribution_origin_95_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'custom_header' => {
           'type' => Optional[Aws_cloudfront_distribution_origin_95_custom_header_96],
           'value' => undef
@@ -4728,20 +4348,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_origin_95_custom_header_96 => {
       attributes => {
-        'aws_cloudfront_distribution_origin_95_custom_header_96_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
     },
     Aws_cloudfront_distribution_origin_95_custom_origin_config_97 => {
       attributes => {
-        'aws_cloudfront_distribution_origin_95_custom_origin_config_97_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'http_port' => Integer,
         'https_port' => Integer,
         'origin_keepalive_timeout' => {
@@ -4758,28 +4370,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_origin_95_s3_origin_config_98 => {
       attributes => {
-        'aws_cloudfront_distribution_origin_95_s3_origin_config_98_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'origin_access_identity' => String
       }
     },
     Aws_cloudfront_distribution_restrictions_99 => {
       attributes => {
-        'aws_cloudfront_distribution_restrictions_99_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'geo_restriction' => Aws_cloudfront_distribution_restrictions_99_geo_restriction_100
       }
     },
     Aws_cloudfront_distribution_restrictions_99_geo_restriction_100 => {
       attributes => {
-        'aws_cloudfront_distribution_restrictions_99_geo_restriction_100_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'locations' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -4789,10 +4389,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudfront_distribution_viewer_certificate_101 => {
       attributes => {
-        'aws_cloudfront_distribution_viewer_certificate_101_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'acm_certificate_arn' => {
           'type' => Optional[String],
           'value' => undef
@@ -4905,7 +4501,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cluster_certificates' => {
-          'type' => Optional[Aws_cloudhsm_v2_cluster_cluster_certificates_102],
+          'type' => Optional[Array[Aws_cloudhsm_v2_cluster_cluster_certificates_102]],
           'value' => undef
         },
         'cluster_id' => {
@@ -4949,10 +4545,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudhsm_v2_cluster_cluster_certificates_102 => {
       attributes => {
-        'aws_cloudhsm_v2_cluster_cluster_certificates_102_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_hardware_certificate' => {
           'type' => Optional[String],
           'value' => undef
@@ -5046,7 +4638,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'event_selector' => {
-          'type' => Optional[Aws_cloudtrail_event_selector_103],
+          'type' => Optional[Array[Aws_cloudtrail_event_selector_103]],
           'value' => undef
         },
         'home_region' => {
@@ -5098,12 +4690,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudtrail_event_selector_103 => {
       attributes => {
-        'aws_cloudtrail_event_selector_103_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data_resource' => {
-          'type' => Optional[Aws_cloudtrail_event_selector_103_data_resource_104],
+          'type' => Optional[Array[Aws_cloudtrail_event_selector_103_data_resource_104]],
           'value' => undef
         },
         'include_management_events' => {
@@ -5118,10 +4706,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudtrail_event_selector_103_data_resource_104 => {
       attributes => {
-        'aws_cloudtrail_event_selector_103_data_resource_104_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String,
         'values' => Array[String]
       }
@@ -5162,7 +4746,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'condition' => {
-          'type' => Optional[Aws_cloudwatch_event_permission_condition_105],
+          'type' => Optional[Array[Aws_cloudwatch_event_permission_condition_105]],
           'value' => undef
         },
         'principal' => String,
@@ -5182,10 +4766,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_permission_condition_105 => {
       attributes => {
-        'aws_cloudwatch_event_permission_condition_105_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'type' => String,
         'value' => String
@@ -5250,11 +4830,11 @@ type TerraformAws = TypeSet[{
         },
         'arn' => String,
         'batch_target' => {
-          'type' => Optional[Aws_cloudwatch_event_target_batch_target_106],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_batch_target_106]],
           'value' => undef
         },
         'ecs_target' => {
-          'type' => Optional[Aws_cloudwatch_event_target_ecs_target_107],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_ecs_target_107]],
           'value' => undef
         },
         'input' => {
@@ -5266,11 +4846,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'input_transformer' => {
-          'type' => Optional[Aws_cloudwatch_event_target_input_transformer_109],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_input_transformer_109]],
           'value' => undef
         },
         'kinesis_target' => {
-          'type' => Optional[Aws_cloudwatch_event_target_kinesis_target_110],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_kinesis_target_110]],
           'value' => undef
         },
         'role_arn' => {
@@ -5279,11 +4859,11 @@ type TerraformAws = TypeSet[{
         },
         'rule' => String,
         'run_command_targets' => {
-          'type' => Optional[Aws_cloudwatch_event_target_run_command_targets_111],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_run_command_targets_111]],
           'value' => undef
         },
         'sqs_target' => {
-          'type' => Optional[Aws_cloudwatch_event_target_sqs_target_112],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_sqs_target_112]],
           'value' => undef
         },
         'target_id' => {
@@ -5305,10 +4885,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_target_batch_target_106 => {
       attributes => {
-        'aws_cloudwatch_event_target_batch_target_106_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'array_size' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -5323,10 +4899,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_target_ecs_target_107 => {
       attributes => {
-        'aws_cloudwatch_event_target_ecs_target_107_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -5336,7 +4908,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'network_configuration' => {
-          'type' => Optional[Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108],
+          'type' => Optional[Array[Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108]],
           'value' => undef
         },
         'platform_version' => {
@@ -5352,10 +4924,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_target_ecs_target_107_network_configuration_108 => {
       attributes => {
-        'aws_cloudwatch_event_target_ecs_target_107_network_configuration_108_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'assign_public_ip' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5369,10 +4937,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_target_input_transformer_109 => {
       attributes => {
-        'aws_cloudwatch_event_target_input_transformer_109_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'input_paths' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -5382,10 +4946,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_target_kinesis_target_110 => {
       attributes => {
-        'aws_cloudwatch_event_target_kinesis_target_110_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'partition_key_path' => {
           'type' => Optional[String],
           'value' => undef
@@ -5394,20 +4954,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_event_target_run_command_targets_111 => {
       attributes => {
-        'aws_cloudwatch_event_target_run_command_targets_111_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'values' => Array[String]
       }
     },
     Aws_cloudwatch_event_target_sqs_target_112 => {
       attributes => {
-        'aws_cloudwatch_event_target_sqs_target_112_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'message_group_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -5511,7 +5063,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'log_group_name' => String,
-        'metric_transformation' => Aws_cloudwatch_log_metric_filter_metric_transformation_113,
+        'metric_transformation' => Array[Aws_cloudwatch_log_metric_filter_metric_transformation_113],
         'name' => String,
         'pattern' => String
       }
@@ -5529,10 +5081,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cloudwatch_log_metric_filter_metric_transformation_113 => {
       attributes => {
-        'aws_cloudwatch_log_metric_filter_metric_transformation_113_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_value' => {
           'type' => Optional[String],
           'value' => undef
@@ -5721,7 +5269,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cache' => {
-          'type' => Optional[Aws_codebuild_project_cache_115],
+          'type' => Optional[Array[Aws_codebuild_project_cache_115]],
           'value' => undef
         },
         'description' => {
@@ -5753,7 +5301,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'vpc_config' => {
-          'type' => Optional[Aws_codebuild_project_vpc_config_123],
+          'type' => Optional[Array[Aws_codebuild_project_vpc_config_123]],
           'value' => undef
         }
       }
@@ -5771,10 +5319,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_artifacts_114 => {
       attributes => {
-        'aws_codebuild_project_artifacts_114_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'encryption_disabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5804,10 +5348,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_cache_115 => {
       attributes => {
-        'aws_codebuild_project_cache_115_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'location' => {
           'type' => Optional[String],
           'value' => undef
@@ -5820,17 +5360,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_environment_116 => {
       attributes => {
-        'aws_codebuild_project_environment_116_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'certificate' => {
           'type' => Optional[String],
           'value' => undef
         },
         'compute_type' => String,
         'environment_variable' => {
-          'type' => Optional[Aws_codebuild_project_environment_116_environment_variable_117],
+          'type' => Optional[Array[Aws_codebuild_project_environment_116_environment_variable_117]],
           'value' => undef
         },
         'image' => String,
@@ -5843,10 +5379,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_environment_116_environment_variable_117 => {
       attributes => {
-        'aws_codebuild_project_environment_116_environment_variable_117_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'type' => {
           'type' => Optional[String],
@@ -5857,10 +5389,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_secondary_artifacts_118 => {
       attributes => {
-        'aws_codebuild_project_secondary_artifacts_118_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'artifact_identifier' => String,
         'encryption_disabled' => {
           'type' => Optional[Boolean],
@@ -5891,10 +5419,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_secondary_sources_119 => {
       attributes => {
-        'aws_codebuild_project_secondary_sources_119_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auth' => {
           'type' => Optional[Aws_codebuild_project_secondary_sources_119_auth_120],
           'value' => undef
@@ -5925,10 +5449,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_secondary_sources_119_auth_120 => {
       attributes => {
-        'aws_codebuild_project_secondary_sources_119_auth_120_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource' => {
           'type' => Optional[String],
           'value' => undef
@@ -5938,10 +5458,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_source_121 => {
       attributes => {
-        'aws_codebuild_project_source_121_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auth' => {
           'type' => Optional[Aws_codebuild_project_source_121_auth_122],
           'value' => undef
@@ -5971,10 +5487,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_source_121_auth_122 => {
       attributes => {
-        'aws_codebuild_project_source_121_auth_122_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource' => {
           'type' => Optional[String],
           'value' => undef
@@ -5984,10 +5496,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codebuild_project_vpc_config_123 => {
       attributes => {
-        'aws_codebuild_project_vpc_config_123_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'security_group_ids' => Array[String],
         'subnets' => Array[String],
         'vpc_id' => String
@@ -6100,10 +5608,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codecommit_trigger_trigger_124 => {
       attributes => {
-        'aws_codecommit_trigger_trigger_124_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'branches' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -6161,11 +5665,11 @@ type TerraformAws = TypeSet[{
         },
         'deployment_config_name' => String,
         'minimum_healthy_hosts' => {
-          'type' => Optional[Aws_codedeploy_deployment_config_minimum_healthy_hosts_125],
+          'type' => Optional[Array[Aws_codedeploy_deployment_config_minimum_healthy_hosts_125]],
           'value' => undef
         },
         'traffic_routing_config' => {
-          'type' => Optional[Aws_codedeploy_deployment_config_traffic_routing_config_126],
+          'type' => Optional[Array[Aws_codedeploy_deployment_config_traffic_routing_config_126]],
           'value' => undef
         }
       }
@@ -6183,10 +5687,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_config_minimum_healthy_hosts_125 => {
       attributes => {
-        'aws_codedeploy_deployment_config_minimum_healthy_hosts_125_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6199,16 +5699,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_config_traffic_routing_config_126 => {
       attributes => {
-        'aws_codedeploy_deployment_config_traffic_routing_config_126_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'time_based_canary' => {
-          'type' => Optional[Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127],
+          'type' => Optional[Array[Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127]],
           'value' => undef
         },
         'time_based_linear' => {
-          'type' => Optional[Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128],
+          'type' => Optional[Array[Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128]],
           'value' => undef
         },
         'type' => {
@@ -6219,10 +5715,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127 => {
       attributes => {
-        'aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_canary_127_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'interval' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6235,10 +5727,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128 => {
       attributes => {
-        'aws_codedeploy_deployment_config_traffic_routing_config_126_time_based_linear_128_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'interval' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6256,12 +5744,12 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'alarm_configuration' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_alarm_configuration_129],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_alarm_configuration_129]],
           'value' => undef
         },
         'app_name' => String,
         'auto_rollback_configuration' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_auto_rollback_configuration_130],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_auto_rollback_configuration_130]],
           'value' => undef
         },
         'autoscaling_groups' => {
@@ -6269,7 +5757,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'blue_green_deployment_config' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_blue_green_deployment_config_131],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_blue_green_deployment_config_131]],
           'value' => undef
         },
         'deployment_config_name' => {
@@ -6278,7 +5766,7 @@ type TerraformAws = TypeSet[{
         },
         'deployment_group_name' => String,
         'deployment_style' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_deployment_style_135],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_deployment_style_135]],
           'value' => undef
         },
         'ec2_tag_filter' => {
@@ -6290,11 +5778,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ecs_service' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_ecs_service_139],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_ecs_service_139]],
           'value' => undef
         },
         'load_balancer_info' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_load_balancer_info_140],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_load_balancer_info_140]],
           'value' => undef
         },
         'on_premises_instance_tag_filter' => {
@@ -6321,10 +5809,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_alarm_configuration_129 => {
       attributes => {
-        'aws_codedeploy_deployment_group_alarm_configuration_129_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'alarms' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -6341,10 +5825,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_auto_rollback_configuration_130 => {
       attributes => {
-        'aws_codedeploy_deployment_group_auto_rollback_configuration_130_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6357,30 +5837,22 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_blue_green_deployment_config_131 => {
       attributes => {
-        'aws_codedeploy_deployment_group_blue_green_deployment_config_131_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'deployment_ready_option' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132]],
           'value' => undef
         },
         'green_fleet_provisioning_option' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133]],
           'value' => undef
         },
         'terminate_blue_instances_on_deployment_success' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134]],
           'value' => undef
         }
       }
     },
     Aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132 => {
       attributes => {
-        'aws_codedeploy_deployment_group_blue_green_deployment_config_131_deployment_ready_option_132_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action_on_timeout' => {
           'type' => Optional[String],
           'value' => undef
@@ -6393,10 +5865,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133 => {
       attributes => {
-        'aws_codedeploy_deployment_group_blue_green_deployment_config_131_green_fleet_provisioning_option_133_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => {
           'type' => Optional[String],
           'value' => undef
@@ -6405,10 +5873,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134 => {
       attributes => {
-        'aws_codedeploy_deployment_group_blue_green_deployment_config_131_terminate_blue_instances_on_deployment_success_134_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => {
           'type' => Optional[String],
           'value' => undef
@@ -6421,10 +5885,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_deployment_style_135 => {
       attributes => {
-        'aws_codedeploy_deployment_group_deployment_style_135_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'deployment_option' => {
           'type' => Optional[String],
           'value' => undef
@@ -6437,10 +5897,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_ec2_tag_filter_136 => {
       attributes => {
-        'aws_codedeploy_deployment_group_ec2_tag_filter_136_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -6457,10 +5913,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_ec2_tag_set_137 => {
       attributes => {
-        'aws_codedeploy_deployment_group_ec2_tag_set_137_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ec2_tag_filter' => {
           'type' => Optional[Aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138],
           'value' => undef
@@ -6469,10 +5921,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138 => {
       attributes => {
-        'aws_codedeploy_deployment_group_ec2_tag_set_137_ec2_tag_filter_138_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -6489,20 +5937,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_ecs_service_139 => {
       attributes => {
-        'aws_codedeploy_deployment_group_ecs_service_139_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cluster_name' => String,
         'service_name' => String
       }
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'elb_info' => {
           'type' => Optional[Aws_codedeploy_deployment_group_load_balancer_info_140_elb_info_141],
           'value' => undef
@@ -6512,17 +5952,13 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'target_group_pair_info' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143]],
           'value' => undef
         }
       }
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140_elb_info_141 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_elb_info_141_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6531,10 +5967,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_info_142 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_target_group_info_142_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6543,51 +5975,31 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'prod_traffic_route' => Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144,
-        'target_group' => Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145,
+        'prod_traffic_route' => Array[Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144],
+        'target_group' => Array[Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145],
         'test_traffic_route' => {
-          'type' => Optional[Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146],
+          'type' => Optional[Array[Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146]],
           'value' => undef
         }
       }
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_prod_traffic_route_144_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'listener_arns' => Array[String]
       }
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_target_group_145_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String
       }
     },
     Aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146 => {
       attributes => {
-        'aws_codedeploy_deployment_group_load_balancer_info_140_target_group_pair_info_143_test_traffic_route_146_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'listener_arns' => Array[String]
       }
     },
     Aws_codedeploy_deployment_group_on_premises_instance_tag_filter_147 => {
       attributes => {
-        'aws_codedeploy_deployment_group_on_premises_instance_tag_filter_147_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -6604,10 +6016,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codedeploy_deployment_group_trigger_configuration_148 => {
       attributes => {
-        'aws_codedeploy_deployment_group_trigger_configuration_148_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'trigger_events' => Array[String],
         'trigger_name' => String,
         'trigger_target_arn' => String
@@ -6623,10 +6031,10 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'artifact_store' => Aws_codepipeline_artifact_store_149,
+        'artifact_store' => Array[Aws_codepipeline_artifact_store_149],
         'name' => String,
         'role_arn' => String,
-        'stage' => Aws_codepipeline_stage_151
+        'stage' => Array[Aws_codepipeline_stage_151]
       }
     },
     Aws_codepipelineHandler => {
@@ -6642,12 +6050,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_codepipeline_artifact_store_149 => {
       attributes => {
-        'aws_codepipeline_artifact_store_149_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'encryption_key' => {
-          'type' => Optional[Aws_codepipeline_artifact_store_149_encryption_key_150],
+          'type' => Optional[Array[Aws_codepipeline_artifact_store_149_encryption_key_150]],
           'value' => undef
         },
         'location' => String,
@@ -6656,30 +6060,18 @@ type TerraformAws = TypeSet[{
     },
     Aws_codepipeline_artifact_store_149_encryption_key_150 => {
       attributes => {
-        'aws_codepipeline_artifact_store_149_encryption_key_150_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => String,
         'type' => String
       }
     },
     Aws_codepipeline_stage_151 => {
       attributes => {
-        'aws_codepipeline_stage_151_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'action' => Aws_codepipeline_stage_151_action_152,
+        'action' => Array[Aws_codepipeline_stage_151_action_152],
         'name' => String
       }
     },
     Aws_codepipeline_stage_151_action_152 => {
       attributes => {
-        'aws_codepipeline_stage_151_action_152_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'category' => String,
         'configuration' => {
           'type' => Optional[Hash[String, String]],
@@ -6715,7 +6107,7 @@ type TerraformAws = TypeSet[{
         },
         'authentication' => String,
         'authentication_configuration' => {
-          'type' => Optional[Aws_codepipeline_webhook_authentication_configuration_153],
+          'type' => Optional[Array[Aws_codepipeline_webhook_authentication_configuration_153]],
           'value' => undef
         },
         'filter' => Aws_codepipeline_webhook_filter_154,
@@ -6741,10 +6133,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codepipeline_webhook_authentication_configuration_153 => {
       attributes => {
-        'aws_codepipeline_webhook_authentication_configuration_153_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allowed_ip_range' => {
           'type' => Optional[String],
           'value' => undef
@@ -6757,10 +6145,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_codepipeline_webhook_filter_154 => {
       attributes => {
-        'aws_codepipeline_webhook_filter_154_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'json_path' => String,
         'match_equals' => String
       }
@@ -6815,10 +6199,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_identity_pool_cognito_identity_providers_155 => {
       attributes => {
-        'aws_cognito_identity_pool_cognito_identity_providers_155_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'client_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -6860,17 +6240,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_identity_pool_roles_attachment_role_mapping_156 => {
       attributes => {
-        'aws_cognito_identity_pool_roles_attachment_role_mapping_156_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ambiguous_role_resolution' => {
           'type' => Optional[String],
           'value' => undef
         },
         'identity_provider' => String,
         'mapping_rule' => {
-          'type' => Optional[Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157],
+          'type' => Optional[Array[Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157]],
           'value' => undef
         },
         'type' => String
@@ -6878,10 +6254,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157 => {
       attributes => {
-        'aws_cognito_identity_pool_roles_attachment_role_mapping_156_mapping_rule_157_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'claim' => String,
         'match_type' => String,
         'role_arn' => String,
@@ -6951,10 +6323,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_resource_server_scope_158 => {
       attributes => {
-        'aws_cognito_resource_server_scope_158_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'scope_description' => String,
         'scope_name' => String
       }
@@ -6999,7 +6367,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'admin_create_user_config' => {
-          'type' => Optional[Aws_cognito_user_pool_admin_create_user_config_159],
+          'type' => Optional[Array[Aws_cognito_user_pool_admin_create_user_config_159]],
           'value' => undef
         },
         'alias_attributes' => {
@@ -7019,11 +6387,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'device_configuration' => {
-          'type' => Optional[Aws_cognito_user_pool_device_configuration_161],
+          'type' => Optional[Array[Aws_cognito_user_pool_device_configuration_161]],
           'value' => undef
         },
         'email_configuration' => {
-          'type' => Optional[Aws_cognito_user_pool_email_configuration_162],
+          'type' => Optional[Array[Aws_cognito_user_pool_email_configuration_162]],
           'value' => undef
         },
         'email_verification_message' => {
@@ -7039,7 +6407,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'lambda_config' => {
-          'type' => Optional[Aws_cognito_user_pool_lambda_config_163],
+          'type' => Optional[Array[Aws_cognito_user_pool_lambda_config_163]],
           'value' => undef
         },
         'last_modified_date' => {
@@ -7052,7 +6420,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'password_policy' => {
-          'type' => Optional[Aws_cognito_user_pool_password_policy_164],
+          'type' => Optional[Array[Aws_cognito_user_pool_password_policy_164]],
           'value' => undef
         },
         'schema' => {
@@ -7064,7 +6432,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'sms_configuration' => {
-          'type' => Optional[Aws_cognito_user_pool_sms_configuration_168],
+          'type' => Optional[Array[Aws_cognito_user_pool_sms_configuration_168]],
           'value' => undef
         },
         'sms_verification_message' => {
@@ -7080,7 +6448,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'verification_message_template' => {
-          'type' => Optional[Aws_cognito_user_pool_verification_message_template_169],
+          'type' => Optional[Array[Aws_cognito_user_pool_verification_message_template_169]],
           'value' => undef
         }
       }
@@ -7098,16 +6466,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_admin_create_user_config_159 => {
       attributes => {
-        'aws_cognito_user_pool_admin_create_user_config_159_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_admin_create_user_only' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'invite_message_template' => {
-          'type' => Optional[Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160],
+          'type' => Optional[Array[Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160]],
           'value' => undef
         },
         'unused_account_validity_days' => {
@@ -7118,10 +6482,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160 => {
       attributes => {
-        'aws_cognito_user_pool_admin_create_user_config_159_invite_message_template_160_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'email_message' => {
           'type' => Optional[String],
           'value' => undef
@@ -7211,10 +6571,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_device_configuration_161 => {
       attributes => {
-        'aws_cognito_user_pool_device_configuration_161_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'challenge_required_on_new_device' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -7268,10 +6624,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_email_configuration_162 => {
       attributes => {
-        'aws_cognito_user_pool_email_configuration_162_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'reply_to_email_address' => {
           'type' => Optional[String],
           'value' => undef
@@ -7284,10 +6636,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_lambda_config_163 => {
       attributes => {
-        'aws_cognito_user_pool_lambda_config_163_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'create_auth_challenge' => {
           'type' => Optional[String],
           'value' => undef
@@ -7332,10 +6680,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_password_policy_164 => {
       attributes => {
-        'aws_cognito_user_pool_password_policy_164_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'minimum_length' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -7360,10 +6704,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_schema_165 => {
       attributes => {
-        'aws_cognito_user_pool_schema_165_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'attribute_data_type' => String,
         'developer_only_attribute' => {
           'type' => Optional[Boolean],
@@ -7375,7 +6715,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'number_attribute_constraints' => {
-          'type' => Optional[Aws_cognito_user_pool_schema_165_number_attribute_constraints_166],
+          'type' => Optional[Array[Aws_cognito_user_pool_schema_165_number_attribute_constraints_166]],
           'value' => undef
         },
         'required' => {
@@ -7383,17 +6723,13 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'string_attribute_constraints' => {
-          'type' => Optional[Aws_cognito_user_pool_schema_165_string_attribute_constraints_167],
+          'type' => Optional[Array[Aws_cognito_user_pool_schema_165_string_attribute_constraints_167]],
           'value' => undef
         }
       }
     },
     Aws_cognito_user_pool_schema_165_number_attribute_constraints_166 => {
       attributes => {
-        'aws_cognito_user_pool_schema_165_number_attribute_constraints_166_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_value' => {
           'type' => Optional[String],
           'value' => undef
@@ -7406,10 +6742,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_schema_165_string_attribute_constraints_167 => {
       attributes => {
-        'aws_cognito_user_pool_schema_165_string_attribute_constraints_167_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_length' => {
           'type' => Optional[String],
           'value' => undef
@@ -7422,20 +6754,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_cognito_user_pool_sms_configuration_168 => {
       attributes => {
-        'aws_cognito_user_pool_sms_configuration_168_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'external_id' => String,
         'sns_caller_arn' => String
       }
     },
     Aws_cognito_user_pool_verification_message_template_169 => {
       attributes => {
-        'aws_cognito_user_pool_verification_message_template_169_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_email_option' => {
           'type' => Optional[String],
           'value' => undef
@@ -7515,10 +6839,10 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'scope' => {
-          'type' => Optional[Aws_config_config_rule_scope_170],
+          'type' => Optional[Array[Aws_config_config_rule_scope_170]],
           'value' => undef
         },
-        'source' => Aws_config_config_rule_source_171
+        'source' => Array[Aws_config_config_rule_source_171]
       }
     },
     Aws_config_config_ruleHandler => {
@@ -7534,10 +6858,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_config_rule_scope_170 => {
       attributes => {
-        'aws_config_config_rule_scope_170_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'compliance_resource_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -7558,10 +6878,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_config_rule_source_171 => {
       attributes => {
-        'aws_config_config_rule_source_171_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'owner' => String,
         'source_detail' => {
           'type' => Optional[Aws_config_config_rule_source_171_source_detail_172],
@@ -7572,10 +6888,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_config_rule_source_171_source_detail_172 => {
       attributes => {
-        'aws_config_config_rule_source_171_source_detail_172_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'event_source' => {
           'type' => Optional[String],
           'value' => undef
@@ -7597,7 +6909,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'account_aggregation_source' => {
-          'type' => Optional[Aws_config_configuration_aggregator_account_aggregation_source_173],
+          'type' => Optional[Array[Aws_config_configuration_aggregator_account_aggregation_source_173]],
           'value' => undef
         },
         'arn' => {
@@ -7606,7 +6918,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'organization_aggregation_source' => {
-          'type' => Optional[Aws_config_configuration_aggregator_organization_aggregation_source_174],
+          'type' => Optional[Array[Aws_config_configuration_aggregator_organization_aggregation_source_174]],
           'value' => undef
         }
       }
@@ -7624,10 +6936,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_configuration_aggregator_account_aggregation_source_173 => {
       attributes => {
-        'aws_config_configuration_aggregator_account_aggregation_source_173_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'account_ids' => Array[String],
         'all_regions' => {
           'type' => Optional[Boolean],
@@ -7641,10 +6949,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_configuration_aggregator_organization_aggregation_source_174 => {
       attributes => {
-        'aws_config_configuration_aggregator_organization_aggregation_source_174_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all_regions' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -7667,7 +6971,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'recording_group' => {
-          'type' => Optional[Aws_config_configuration_recorder_recording_group_175],
+          'type' => Optional[Array[Aws_config_configuration_recorder_recording_group_175]],
           'value' => undef
         },
         'role_arn' => String
@@ -7686,10 +6990,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_configuration_recorder_recording_group_175 => {
       attributes => {
-        'aws_config_configuration_recorder_recording_group_175_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all_supported' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -7741,7 +7041,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'snapshot_delivery_properties' => {
-          'type' => Optional[Aws_config_delivery_channel_snapshot_delivery_properties_176],
+          'type' => Optional[Array[Aws_config_delivery_channel_snapshot_delivery_properties_176]],
           'value' => undef
         },
         'sns_topic_arn' => {
@@ -7763,10 +7063,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_config_delivery_channel_snapshot_delivery_properties_176 => {
       attributes => {
-        'aws_config_delivery_channel_snapshot_delivery_properties_176_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delivery_frequency' => {
           'type' => Optional[String],
           'value' => undef
@@ -7848,7 +7144,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'ec2_config' => Aws_datasync_location_efs_ec2_config_177,
+        'ec2_config' => Array[Aws_datasync_location_efs_ec2_config_177],
         'efs_file_system_arn' => String,
         'subdirectory' => {
           'type' => Optional[String],
@@ -7877,10 +7173,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_datasync_location_efs_ec2_config_177 => {
       attributes => {
-        'aws_datasync_location_efs_ec2_config_177_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'security_group_arns' => Array[String],
         'subnet_arn' => String
       }
@@ -7895,7 +7187,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'on_prem_config' => Aws_datasync_location_nfs_on_prem_config_178,
+        'on_prem_config' => Array[Aws_datasync_location_nfs_on_prem_config_178],
         'server_hostname' => String,
         'subdirectory' => String,
         'tags' => {
@@ -7921,10 +7213,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_datasync_location_nfs_on_prem_config_178 => {
       attributes => {
-        'aws_datasync_location_nfs_on_prem_config_178_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'agent_arns' => Array[String]
       }
     },
@@ -7939,7 +7227,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         's3_bucket_arn' => String,
-        's3_config' => Aws_datasync_location_s3_s3_config_179,
+        's3_config' => Array[Aws_datasync_location_s3_s3_config_179],
         'subdirectory' => String,
         'tags' => {
           'type' => Optional[Hash[String, String]],
@@ -7964,10 +7252,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_datasync_location_s3_s3_config_179 => {
       attributes => {
-        'aws_datasync_location_s3_s3_config_179_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_access_role_arn' => String
       }
     },
@@ -7991,7 +7275,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'options' => {
-          'type' => Optional[Aws_datasync_task_options_180],
+          'type' => Optional[Array[Aws_datasync_task_options_180]],
           'value' => undef
         },
         'source_location_arn' => String,
@@ -8014,10 +7298,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_datasync_task_options_180 => {
       attributes => {
-        'aws_datasync_task_options_180_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'atime' => {
           'type' => Optional[String],
           'value' => undef
@@ -8090,7 +7370,7 @@ type TerraformAws = TypeSet[{
         },
         'node_type' => String,
         'nodes' => {
-          'type' => Optional[Aws_dax_cluster_nodes_181],
+          'type' => Optional[Array[Aws_dax_cluster_nodes_181]],
           'value' => undef
         },
         'notification_topic_arn' => {
@@ -8111,7 +7391,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'server_side_encryption' => {
-          'type' => Optional[Aws_dax_cluster_server_side_encryption_182],
+          'type' => Optional[Array[Aws_dax_cluster_server_side_encryption_182]],
           'value' => undef
         },
         'subnet_group_name' => {
@@ -8137,10 +7417,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dax_cluster_nodes_181 => {
       attributes => {
-        'aws_dax_cluster_nodes_181_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'address' => {
           'type' => Optional[String],
           'value' => undef
@@ -8161,10 +7437,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dax_cluster_server_side_encryption_182 => {
       attributes => {
-        'aws_dax_cluster_server_side_encryption_182_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -8201,10 +7473,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dax_parameter_group_parameters_183 => {
       attributes => {
-        'aws_dax_parameter_group_parameters_183_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
@@ -8539,7 +7807,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         's3_import' => {
-          'type' => Optional[Aws_db_instance_s3_import_184],
+          'type' => Optional[Array[Aws_db_instance_s3_import_184]],
           'value' => undef
         },
         'security_group_names' => {
@@ -8597,10 +7865,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_db_instance_s3_import_184 => {
       attributes => {
-        'aws_db_instance_s3_import_184_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_name' => String,
         'bucket_prefix' => {
           'type' => Optional[String],
@@ -8658,10 +7922,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_db_option_group_option_185 => {
       attributes => {
-        'aws_db_option_group_option_185_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'db_security_group_memberships' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8687,10 +7947,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_db_option_group_option_185_option_settings_186 => {
       attributes => {
-        'aws_db_option_group_option_185_option_settings_186_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
@@ -8741,10 +7997,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_db_parameter_group_parameter_187 => {
       attributes => {
-        'aws_db_parameter_group_parameter_187_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'apply_method' => {
           'type' => Optional[String],
           'value' => undef
@@ -8788,10 +8040,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_db_security_group_ingress_188 => {
       attributes => {
-        'aws_db_security_group_ingress_188_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr' => {
           'type' => Optional[String],
           'value' => undef
@@ -8989,10 +8237,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_default_network_acl_egress_189 => {
       attributes => {
-        'aws_default_network_acl_egress_189_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => String,
         'cidr_block' => {
           'type' => Optional[String],
@@ -9018,10 +8262,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_default_network_acl_ingress_190 => {
       attributes => {
-        'aws_default_network_acl_ingress_190_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => String,
         'cidr_block' => {
           'type' => Optional[String],
@@ -9087,10 +8327,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_default_route_table_route_191 => {
       attributes => {
-        'aws_default_route_table_route_191_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_block' => {
           'type' => Optional[String],
           'value' => undef
@@ -9182,10 +8418,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_default_security_group_egress_192 => {
       attributes => {
-        'aws_default_security_group_egress_192_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_blocks' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9217,10 +8449,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_default_security_group_ingress_193 => {
       attributes => {
-        'aws_default_security_group_ingress_193_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_blocks' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9505,7 +8733,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'connect_settings' => {
-          'type' => Optional[Aws_directory_service_directory_connect_settings_194],
+          'type' => Optional[Array[Aws_directory_service_directory_connect_settings_194]],
           'value' => undef
         },
         'description' => {
@@ -9547,7 +8775,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'vpc_settings' => {
-          'type' => Optional[Aws_directory_service_directory_vpc_settings_195],
+          'type' => Optional[Array[Aws_directory_service_directory_vpc_settings_195]],
           'value' => undef
         }
       }
@@ -9565,10 +8793,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_directory_service_directory_connect_settings_194 => {
       attributes => {
-        'aws_directory_service_directory_connect_settings_194_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'customer_dns_ips' => Array[String],
         'customer_username' => String,
         'subnet_ids' => Array[String],
@@ -9577,10 +8801,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_directory_service_directory_vpc_settings_195 => {
       attributes => {
-        'aws_directory_service_directory_vpc_settings_195_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'subnet_ids' => Array[String],
         'vpc_id' => String
       }
@@ -9593,7 +8813,7 @@ type TerraformAws = TypeSet[{
         },
         'description' => String,
         'execution_role_arn' => String,
-        'policy_details' => Aws_dlm_lifecycle_policy_policy_details_196,
+        'policy_details' => Array[Aws_dlm_lifecycle_policy_policy_details_196],
         'state' => {
           'type' => Optional[String],
           'value' => undef
@@ -9613,28 +8833,20 @@ type TerraformAws = TypeSet[{
     },
     Aws_dlm_lifecycle_policy_policy_details_196 => {
       attributes => {
-        'aws_dlm_lifecycle_policy_policy_details_196_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_types' => Array[String],
-        'schedule' => Aws_dlm_lifecycle_policy_policy_details_196_schedule_197,
+        'schedule' => Array[Aws_dlm_lifecycle_policy_policy_details_196_schedule_197],
         'target_tags' => Hash[String, String]
       }
     },
     Aws_dlm_lifecycle_policy_policy_details_196_schedule_197 => {
       attributes => {
-        'aws_dlm_lifecycle_policy_policy_details_196_schedule_197_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'copy_tags' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
-        'create_rule' => Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198,
+        'create_rule' => Array[Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198],
         'name' => String,
-        'retain_rule' => Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199,
+        'retain_rule' => Array[Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199],
         'tags_to_add' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -9643,10 +8855,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198 => {
       attributes => {
-        'aws_dlm_lifecycle_policy_policy_details_196_schedule_197_create_rule_198_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'interval' => Integer,
         'interval_unit' => {
           'type' => Optional[String],
@@ -9660,10 +8868,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199 => {
       attributes => {
-        'aws_dlm_lifecycle_policy_policy_details_196_schedule_197_retain_rule_199_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer
       }
     },
@@ -9729,7 +8933,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'mongodb_settings' => {
-          'type' => Optional[Aws_dms_endpoint_mongodb_settings_200],
+          'type' => Optional[Array[Aws_dms_endpoint_mongodb_settings_200]],
           'value' => undef
         },
         'password' => {
@@ -9741,7 +8945,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         's3_settings' => {
-          'type' => Optional[Aws_dms_endpoint_s3_settings_201],
+          'type' => Optional[Array[Aws_dms_endpoint_s3_settings_201]],
           'value' => undef
         },
         'server_name' => {
@@ -9779,10 +8983,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dms_endpoint_mongodb_settings_200 => {
       attributes => {
-        'aws_dms_endpoint_mongodb_settings_200_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auth_mechanism' => {
           'type' => Optional[String],
           'value' => undef
@@ -9811,10 +9011,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dms_endpoint_s3_settings_201 => {
       attributes => {
-        'aws_dms_endpoint_s3_settings_201_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_folder' => {
           'type' => Optional[String],
           'value' => undef
@@ -10047,10 +9243,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_docdb_cluster_parameter_group_parameter_202 => {
       attributes => {
-        'aws_docdb_cluster_parameter_group_parameter_202_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'apply_method' => {
           'type' => Optional[String],
           'value' => undef
@@ -10559,10 +9751,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dynamodb_global_table_replica_203 => {
       attributes => {
-        'aws_dynamodb_global_table_replica_203_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'region_name' => String
       }
     },
@@ -10592,7 +9780,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'point_in_time_recovery' => {
-          'type' => Optional[Aws_dynamodb_table_point_in_time_recovery_207],
+          'type' => Optional[Array[Aws_dynamodb_table_point_in_time_recovery_207]],
           'value' => undef
         },
         'range_key' => {
@@ -10604,7 +9792,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'server_side_encryption' => {
-          'type' => Optional[Aws_dynamodb_table_server_side_encryption_208],
+          'type' => Optional[Array[Aws_dynamodb_table_server_side_encryption_208]],
           'value' => undef
         },
         'stream_arn' => {
@@ -10650,20 +9838,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_dynamodb_table_attribute_204 => {
       attributes => {
-        'aws_dynamodb_table_attribute_204_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'type' => String
       }
     },
     Aws_dynamodb_table_global_secondary_index_205 => {
       attributes => {
-        'aws_dynamodb_table_global_secondary_index_205_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'hash_key' => String,
         'name' => String,
         'non_key_attributes' => {
@@ -10713,10 +9893,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_dynamodb_table_local_secondary_index_206 => {
       attributes => {
-        'aws_dynamodb_table_local_secondary_index_206_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'non_key_attributes' => {
           'type' => Optional[Array[String]],
@@ -10728,28 +9904,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_dynamodb_table_point_in_time_recovery_207 => {
       attributes => {
-        'aws_dynamodb_table_point_in_time_recovery_207_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean
       }
     },
     Aws_dynamodb_table_server_side_encryption_208 => {
       attributes => {
-        'aws_dynamodb_table_server_side_encryption_208_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean
       }
     },
     Aws_dynamodb_table_ttl_209 => {
       attributes => {
-        'aws_dynamodb_table_ttl_209_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'attribute_name' => String,
         'enabled' => Boolean
       }
@@ -10976,9 +10140,9 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'launch_template_config' => Aws_ec2_fleet_launch_template_config_210,
+        'launch_template_config' => Array[Aws_ec2_fleet_launch_template_config_210],
         'on_demand_options' => {
-          'type' => Optional[Aws_ec2_fleet_on_demand_options_213],
+          'type' => Optional[Array[Aws_ec2_fleet_on_demand_options_213]],
           'value' => undef
         },
         'replace_unhealthy_instances' => {
@@ -10986,14 +10150,14 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'spot_options' => {
-          'type' => Optional[Aws_ec2_fleet_spot_options_214],
+          'type' => Optional[Array[Aws_ec2_fleet_spot_options_214]],
           'value' => undef
         },
         'tags' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
         },
-        'target_capacity_specification' => Aws_ec2_fleet_target_capacity_specification_215,
+        'target_capacity_specification' => Array[Aws_ec2_fleet_target_capacity_specification_215],
         'terminate_instances' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -11021,23 +10185,15 @@ type TerraformAws = TypeSet[{
     },
     Aws_ec2_fleet_launch_template_config_210 => {
       attributes => {
-        'aws_ec2_fleet_launch_template_config_210_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'launch_template_specification' => Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211,
+        'launch_template_specification' => Array[Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211],
         'override' => {
-          'type' => Optional[Aws_ec2_fleet_launch_template_config_210_override_212],
+          'type' => Optional[Array[Aws_ec2_fleet_launch_template_config_210_override_212]],
           'value' => undef
         }
       }
     },
     Aws_ec2_fleet_launch_template_config_210_launch_template_specification_211 => {
       attributes => {
-        'aws_ec2_fleet_launch_template_config_210_launch_template_specification_211_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'launch_template_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -11051,10 +10207,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ec2_fleet_launch_template_config_210_override_212 => {
       attributes => {
-        'aws_ec2_fleet_launch_template_config_210_override_212_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'availability_zone' => {
           'type' => Optional[String],
           'value' => undef
@@ -11083,10 +10235,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ec2_fleet_on_demand_options_213 => {
       attributes => {
-        'aws_ec2_fleet_on_demand_options_213_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allocation_strategy' => {
           'type' => Optional[String],
           'value' => undef
@@ -11095,10 +10243,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ec2_fleet_spot_options_214 => {
       attributes => {
-        'aws_ec2_fleet_spot_options_214_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allocation_strategy' => {
           'type' => Optional[String],
           'value' => undef
@@ -11115,10 +10259,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ec2_fleet_target_capacity_specification_215 => {
       attributes => {
-        'aws_ec2_fleet_target_capacity_specification_215_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_target_capacity_type' => String,
         'on_demand_target_capacity' => {
           'type' => Optional[Integer],
@@ -11481,7 +10621,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'deployment_controller' => {
-          'type' => Optional[Aws_ecs_service_deployment_controller_216],
+          'type' => Optional[Array[Aws_ecs_service_deployment_controller_216]],
           'value' => undef
         },
         'deployment_maximum_percent' => {
@@ -11518,11 +10658,11 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'network_configuration' => {
-          'type' => Optional[Aws_ecs_service_network_configuration_218],
+          'type' => Optional[Array[Aws_ecs_service_network_configuration_218]],
           'value' => undef
         },
         'ordered_placement_strategy' => {
-          'type' => Optional[Aws_ecs_service_ordered_placement_strategy_219],
+          'type' => Optional[Array[Aws_ecs_service_ordered_placement_strategy_219]],
           'value' => undef
         },
         'placement_constraints' => {
@@ -11569,10 +10709,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_deployment_controller_216 => {
       attributes => {
-        'aws_ecs_service_deployment_controller_216_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11581,10 +10717,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_load_balancer_217 => {
       attributes => {
-        'aws_ecs_service_load_balancer_217_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => String,
         'container_port' => Integer,
         'elb_name' => {
@@ -11599,10 +10731,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_network_configuration_218 => {
       attributes => {
-        'aws_ecs_service_network_configuration_218_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'assign_public_ip' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -11616,10 +10744,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_ordered_placement_strategy_219 => {
       attributes => {
-        'aws_ecs_service_ordered_placement_strategy_219_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field' => {
           'type' => Optional[String],
           'value' => undef
@@ -11629,10 +10753,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_placement_constraints_220 => {
       attributes => {
-        'aws_ecs_service_placement_constraints_220_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'expression' => {
           'type' => Optional[String],
           'value' => undef
@@ -11642,10 +10762,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_placement_strategy_221 => {
       attributes => {
-        'aws_ecs_service_placement_strategy_221_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field' => {
           'type' => Optional[String],
           'value' => undef
@@ -11655,10 +10771,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_service_service_registries_222 => {
       attributes => {
-        'aws_ecs_service_service_registries_222_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11749,10 +10861,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_task_definition_placement_constraints_223 => {
       attributes => {
-        'aws_ecs_task_definition_placement_constraints_223_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'expression' => {
           'type' => Optional[String],
           'value' => undef
@@ -11762,12 +10870,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_task_definition_volume_224 => {
       attributes => {
-        'aws_ecs_task_definition_volume_224_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'docker_volume_configuration' => {
-          'type' => Optional[Aws_ecs_task_definition_volume_224_docker_volume_configuration_225],
+          'type' => Optional[Array[Aws_ecs_task_definition_volume_224_docker_volume_configuration_225]],
           'value' => undef
         },
         'host_path' => {
@@ -11779,10 +10883,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ecs_task_definition_volume_224_docker_volume_configuration_225 => {
       attributes => {
-        'aws_ecs_task_definition_volume_224_docker_volume_configuration_225_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'autoprovision' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -12042,7 +11142,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'certificate_authority' => {
-          'type' => Optional[Aws_eks_cluster_certificate_authority_226],
+          'type' => Optional[Array[Aws_eks_cluster_certificate_authority_226]],
           'value' => undef
         },
         'created_at' => {
@@ -12063,7 +11163,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'vpc_config' => Aws_eks_cluster_vpc_config_227
+        'vpc_config' => Array[Aws_eks_cluster_vpc_config_227]
       }
     },
     Aws_eks_clusterHandler => {
@@ -12079,10 +11179,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_eks_cluster_certificate_authority_226 => {
       attributes => {
-        'aws_eks_cluster_certificate_authority_226_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -12091,10 +11187,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_eks_cluster_vpc_config_227 => {
       attributes => {
-        'aws_eks_cluster_vpc_config_227_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'security_group_ids' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -12113,7 +11205,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'appversion_lifecycle' => {
-          'type' => Optional[Aws_elastic_beanstalk_application_appversion_lifecycle_228],
+          'type' => Optional[Array[Aws_elastic_beanstalk_application_appversion_lifecycle_228]],
           'value' => undef
         },
         'description' => {
@@ -12136,10 +11228,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastic_beanstalk_application_appversion_lifecycle_228 => {
       attributes => {
-        'aws_elastic_beanstalk_application_appversion_lifecycle_228_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_source_from_s3' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -12225,10 +11313,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastic_beanstalk_configuration_template_setting_229 => {
       attributes => {
-        'aws_elastic_beanstalk_configuration_template_setting_229_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'namespace' => String,
         'resource' => {
@@ -12341,10 +11425,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastic_beanstalk_environment_all_settings_230 => {
       attributes => {
-        'aws_elastic_beanstalk_environment_all_settings_230_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'namespace' => String,
         'resource' => {
@@ -12356,10 +11436,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastic_beanstalk_environment_setting_231 => {
       attributes => {
-        'aws_elastic_beanstalk_environment_setting_231_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'namespace' => String,
         'resource' => {
@@ -12392,7 +11468,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cache_nodes' => {
-          'type' => Optional[Aws_elasticache_cluster_cache_nodes_232],
+          'type' => Optional[Array[Aws_elasticache_cluster_cache_nodes_232]],
           'value' => undef
         },
         'cluster_address' => {
@@ -12491,10 +11567,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticache_cluster_cache_nodes_232 => {
       attributes => {
-        'aws_elasticache_cluster_cache_nodes_232_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'address' => {
           'type' => Optional[String],
           'value' => undef
@@ -12544,10 +11616,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticache_parameter_group_parameter_233 => {
       attributes => {
-        'aws_elasticache_parameter_group_parameter_233_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
@@ -12583,7 +11651,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cluster_mode' => {
-          'type' => Optional[Aws_elasticache_replication_group_cluster_mode_234],
+          'type' => Optional[Array[Aws_elasticache_replication_group_cluster_mode_234]],
           'value' => undef
         },
         'configuration_endpoint_address' => {
@@ -12683,10 +11751,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticache_replication_group_cluster_mode_234 => {
       attributes => {
-        'aws_elasticache_replication_group_cluster_mode_234_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'num_node_groups' => Integer,
         'replicas_per_node_group' => Integer
       }
@@ -12760,11 +11824,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cluster_config' => {
-          'type' => Optional[Aws_elasticsearch_domain_cluster_config_235],
+          'type' => Optional[Array[Aws_elasticsearch_domain_cluster_config_235]],
           'value' => undef
         },
         'cognito_options' => {
-          'type' => Optional[Aws_elasticsearch_domain_cognito_options_236],
+          'type' => Optional[Array[Aws_elasticsearch_domain_cognito_options_236]],
           'value' => undef
         },
         'domain_id' => {
@@ -12773,7 +11837,7 @@ type TerraformAws = TypeSet[{
         },
         'domain_name' => String,
         'ebs_options' => {
-          'type' => Optional[Aws_elasticsearch_domain_ebs_options_237],
+          'type' => Optional[Array[Aws_elasticsearch_domain_ebs_options_237]],
           'value' => undef
         },
         'elasticsearch_version' => {
@@ -12781,7 +11845,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'encrypt_at_rest' => {
-          'type' => Optional[Aws_elasticsearch_domain_encrypt_at_rest_238],
+          'type' => Optional[Array[Aws_elasticsearch_domain_encrypt_at_rest_238]],
           'value' => undef
         },
         'endpoint' => {
@@ -12797,11 +11861,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'node_to_node_encryption' => {
-          'type' => Optional[Aws_elasticsearch_domain_node_to_node_encryption_240],
+          'type' => Optional[Array[Aws_elasticsearch_domain_node_to_node_encryption_240]],
           'value' => undef
         },
         'snapshot_options' => {
-          'type' => Optional[Aws_elasticsearch_domain_snapshot_options_241],
+          'type' => Optional[Array[Aws_elasticsearch_domain_snapshot_options_241]],
           'value' => undef
         },
         'tags' => {
@@ -12809,7 +11873,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'vpc_options' => {
-          'type' => Optional[Aws_elasticsearch_domain_vpc_options_242],
+          'type' => Optional[Array[Aws_elasticsearch_domain_vpc_options_242]],
           'value' => undef
         }
       }
@@ -12827,10 +11891,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_cluster_config_235 => {
       attributes => {
-        'aws_elasticsearch_domain_cluster_config_235_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dedicated_master_count' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -12859,10 +11919,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_cognito_options_236 => {
       attributes => {
-        'aws_elasticsearch_domain_cognito_options_236_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -12874,10 +11930,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_ebs_options_237 => {
       attributes => {
-        'aws_elasticsearch_domain_ebs_options_237_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ebs_enabled' => Boolean,
         'iops' => {
           'type' => Optional[Integer],
@@ -12895,10 +11947,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_encrypt_at_rest_238 => {
       attributes => {
-        'aws_elasticsearch_domain_encrypt_at_rest_238_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean,
         'kms_key_id' => {
           'type' => Optional[String],
@@ -12908,10 +11956,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_log_publishing_options_239 => {
       attributes => {
-        'aws_elasticsearch_domain_log_publishing_options_239_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cloudwatch_log_group_arn' => String,
         'enabled' => {
           'type' => Optional[Boolean],
@@ -12922,10 +11966,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_node_to_node_encryption_240 => {
       attributes => {
-        'aws_elasticsearch_domain_node_to_node_encryption_240_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean
       }
     },
@@ -12952,19 +11992,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_elasticsearch_domain_snapshot_options_241 => {
       attributes => {
-        'aws_elasticsearch_domain_snapshot_options_241_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'automated_snapshot_start_hour' => Integer
       }
     },
     Aws_elasticsearch_domain_vpc_options_242 => {
       attributes => {
-        'aws_elasticsearch_domain_vpc_options_242_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'availability_zones' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13042,10 +12074,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_pipeline_content_config_243 => {
       attributes => {
-        'aws_elastictranscoder_pipeline_content_config_243_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => {
           'type' => Optional[String],
           'value' => undef
@@ -13058,10 +12086,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_pipeline_content_config_permissions_244 => {
       attributes => {
-        'aws_elastictranscoder_pipeline_content_config_permissions_244_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13078,10 +12102,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_pipeline_notifications_245 => {
       attributes => {
-        'aws_elastictranscoder_pipeline_notifications_245_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'completed' => {
           'type' => Optional[String],
           'value' => undef
@@ -13102,10 +12122,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_pipeline_thumbnail_config_246 => {
       attributes => {
-        'aws_elastictranscoder_pipeline_thumbnail_config_246_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => {
           'type' => Optional[String],
           'value' => undef
@@ -13118,10 +12134,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_pipeline_thumbnail_config_permissions_247 => {
       attributes => {
-        'aws_elastictranscoder_pipeline_thumbnail_config_permissions_247_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13198,10 +12210,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_preset_audio_248 => {
       attributes => {
-        'aws_elastictranscoder_preset_audio_248_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'audio_packing_mode' => {
           'type' => Optional[String],
           'value' => undef
@@ -13226,10 +12234,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_preset_audio_codec_options_249 => {
       attributes => {
-        'aws_elastictranscoder_preset_audio_codec_options_249_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bit_depth' => {
           'type' => Optional[String],
           'value' => undef
@@ -13250,10 +12254,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_preset_thumbnails_250 => {
       attributes => {
-        'aws_elastictranscoder_preset_thumbnails_250_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aspect_ratio' => {
           'type' => Optional[String],
           'value' => undef
@@ -13290,10 +12290,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_preset_video_251 => {
       attributes => {
-        'aws_elastictranscoder_preset_video_251_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aspect_ratio' => {
           'type' => Optional[String],
           'value' => undef
@@ -13350,10 +12346,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elastictranscoder_preset_video_watermarks_252 => {
       attributes => {
-        'aws_elastictranscoder_preset_video_watermarks_252_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'horizontal_align' => {
           'type' => Optional[String],
           'value' => undef
@@ -13403,7 +12395,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'access_logs' => {
-          'type' => Optional[Aws_elb_access_logs_253],
+          'type' => Optional[Array[Aws_elb_access_logs_253]],
           'value' => undef
         },
         'arn' => {
@@ -13431,7 +12423,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'health_check' => {
-          'type' => Optional[Aws_elb_health_check_254],
+          'type' => Optional[Array[Aws_elb_health_check_254]],
           'value' => undef
         },
         'idle_timeout' => {
@@ -13494,10 +12486,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elb_access_logs_253 => {
       attributes => {
-        'aws_elb_access_logs_253_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => String,
         'bucket_prefix' => {
           'type' => Optional[String],
@@ -13536,10 +12524,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elb_health_check_254 => {
       attributes => {
-        'aws_elb_health_check_254_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'healthy_threshold' => Integer,
         'interval' => Integer,
         'target' => String,
@@ -13549,10 +12533,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_elb_listener_255 => {
       attributes => {
-        'aws_elb_listener_255_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'instance_port' => Integer,
         'instance_protocol' => String,
         'lb_port' => Integer,
@@ -13614,7 +12594,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ec2_attributes' => {
-          'type' => Optional[Aws_emr_cluster_ec2_attributes_257],
+          'type' => Optional[Array[Aws_emr_cluster_ec2_attributes_257]],
           'value' => undef
         },
         'instance_group' => {
@@ -13626,7 +12606,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'kerberos_attributes' => {
-          'type' => Optional[Aws_emr_cluster_kerberos_attributes_260],
+          'type' => Optional[Array[Aws_emr_cluster_kerberos_attributes_260]],
           'value' => undef
         },
         'log_uri' => {
@@ -13653,7 +12633,7 @@ type TerraformAws = TypeSet[{
         },
         'service_role' => String,
         'step' => {
-          'type' => Optional[Aws_emr_cluster_step_261],
+          'type' => Optional[Array[Aws_emr_cluster_step_261]],
           'value' => undef
         },
         'tags' => {
@@ -13683,10 +12663,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_cluster_bootstrap_action_256 => {
       attributes => {
-        'aws_emr_cluster_bootstrap_action_256_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13697,10 +12673,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_cluster_ec2_attributes_257 => {
       attributes => {
-        'aws_emr_cluster_ec2_attributes_257_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'additional_master_security_groups' => {
           'type' => Optional[String],
           'value' => undef
@@ -13734,10 +12706,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_cluster_instance_group_258 => {
       attributes => {
-        'aws_emr_cluster_instance_group_258_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'autoscaling_policy' => {
           'type' => Optional[String],
           'value' => undef
@@ -13768,10 +12736,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_cluster_instance_group_258_ebs_config_259 => {
       attributes => {
-        'aws_emr_cluster_instance_group_258_ebs_config_259_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -13786,10 +12750,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_cluster_kerberos_attributes_260 => {
       attributes => {
-        'aws_emr_cluster_kerberos_attributes_260_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ad_domain_join_password' => {
           'type' => Optional[String],
           'value' => undef
@@ -13808,21 +12768,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_cluster_step_261 => {
       attributes => {
-        'aws_emr_cluster_step_261_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action_on_failure' => String,
-        'hadoop_jar_step' => Aws_emr_cluster_step_261_hadoop_jar_step_262,
+        'hadoop_jar_step' => Array[Aws_emr_cluster_step_261_hadoop_jar_step_262],
         'name' => String
       }
     },
     Aws_emr_cluster_step_261_hadoop_jar_step_262 => {
       attributes => {
-        'aws_emr_cluster_step_261_hadoop_jar_step_262_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13885,10 +12837,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_emr_instance_group_ebs_config_263 => {
       attributes => {
-        'aws_emr_instance_group_ebs_config_263_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -13996,7 +12944,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'name' => String,
-        'routing_strategy' => Aws_gamelift_alias_routing_strategy_264
+        'routing_strategy' => Array[Aws_gamelift_alias_routing_strategy_264]
       }
     },
     Aws_gamelift_aliasHandler => {
@@ -14012,10 +12960,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_gamelift_alias_routing_strategy_264 => {
       attributes => {
-        'aws_gamelift_alias_routing_strategy_264_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fleet_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -14035,7 +12979,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'operating_system' => String,
-        'storage_location' => Aws_gamelift_build_storage_location_265,
+        'storage_location' => Array[Aws_gamelift_build_storage_location_265],
         'version' => {
           'type' => Optional[String],
           'value' => undef
@@ -14055,10 +12999,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_gamelift_build_storage_location_265 => {
       attributes => {
-        'aws_gamelift_build_storage_location_265_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => String,
         'key' => String,
         'role_arn' => String
@@ -14080,7 +13020,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ec2_inbound_permission' => {
-          'type' => Optional[Aws_gamelift_fleet_ec2_inbound_permission_266],
+          'type' => Optional[Array[Aws_gamelift_fleet_ec2_inbound_permission_266]],
           'value' => undef
         },
         'ec2_instance_type' => String,
@@ -14102,11 +13042,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'resource_creation_limit_policy' => {
-          'type' => Optional[Aws_gamelift_fleet_resource_creation_limit_policy_267],
+          'type' => Optional[Array[Aws_gamelift_fleet_resource_creation_limit_policy_267]],
           'value' => undef
         },
         'runtime_configuration' => {
-          'type' => Optional[Aws_gamelift_fleet_runtime_configuration_268],
+          'type' => Optional[Array[Aws_gamelift_fleet_runtime_configuration_268]],
           'value' => undef
         }
       }
@@ -14124,10 +13064,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_gamelift_fleet_ec2_inbound_permission_266 => {
       attributes => {
-        'aws_gamelift_fleet_ec2_inbound_permission_266_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'from_port' => Integer,
         'ip_range' => String,
         'protocol' => String,
@@ -14136,10 +13072,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_gamelift_fleet_resource_creation_limit_policy_267 => {
       attributes => {
-        'aws_gamelift_fleet_resource_creation_limit_policy_267_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'new_game_sessions_per_creator' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -14152,10 +13084,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_gamelift_fleet_runtime_configuration_268 => {
       attributes => {
-        'aws_gamelift_fleet_runtime_configuration_268_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'game_session_activation_timeout_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -14165,17 +13093,13 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'server_process' => {
-          'type' => Optional[Aws_gamelift_fleet_runtime_configuration_268_server_process_269],
+          'type' => Optional[Array[Aws_gamelift_fleet_runtime_configuration_268_server_process_269]],
           'value' => undef
         }
       }
     },
     Aws_gamelift_fleet_runtime_configuration_268_server_process_269 => {
       attributes => {
-        'aws_gamelift_fleet_runtime_configuration_268_server_process_269_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'concurrent_executions' => Integer,
         'launch_path' => String,
         'parameters' => {
@@ -14200,7 +13124,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'player_latency_policy' => {
-          'type' => Optional[Aws_gamelift_game_session_queue_player_latency_policy_270],
+          'type' => Optional[Array[Aws_gamelift_game_session_queue_player_latency_policy_270]],
           'value' => undef
         },
         'timeout_in_seconds' => {
@@ -14222,10 +13146,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_gamelift_game_session_queue_player_latency_policy_270 => {
       attributes => {
-        'aws_gamelift_game_session_queue_player_latency_policy_270_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'maximum_individual_player_latency_milliseconds' => Integer,
         'policy_duration_seconds' => {
           'type' => Optional[Integer],
@@ -14253,7 +13173,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'notification' => {
-          'type' => Optional[Aws_glacier_vault_notification_271],
+          'type' => Optional[Array[Aws_glacier_vault_notification_271]],
           'value' => undef
         },
         'tags' => {
@@ -14301,10 +13221,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glacier_vault_notification_271 => {
       attributes => {
-        'aws_glacier_vault_notification_271_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'events' => Array[String],
         'sns_topic' => String
       }
@@ -14316,7 +13232,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'attributes' => {
-          'type' => Optional[Aws_globalaccelerator_accelerator_attributes_272],
+          'type' => Optional[Array[Aws_globalaccelerator_accelerator_attributes_272]],
           'value' => undef
         },
         'enabled' => {
@@ -14328,7 +13244,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ip_sets' => {
-          'type' => Optional[Aws_globalaccelerator_accelerator_ip_sets_273],
+          'type' => Optional[Array[Aws_globalaccelerator_accelerator_ip_sets_273]],
           'value' => undef
         },
         'name' => String
@@ -14347,10 +13263,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_globalaccelerator_accelerator_attributes_272 => {
       attributes => {
-        'aws_globalaccelerator_accelerator_attributes_272_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'flow_logs_enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -14367,10 +13279,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_globalaccelerator_accelerator_ip_sets_273 => {
       attributes => {
-        'aws_globalaccelerator_accelerator_ip_sets_273_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_addresses' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -14442,7 +13350,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'partition_keys' => {
-          'type' => Optional[Aws_glue_catalog_table_partition_keys_274],
+          'type' => Optional[Array[Aws_glue_catalog_table_partition_keys_274]],
           'value' => undef
         },
         'retention' => {
@@ -14450,7 +13358,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'storage_descriptor' => {
-          'type' => Optional[Aws_glue_catalog_table_storage_descriptor_275],
+          'type' => Optional[Array[Aws_glue_catalog_table_storage_descriptor_275]],
           'value' => undef
         },
         'table_type' => {
@@ -14480,10 +13388,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_catalog_table_partition_keys_274 => {
       attributes => {
-        'aws_glue_catalog_table_partition_keys_274_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'comment' => {
           'type' => Optional[String],
           'value' => undef
@@ -14497,16 +13401,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_catalog_table_storage_descriptor_275 => {
       attributes => {
-        'aws_glue_catalog_table_storage_descriptor_275_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_columns' => {
           'type' => Optional[Array[String]],
           'value' => undef
         },
         'columns' => {
-          'type' => Optional[Aws_glue_catalog_table_storage_descriptor_275_columns_276],
+          'type' => Optional[Array[Aws_glue_catalog_table_storage_descriptor_275_columns_276]],
           'value' => undef
         },
         'compressed' => {
@@ -14534,15 +13434,15 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ser_de_info' => {
-          'type' => Optional[Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277],
+          'type' => Optional[Array[Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277]],
           'value' => undef
         },
         'skewed_info' => {
-          'type' => Optional[Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278],
+          'type' => Optional[Array[Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278]],
           'value' => undef
         },
         'sort_columns' => {
-          'type' => Optional[Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279],
+          'type' => Optional[Array[Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279]],
           'value' => undef
         },
         'stored_as_sub_directories' => {
@@ -14553,10 +13453,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_catalog_table_storage_descriptor_275_columns_276 => {
       attributes => {
-        'aws_glue_catalog_table_storage_descriptor_275_columns_276_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'comment' => {
           'type' => Optional[String],
           'value' => undef
@@ -14570,10 +13466,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277 => {
       attributes => {
-        'aws_glue_catalog_table_storage_descriptor_275_ser_de_info_277_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14590,10 +13482,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_catalog_table_storage_descriptor_275_skewed_info_278 => {
       attributes => {
-        'aws_glue_catalog_table_storage_descriptor_275_skewed_info_278_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'skewed_column_names' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -14610,10 +13498,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_catalog_table_storage_descriptor_275_sort_columns_279 => {
       attributes => {
-        'aws_glue_catalog_table_storage_descriptor_275_sort_columns_279_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'column' => String,
         'sort_order' => Integer
       }
@@ -14625,16 +13509,16 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'grok_classifier' => {
-          'type' => Optional[Aws_glue_classifier_grok_classifier_280],
+          'type' => Optional[Array[Aws_glue_classifier_grok_classifier_280]],
           'value' => undef
         },
         'json_classifier' => {
-          'type' => Optional[Aws_glue_classifier_json_classifier_281],
+          'type' => Optional[Array[Aws_glue_classifier_json_classifier_281]],
           'value' => undef
         },
         'name' => String,
         'xml_classifier' => {
-          'type' => Optional[Aws_glue_classifier_xml_classifier_282],
+          'type' => Optional[Array[Aws_glue_classifier_xml_classifier_282]],
           'value' => undef
         }
       }
@@ -14652,10 +13536,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_classifier_grok_classifier_280 => {
       attributes => {
-        'aws_glue_classifier_grok_classifier_280_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'classification' => String,
         'custom_patterns' => {
           'type' => Optional[String],
@@ -14666,19 +13546,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_classifier_json_classifier_281 => {
       attributes => {
-        'aws_glue_classifier_json_classifier_281_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'json_path' => String
       }
     },
     Aws_glue_classifier_xml_classifier_282 => {
       attributes => {
-        'aws_glue_classifier_xml_classifier_282_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'classification' => String,
         'row_tag' => String
       }
@@ -14708,7 +13580,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'physical_connection_requirements' => {
-          'type' => Optional[Aws_glue_connection_physical_connection_requirements_283],
+          'type' => Optional[Array[Aws_glue_connection_physical_connection_requirements_283]],
           'value' => undef
         }
       }
@@ -14726,10 +13598,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_connection_physical_connection_requirements_283 => {
       attributes => {
-        'aws_glue_connection_physical_connection_requirements_283_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'availability_zone' => {
           'type' => Optional[String],
           'value' => undef
@@ -14764,17 +13632,17 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'dynamodb_target' => {
-          'type' => Optional[Aws_glue_crawler_dynamodb_target_284],
+          'type' => Optional[Array[Aws_glue_crawler_dynamodb_target_284]],
           'value' => undef
         },
         'jdbc_target' => {
-          'type' => Optional[Aws_glue_crawler_jdbc_target_285],
+          'type' => Optional[Array[Aws_glue_crawler_jdbc_target_285]],
           'value' => undef
         },
         'name' => String,
         'role' => String,
         's3_target' => {
-          'type' => Optional[Aws_glue_crawler_s3_target_286],
+          'type' => Optional[Array[Aws_glue_crawler_s3_target_286]],
           'value' => undef
         },
         'schedule' => {
@@ -14782,7 +13650,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'schema_change_policy' => {
-          'type' => Optional[Aws_glue_crawler_schema_change_policy_287],
+          'type' => Optional[Array[Aws_glue_crawler_schema_change_policy_287]],
           'value' => undef
         },
         'security_configuration' => {
@@ -14808,19 +13676,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_crawler_dynamodb_target_284 => {
       attributes => {
-        'aws_glue_crawler_dynamodb_target_284_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String
       }
     },
     Aws_glue_crawler_jdbc_target_285 => {
       attributes => {
-        'aws_glue_crawler_jdbc_target_285_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'connection_name' => String,
         'exclusions' => {
           'type' => Optional[Array[String]],
@@ -14831,10 +13691,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_crawler_s3_target_286 => {
       attributes => {
-        'aws_glue_crawler_s3_target_286_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exclusions' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -14844,10 +13700,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_crawler_schema_change_policy_287 => {
       attributes => {
-        'aws_glue_crawler_schema_change_policy_287_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_behavior' => {
           'type' => Optional[String],
           'value' => undef
@@ -14868,7 +13720,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[Integer],
           'value' => undef
         },
-        'command' => Aws_glue_job_command_288,
+        'command' => Array[Aws_glue_job_command_288],
         'connections' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -14882,7 +13734,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'execution_property' => {
-          'type' => Optional[Aws_glue_job_execution_property_289],
+          'type' => Optional[Array[Aws_glue_job_execution_property_289]],
           'value' => undef
         },
         'max_retries' => {
@@ -14914,10 +13766,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_job_command_288 => {
       attributes => {
-        'aws_glue_job_command_288_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14927,10 +13775,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_job_execution_property_289 => {
       attributes => {
-        'aws_glue_job_execution_property_289_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_concurrent_runs' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -14943,7 +13787,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'encryption_configuration' => Aws_glue_security_configuration_encryption_configuration_290,
+        'encryption_configuration' => Array[Aws_glue_security_configuration_encryption_configuration_290],
         'name' => String
       }
     },
@@ -14960,21 +13804,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_security_configuration_encryption_configuration_290 => {
       attributes => {
-        'aws_glue_security_configuration_encryption_configuration_290_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'cloudwatch_encryption' => Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291,
-        'job_bookmarks_encryption' => Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292,
-        's3_encryption' => Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293
+        'cloudwatch_encryption' => Array[Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291],
+        'job_bookmarks_encryption' => Array[Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292],
+        's3_encryption' => Array[Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293]
       }
     },
     Aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291 => {
       attributes => {
-        'aws_glue_security_configuration_encryption_configuration_290_cloudwatch_encryption_291_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cloudwatch_encryption_mode' => {
           'type' => Optional[String],
           'value' => undef
@@ -14987,10 +13823,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292 => {
       attributes => {
-        'aws_glue_security_configuration_encryption_configuration_290_job_bookmarks_encryption_292_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'job_bookmarks_encryption_mode' => {
           'type' => Optional[String],
           'value' => undef
@@ -15003,10 +13835,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293 => {
       attributes => {
-        'aws_glue_security_configuration_encryption_configuration_290_s3_encryption_293_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'kms_key_arn' => {
           'type' => Optional[String],
           'value' => undef
@@ -15023,7 +13851,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'actions' => Aws_glue_trigger_actions_294,
+        'actions' => Array[Aws_glue_trigger_actions_294],
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -15034,7 +13862,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'predicate' => {
-          'type' => Optional[Aws_glue_trigger_predicate_295],
+          'type' => Optional[Array[Aws_glue_trigger_predicate_295]],
           'value' => undef
         },
         'schedule' => {
@@ -15057,10 +13885,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_trigger_actions_294 => {
       attributes => {
-        'aws_glue_trigger_actions_294_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'arguments' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -15074,11 +13898,7 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_trigger_predicate_295 => {
       attributes => {
-        'aws_glue_trigger_predicate_295_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'conditions' => Aws_glue_trigger_predicate_295_conditions_296,
+        'conditions' => Array[Aws_glue_trigger_predicate_295_conditions_296],
         'logical' => {
           'type' => Optional[String],
           'value' => undef
@@ -15087,10 +13907,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_glue_trigger_predicate_295_conditions_296 => {
       attributes => {
-        'aws_glue_trigger_predicate_295_conditions_296_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'job_name' => String,
         'logical_operator' => {
           'type' => Optional[String],
@@ -16122,7 +14938,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'credit_specification' => {
-          'type' => Optional[Aws_instance_credit_specification_297],
+          'type' => Optional[Array[Aws_instance_credit_specification_297]],
           'value' => undef
         },
         'disable_api_termination' => {
@@ -16215,7 +15031,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'root_block_device' => {
-          'type' => Optional[Aws_instance_root_block_device_301],
+          'type' => Optional[Array[Aws_instance_root_block_device_301]],
           'value' => undef
         },
         'security_groups' => {
@@ -16269,10 +15085,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_instance_credit_specification_297 => {
       attributes => {
-        'aws_instance_credit_specification_297_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu_credits' => {
           'type' => Optional[String],
           'value' => undef
@@ -16281,10 +15093,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_instance_ebs_block_device_298 => {
       attributes => {
-        'aws_instance_ebs_block_device_298_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -16318,10 +15126,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_instance_ephemeral_block_device_299 => {
       attributes => {
-        'aws_instance_ephemeral_block_device_299_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => String,
         'no_device' => {
           'type' => Optional[Boolean],
@@ -16335,10 +15139,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_instance_network_interface_300 => {
       attributes => {
-        'aws_instance_network_interface_300_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -16349,10 +15149,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_instance_root_block_device_301 => {
       attributes => {
-        'aws_instance_root_block_device_301_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -16558,7 +15354,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'properties' => {
-          'type' => Optional[Aws_iot_thing_type_properties_302],
+          'type' => Optional[Array[Aws_iot_thing_type_properties_302]],
           'value' => undef
         }
       }
@@ -16576,10 +15372,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_thing_type_properties_302 => {
       attributes => {
-        'aws_iot_thing_type_properties_302_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -16667,10 +15459,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_cloudwatch_alarm_303 => {
       attributes => {
-        'aws_iot_topic_rule_cloudwatch_alarm_303_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'alarm_name' => String,
         'role_arn' => String,
         'state_reason' => String,
@@ -16679,10 +15467,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_cloudwatch_metric_304 => {
       attributes => {
-        'aws_iot_topic_rule_cloudwatch_metric_304_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'metric_name' => String,
         'metric_namespace' => String,
         'metric_timestamp' => {
@@ -16696,10 +15480,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_dynamodb_305 => {
       attributes => {
-        'aws_iot_topic_rule_dynamodb_305_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'hash_key_field' => String,
         'hash_key_type' => {
           'type' => Optional[String],
@@ -16722,10 +15502,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_elasticsearch_306 => {
       attributes => {
-        'aws_iot_topic_rule_elasticsearch_306_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoint' => String,
         'id' => String,
         'index' => String,
@@ -16735,10 +15511,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_firehose_307 => {
       attributes => {
-        'aws_iot_topic_rule_firehose_307_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delivery_stream_name' => String,
         'role_arn' => String,
         'separator' => {
@@ -16749,10 +15521,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_kinesis_308 => {
       attributes => {
-        'aws_iot_topic_rule_kinesis_308_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'partition_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -16763,29 +15531,17 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_lambda_309 => {
       attributes => {
-        'aws_iot_topic_rule_lambda_309_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'function_arn' => String
       }
     },
     Aws_iot_topic_rule_republish_310 => {
       attributes => {
-        'aws_iot_topic_rule_republish_310_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'role_arn' => String,
         'topic' => String
       }
     },
     Aws_iot_topic_rule_s3_311 => {
       attributes => {
-        'aws_iot_topic_rule_s3_311_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_name' => String,
         'key' => String,
         'role_arn' => String
@@ -16793,10 +15549,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_sns_312 => {
       attributes => {
-        'aws_iot_topic_rule_sns_312_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'message_format' => {
           'type' => Optional[String],
           'value' => undef
@@ -16807,10 +15559,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_iot_topic_rule_sqs_313 => {
       attributes => {
-        'aws_iot_topic_rule_sqs_313_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'queue_url' => String,
         'role_arn' => String,
         'use_base64' => Boolean
@@ -16859,7 +15607,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cloudwatch_logging_options' => {
-          'type' => Optional[Aws_kinesis_analytics_application_cloudwatch_logging_options_314],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_cloudwatch_logging_options_314]],
           'value' => undef
         },
         'code' => {
@@ -16875,7 +15623,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'inputs' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315]],
           'value' => undef
         },
         'last_update_timestamp' => {
@@ -16884,11 +15632,11 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'outputs' => {
-          'type' => Optional[Aws_kinesis_analytics_application_outputs_328],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_outputs_328]],
           'value' => undef
         },
         'reference_data_sources' => {
-          'type' => Optional[Aws_kinesis_analytics_application_reference_data_sources_333],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_reference_data_sources_333]],
           'value' => undef
         },
         'status' => {
@@ -16914,10 +15662,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_cloudwatch_logging_options_314 => {
       attributes => {
-        'aws_kinesis_analytics_application_cloudwatch_logging_options_314_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => {
           'type' => Optional[String],
           'value' => undef
@@ -16928,34 +15672,30 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_inputs_315 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => {
           'type' => Optional[String],
           'value' => undef
         },
         'kinesis_firehose' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316]],
           'value' => undef
         },
         'kinesis_stream' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317]],
           'value' => undef
         },
         'name_prefix' => String,
         'parallelism' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_parallelism_318],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_parallelism_318]],
           'value' => undef
         },
         'processing_configuration' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_processing_configuration_319],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_processing_configuration_319]],
           'value' => undef
         },
-        'schema' => Aws_kinesis_analytics_application_inputs_315_schema_321,
+        'schema' => Array[Aws_kinesis_analytics_application_inputs_315_schema_321],
         'starting_position_configuration' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327]],
           'value' => undef
         },
         'stream_names' => {
@@ -16966,72 +15706,44 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_kinesis_firehose_316_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_analytics_application_inputs_315_kinesis_stream_317 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_kinesis_stream_317_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_analytics_application_inputs_315_parallelism_318 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_parallelism_318_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer
       }
     },
     Aws_kinesis_analytics_application_inputs_315_processing_configuration_319 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_processing_configuration_319_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'lambda' => Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320
+        'lambda' => Array[Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320]
       }
     },
     Aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_processing_configuration_319_lambda_320_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_analytics_application_inputs_315_schema_321 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_schema_321_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'record_columns' => Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322,
+        'record_columns' => Array[Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322],
         'record_encoding' => {
           'type' => Optional[String],
           'value' => undef
         },
-        'record_format' => Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323
+        'record_format' => Array[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323]
       }
     },
     Aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_schema_321_record_columns_322_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mapping' => {
           'type' => Optional[String],
           'value' => undef
@@ -17042,12 +15754,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mapping_parameters' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324]],
           'value' => undef
         },
         'record_format_type' => {
@@ -17058,45 +15766,29 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'csv' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325]],
           'value' => undef
         },
         'json' => {
-          'type' => Optional[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_csv_325_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'record_column_delimiter' => String,
         'record_row_delimiter' => String
       }
     },
     Aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_schema_321_record_format_323_mapping_parameters_324_json_326_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'record_row_path' => String
       }
     },
     Aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327 => {
       attributes => {
-        'aws_kinesis_analytics_application_inputs_315_starting_position_configuration_327_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'starting_position' => {
           'type' => Optional[String],
           'value' => undef
@@ -17105,66 +15797,46 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_outputs_328 => {
       attributes => {
-        'aws_kinesis_analytics_application_outputs_328_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => {
           'type' => Optional[String],
           'value' => undef
         },
         'kinesis_firehose' => {
-          'type' => Optional[Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329]],
           'value' => undef
         },
         'kinesis_stream' => {
-          'type' => Optional[Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330]],
           'value' => undef
         },
         'lambda' => {
-          'type' => Optional[Aws_kinesis_analytics_application_outputs_328_lambda_331],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_outputs_328_lambda_331]],
           'value' => undef
         },
         'name' => String,
-        'schema' => Aws_kinesis_analytics_application_outputs_328_schema_332
+        'schema' => Array[Aws_kinesis_analytics_application_outputs_328_schema_332]
       }
     },
     Aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329 => {
       attributes => {
-        'aws_kinesis_analytics_application_outputs_328_kinesis_firehose_329_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_analytics_application_outputs_328_kinesis_stream_330 => {
       attributes => {
-        'aws_kinesis_analytics_application_outputs_328_kinesis_stream_330_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_analytics_application_outputs_328_lambda_331 => {
       attributes => {
-        'aws_kinesis_analytics_application_outputs_328_lambda_331_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_analytics_application_outputs_328_schema_332 => {
       attributes => {
-        'aws_kinesis_analytics_application_outputs_328_schema_332_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'record_format_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -17173,25 +15845,17 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_reference_data_sources_333 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => {
           'type' => Optional[String],
           'value' => undef
         },
-        's3' => Aws_kinesis_analytics_application_reference_data_sources_333_s3_334,
-        'schema' => Aws_kinesis_analytics_application_reference_data_sources_333_schema_335,
+        's3' => Array[Aws_kinesis_analytics_application_reference_data_sources_333_s3_334],
+        'schema' => Array[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335],
         'table_name' => String
       }
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_s3_334 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_s3_334_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_arn' => String,
         'file_key' => String,
         'role_arn' => String
@@ -17199,24 +15863,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_schema_335 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_schema_335_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'record_columns' => Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336,
+        'record_columns' => Array[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336],
         'record_encoding' => {
           'type' => Optional[String],
           'value' => undef
         },
-        'record_format' => Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337
+        'record_format' => Array[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337]
       }
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_columns_336_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mapping' => {
           'type' => Optional[String],
           'value' => undef
@@ -17227,12 +15883,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mapping_parameters' => {
-          'type' => Optional[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338]],
           'value' => undef
         },
         'record_format_type' => {
@@ -17243,36 +15895,24 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'csv' => {
-          'type' => Optional[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339]],
           'value' => undef
         },
         'json' => {
-          'type' => Optional[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340],
+          'type' => Optional[Array[Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_csv_339_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'record_column_delimiter' => String,
         'record_row_delimiter' => String
       }
     },
     Aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340 => {
       attributes => {
-        'aws_kinesis_analytics_application_reference_data_sources_333_schema_335_record_format_337_mapping_parameters_338_json_340_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'record_row_path' => String
       }
     },
@@ -17292,28 +15932,28 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'elasticsearch_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341]],
           'value' => undef
         },
         'extended_s3_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346]],
           'value' => undef
         },
         'kinesis_source_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363]],
           'value' => undef
         },
         'name' => String,
         'redshift_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364]],
           'value' => undef
         },
         's3_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_s3_configuration_371],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_s3_configuration_371]],
           'value' => undef
         },
         'splunk_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373]],
           'value' => undef
         },
         'tags' => {
@@ -17339,10 +15979,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'buffering_interval' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -17362,7 +15998,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'processing_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343]],
           'value' => undef
         },
         'retry_duration' => {
@@ -17382,10 +16018,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_cloudwatch_logging_options_342 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_cloudwatch_logging_options_342_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -17402,28 +16034,20 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'processors' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameters' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345]],
           'value' => undef
         },
         'type' => String
@@ -17431,20 +16055,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_elasticsearch_configuration_341_processing_configuration_343_processors_344_parameters_345_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameter_name' => String,
         'parameter_value' => String
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_arn' => String,
         'buffer_interval' => {
           'type' => Optional[Integer],
@@ -17463,7 +16079,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'data_format_conversion_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348]],
           'value' => undef
         },
         'error_output_prefix' => {
@@ -17479,12 +16095,12 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'processing_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358]],
           'value' => undef
         },
         'role_arn' => String,
         's3_backup_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361]],
           'value' => undef
         },
         's3_backup_mode' => {
@@ -17495,10 +16111,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_cloudwatch_logging_options_347 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_cloudwatch_logging_options_347_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -17515,50 +16127,34 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
-        'input_format_configuration' => Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349,
-        'output_format_configuration' => Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353,
-        'schema_configuration' => Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357
+        'input_format_configuration' => Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349],
+        'output_format_configuration' => Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353],
+        'schema_configuration' => Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357]
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'deserializer' => Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350
+        'deserializer' => Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350]
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'hive_json_ser_de' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351]],
           'value' => undef
         },
         'open_x_json_ser_de' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_hive_json_ser_de_351_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'timestamp_formats' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -17567,10 +16163,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_input_format_configuration_349_deserializer_350_open_x_json_ser_de_352_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'case_insensitive' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -17587,35 +16179,23 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'serializer' => Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354
+        'serializer' => Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354]
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'orc_ser_de' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355]],
           'value' => undef
         },
         'parquet_ser_de' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_orc_ser_de_355_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'block_size_bytes' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -17660,10 +16240,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_output_format_configuration_353_serializer_354_parquet_ser_de_356_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'block_size_bytes' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -17692,10 +16268,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_data_format_conversion_configuration_348_schema_configuration_357_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'catalog_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -17715,28 +16287,20 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'processors' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameters' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360]],
           'value' => undef
         },
         'type' => String
@@ -17744,20 +16308,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_processing_configuration_358_processors_359_parameters_360_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameter_name' => String,
         'parameter_value' => String
       }
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_arn' => String,
         'buffer_interval' => {
           'type' => Optional[Integer],
@@ -17788,10 +16344,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361_cloudwatch_logging_options_362 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_extended_s3_configuration_346_s3_backup_configuration_361_cloudwatch_logging_options_362_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -17808,20 +16360,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_kinesis_source_configuration_363_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'kinesis_stream_arn' => String,
         'role_arn' => String
       }
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cloudwatch_logging_options' => {
           'type' => Optional[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_logging_options_365],
           'value' => undef
@@ -17838,7 +16382,7 @@ type TerraformAws = TypeSet[{
         'data_table_name' => String,
         'password' => String,
         'processing_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366]],
           'value' => undef
         },
         'retry_duration' => {
@@ -17847,7 +16391,7 @@ type TerraformAws = TypeSet[{
         },
         'role_arn' => String,
         's3_backup_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369]],
           'value' => undef
         },
         's3_backup_mode' => {
@@ -17859,10 +16403,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_logging_options_365 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_cloudwatch_logging_options_365_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -17879,28 +16419,20 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'processors' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameters' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368]],
           'value' => undef
         },
         'type' => String
@@ -17908,20 +16440,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_processing_configuration_366_processors_367_parameters_368_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameter_name' => String,
         'parameter_value' => String
       }
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_arn' => String,
         'buffer_interval' => {
           'type' => Optional[Integer],
@@ -17952,10 +16476,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369_cloudwatch_logging_options_370 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_redshift_configuration_364_s3_backup_configuration_369_cloudwatch_logging_options_370_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -17972,10 +16492,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_s3_configuration_371 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_s3_configuration_371_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_arn' => String,
         'buffer_interval' => {
           'type' => Optional[Integer],
@@ -18006,10 +16522,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_s3_configuration_371_cloudwatch_logging_options_372 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_s3_configuration_371_cloudwatch_logging_options_372_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -18026,10 +16538,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_splunk_configuration_373 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_splunk_configuration_373_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cloudwatch_logging_options' => {
           'type' => Optional[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_logging_options_374],
           'value' => undef
@@ -18045,7 +16553,7 @@ type TerraformAws = TypeSet[{
         },
         'hec_token' => String,
         'processing_configuration' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375]],
           'value' => undef
         },
         'retry_duration' => {
@@ -18060,10 +16568,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_logging_options_374 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_splunk_configuration_373_cloudwatch_logging_options_374_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -18080,28 +16584,20 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'processors' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376]],
           'value' => undef
         }
       }
     },
     Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameters' => {
-          'type' => Optional[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377],
+          'type' => Optional[Array[Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377]],
           'value' => undef
         },
         'type' => String
@@ -18109,10 +16605,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377 => {
       attributes => {
-        'aws_kinesis_firehose_delivery_stream_splunk_configuration_373_processing_configuration_375_processors_376_parameters_377_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'parameter_name' => String,
         'parameter_value' => String
       }
@@ -18250,10 +16742,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_kms_grant_constraints_378 => {
       attributes => {
-        'aws_kms_grant_constraints_378_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'encryption_context_equals' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -18341,7 +16829,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'routing_config' => {
-          'type' => Optional[Aws_lambda_alias_routing_config_379],
+          'type' => Optional[Array[Aws_lambda_alias_routing_config_379]],
           'value' => undef
         }
       }
@@ -18359,10 +16847,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lambda_alias_routing_config_379 => {
       attributes => {
-        'aws_lambda_alias_routing_config_379_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'additional_version_weights' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -18441,7 +16925,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'dead_letter_config' => {
-          'type' => Optional[Aws_lambda_function_dead_letter_config_380],
+          'type' => Optional[Array[Aws_lambda_function_dead_letter_config_380]],
           'value' => undef
         },
         'description' => {
@@ -18449,7 +16933,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'environment' => {
-          'type' => Optional[Aws_lambda_function_environment_381],
+          'type' => Optional[Array[Aws_lambda_function_environment_381]],
           'value' => undef
         },
         'filename' => {
@@ -18521,7 +17005,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'tracing_config' => {
-          'type' => Optional[Aws_lambda_function_tracing_config_382],
+          'type' => Optional[Array[Aws_lambda_function_tracing_config_382]],
           'value' => undef
         },
         'version' => {
@@ -18529,7 +17013,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'vpc_config' => {
-          'type' => Optional[Aws_lambda_function_vpc_config_383],
+          'type' => Optional[Array[Aws_lambda_function_vpc_config_383]],
           'value' => undef
         }
       }
@@ -18547,19 +17031,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_lambda_function_dead_letter_config_380 => {
       attributes => {
-        'aws_lambda_function_dead_letter_config_380_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'target_arn' => String
       }
     },
     Aws_lambda_function_environment_381 => {
       attributes => {
-        'aws_lambda_function_environment_381_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'variables' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -18568,19 +17044,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_lambda_function_tracing_config_382 => {
       attributes => {
-        'aws_lambda_function_tracing_config_382_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mode' => String
       }
     },
     Aws_lambda_function_vpc_config_383 => {
       attributes => {
-        'aws_lambda_function_vpc_config_383_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'security_group_ids' => Array[String],
         'subnet_ids' => Array[String],
         'vpc_id' => {
@@ -18756,7 +17224,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'root_block_device' => {
-          'type' => Optional[Aws_launch_configuration_root_block_device_386],
+          'type' => Optional[Array[Aws_launch_configuration_root_block_device_386]],
           'value' => undef
         },
         'security_groups' => {
@@ -18798,10 +17266,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_configuration_ebs_block_device_384 => {
       attributes => {
-        'aws_launch_configuration_ebs_block_device_384_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -18835,20 +17299,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_configuration_ephemeral_block_device_385 => {
       attributes => {
-        'aws_launch_configuration_ephemeral_block_device_385_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => String,
         'virtual_name' => String
       }
     },
     Aws_launch_configuration_root_block_device_386 => {
       attributes => {
-        'aws_launch_configuration_root_block_device_386_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -18878,15 +17334,15 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'block_device_mappings' => {
-          'type' => Optional[Aws_launch_template_block_device_mappings_387],
+          'type' => Optional[Array[Aws_launch_template_block_device_mappings_387]],
           'value' => undef
         },
         'capacity_reservation_specification' => {
-          'type' => Optional[Aws_launch_template_capacity_reservation_specification_389],
+          'type' => Optional[Array[Aws_launch_template_capacity_reservation_specification_389]],
           'value' => undef
         },
         'credit_specification' => {
-          'type' => Optional[Aws_launch_template_credit_specification_391],
+          'type' => Optional[Array[Aws_launch_template_credit_specification_391]],
           'value' => undef
         },
         'default_version' => {
@@ -18906,11 +17362,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'elastic_gpu_specifications' => {
-          'type' => Optional[Aws_launch_template_elastic_gpu_specifications_392],
+          'type' => Optional[Array[Aws_launch_template_elastic_gpu_specifications_392]],
           'value' => undef
         },
         'iam_instance_profile' => {
-          'type' => Optional[Aws_launch_template_iam_instance_profile_393],
+          'type' => Optional[Array[Aws_launch_template_iam_instance_profile_393]],
           'value' => undef
         },
         'image_id' => {
@@ -18922,7 +17378,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'instance_market_options' => {
-          'type' => Optional[Aws_launch_template_instance_market_options_394],
+          'type' => Optional[Array[Aws_launch_template_instance_market_options_394]],
           'value' => undef
         },
         'instance_type' => {
@@ -18946,7 +17402,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'monitoring' => {
-          'type' => Optional[Aws_launch_template_monitoring_397],
+          'type' => Optional[Array[Aws_launch_template_monitoring_397]],
           'value' => undef
         },
         'name' => {
@@ -18958,11 +17414,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'network_interfaces' => {
-          'type' => Optional[Aws_launch_template_network_interfaces_398],
+          'type' => Optional[Array[Aws_launch_template_network_interfaces_398]],
           'value' => undef
         },
         'placement' => {
-          'type' => Optional[Aws_launch_template_placement_399],
+          'type' => Optional[Array[Aws_launch_template_placement_399]],
           'value' => undef
         },
         'ram_disk_id' => {
@@ -18974,7 +17430,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'tag_specifications' => {
-          'type' => Optional[Aws_launch_template_tag_specifications_400],
+          'type' => Optional[Array[Aws_launch_template_tag_specifications_400]],
           'value' => undef
         },
         'tags' => {
@@ -19004,16 +17460,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_block_device_mappings_387 => {
       attributes => {
-        'aws_launch_template_block_device_mappings_387_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => {
           'type' => Optional[String],
           'value' => undef
         },
         'ebs' => {
-          'type' => Optional[Aws_launch_template_block_device_mappings_387_ebs_388],
+          'type' => Optional[Array[Aws_launch_template_block_device_mappings_387_ebs_388]],
           'value' => undef
         },
         'no_device' => {
@@ -19028,10 +17480,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_block_device_mappings_387_ebs_388 => {
       attributes => {
-        'aws_launch_template_block_device_mappings_387_ebs_388_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[String],
           'value' => undef
@@ -19064,26 +17512,18 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_capacity_reservation_specification_389 => {
       attributes => {
-        'aws_launch_template_capacity_reservation_specification_389_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'capacity_reservation_preference' => {
           'type' => Optional[String],
           'value' => undef
         },
         'capacity_reservation_target' => {
-          'type' => Optional[Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390],
+          'type' => Optional[Array[Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390]],
           'value' => undef
         }
       }
     },
     Aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390 => {
       attributes => {
-        'aws_launch_template_capacity_reservation_specification_389_capacity_reservation_target_390_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'capacity_reservation_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -19092,10 +17532,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_credit_specification_391 => {
       attributes => {
-        'aws_launch_template_credit_specification_391_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu_credits' => {
           'type' => Optional[String],
           'value' => undef
@@ -19104,19 +17540,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_elastic_gpu_specifications_392 => {
       attributes => {
-        'aws_launch_template_elastic_gpu_specifications_392_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_launch_template_iam_instance_profile_393 => {
       attributes => {
-        'aws_launch_template_iam_instance_profile_393_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'arn' => {
           'type' => Optional[String],
           'value' => undef
@@ -19129,26 +17557,18 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_instance_market_options_394 => {
       attributes => {
-        'aws_launch_template_instance_market_options_394_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'market_type' => {
           'type' => Optional[String],
           'value' => undef
         },
         'spot_options' => {
-          'type' => Optional[Aws_launch_template_instance_market_options_394_spot_options_395],
+          'type' => Optional[Array[Aws_launch_template_instance_market_options_394_spot_options_395]],
           'value' => undef
         }
       }
     },
     Aws_launch_template_instance_market_options_394_spot_options_395 => {
       attributes => {
-        'aws_launch_template_instance_market_options_394_spot_options_395_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'block_duration_minutes' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -19173,19 +17593,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_license_specification_396 => {
       attributes => {
-        'aws_launch_template_license_specification_396_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'license_configuration_arn' => String
       }
     },
     Aws_launch_template_monitoring_397 => {
       attributes => {
-        'aws_launch_template_monitoring_397_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -19194,10 +17606,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_network_interfaces_398 => {
       attributes => {
-        'aws_launch_template_network_interfaces_398_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'associate_public_ip_address' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -19250,10 +17658,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_placement_399 => {
       attributes => {
-        'aws_launch_template_placement_399_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'affinity' => {
           'type' => Optional[String],
           'value' => undef
@@ -19282,10 +17686,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_launch_template_tag_specifications_400 => {
       attributes => {
-        'aws_launch_template_tag_specifications_400_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'resource_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -19303,7 +17703,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'access_logs' => {
-          'type' => Optional[Aws_lb_access_logs_401],
+          'type' => Optional[Array[Aws_lb_access_logs_401]],
           'value' => undef
         },
         'arn' => {
@@ -19393,10 +17793,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_access_logs_401 => {
       attributes => {
-        'aws_lb_access_logs_401_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => String,
         'enabled' => {
           'type' => Optional[Boolean],
@@ -19448,7 +17844,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'default_action' => Aws_lb_listener_default_action_403,
+        'default_action' => Array[Aws_lb_listener_default_action_403],
         'load_balancer_arn' => String,
         'port' => Integer,
         'protocol' => {
@@ -19495,20 +17891,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_default_action_403 => {
       attributes => {
-        'aws_lb_listener_default_action_403_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authenticate_cognito' => {
-          'type' => Optional[Aws_lb_listener_default_action_403_authenticate_cognito_404],
+          'type' => Optional[Array[Aws_lb_listener_default_action_403_authenticate_cognito_404]],
           'value' => undef
         },
         'authenticate_oidc' => {
-          'type' => Optional[Aws_lb_listener_default_action_403_authenticate_oidc_405],
+          'type' => Optional[Array[Aws_lb_listener_default_action_403_authenticate_oidc_405]],
           'value' => undef
         },
         'fixed_response' => {
-          'type' => Optional[Aws_lb_listener_default_action_403_fixed_response_406],
+          'type' => Optional[Array[Aws_lb_listener_default_action_403_fixed_response_406]],
           'value' => undef
         },
         'order' => {
@@ -19516,7 +17908,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'redirect' => {
-          'type' => Optional[Aws_lb_listener_default_action_403_redirect_407],
+          'type' => Optional[Array[Aws_lb_listener_default_action_403_redirect_407]],
           'value' => undef
         },
         'target_group_arn' => {
@@ -19528,10 +17920,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_default_action_403_authenticate_cognito_404 => {
       attributes => {
-        'aws_lb_listener_default_action_403_authenticate_cognito_404_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -19559,10 +17947,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_default_action_403_authenticate_oidc_405 => {
       attributes => {
-        'aws_lb_listener_default_action_403_authenticate_oidc_405_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -19593,10 +17977,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_default_action_403_fixed_response_406 => {
       attributes => {
-        'aws_lb_listener_default_action_403_fixed_response_406_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'content_type' => String,
         'message_body' => {
           'type' => Optional[String],
@@ -19610,10 +17990,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_default_action_403_redirect_407 => {
       attributes => {
-        'aws_lb_listener_default_action_403_redirect_407_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
@@ -19643,7 +18019,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'action' => Aws_lb_listener_rule_action_408,
+        'action' => Array[Aws_lb_listener_rule_action_408],
         'arn' => {
           'type' => Optional[String],
           'value' => undef
@@ -19669,20 +18045,16 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_rule_action_408 => {
       attributes => {
-        'aws_lb_listener_rule_action_408_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authenticate_cognito' => {
-          'type' => Optional[Aws_lb_listener_rule_action_408_authenticate_cognito_409],
+          'type' => Optional[Array[Aws_lb_listener_rule_action_408_authenticate_cognito_409]],
           'value' => undef
         },
         'authenticate_oidc' => {
-          'type' => Optional[Aws_lb_listener_rule_action_408_authenticate_oidc_410],
+          'type' => Optional[Array[Aws_lb_listener_rule_action_408_authenticate_oidc_410]],
           'value' => undef
         },
         'fixed_response' => {
-          'type' => Optional[Aws_lb_listener_rule_action_408_fixed_response_411],
+          'type' => Optional[Array[Aws_lb_listener_rule_action_408_fixed_response_411]],
           'value' => undef
         },
         'order' => {
@@ -19690,7 +18062,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'redirect' => {
-          'type' => Optional[Aws_lb_listener_rule_action_408_redirect_412],
+          'type' => Optional[Array[Aws_lb_listener_rule_action_408_redirect_412]],
           'value' => undef
         },
         'target_group_arn' => {
@@ -19702,10 +18074,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_rule_action_408_authenticate_cognito_409 => {
       attributes => {
-        'aws_lb_listener_rule_action_408_authenticate_cognito_409_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -19733,10 +18101,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_rule_action_408_authenticate_oidc_410 => {
       attributes => {
-        'aws_lb_listener_rule_action_408_authenticate_oidc_410_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authentication_request_extra_params' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -19767,10 +18131,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_rule_action_408_fixed_response_411 => {
       attributes => {
-        'aws_lb_listener_rule_action_408_fixed_response_411_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'content_type' => String,
         'message_body' => {
           'type' => Optional[String],
@@ -19784,10 +18144,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_rule_action_408_redirect_412 => {
       attributes => {
-        'aws_lb_listener_rule_action_408_redirect_412_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
@@ -19813,10 +18169,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_listener_rule_condition_413 => {
       attributes => {
-        'aws_lb_listener_rule_condition_413_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field' => {
           'type' => Optional[String],
           'value' => undef
@@ -19855,20 +18207,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_ssl_negotiation_policy_attribute_414 => {
       attributes => {
-        'aws_lb_ssl_negotiation_policy_attribute_414_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
     },
     Aws_lb_subnet_mapping_402 => {
       attributes => {
-        'aws_lb_subnet_mapping_402_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allocation_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -19895,7 +18239,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'health_check' => {
-          'type' => Optional[Aws_lb_target_group_health_check_415],
+          'type' => Optional[Array[Aws_lb_target_group_health_check_415]],
           'value' => undef
         },
         'name' => {
@@ -19923,7 +18267,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'stickiness' => {
-          'type' => Optional[Aws_lb_target_group_stickiness_416],
+          'type' => Optional[Array[Aws_lb_target_group_stickiness_416]],
           'value' => undef
         },
         'tags' => {
@@ -19982,10 +18326,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_target_group_health_check_415 => {
       attributes => {
-        'aws_lb_target_group_health_check_415_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'healthy_threshold' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -20022,10 +18362,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_lb_target_group_stickiness_416 => {
       attributes => {
-        'aws_lb_target_group_stickiness_416_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cookie_duration' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -20376,10 +18712,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_load_balancer_policy_policy_attribute_417 => {
       attributes => {
-        'aws_load_balancer_policy_policy_attribute_417_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -20418,7 +18750,7 @@ type TerraformAws = TypeSet[{
         },
         'bucket_name' => String,
         'classification_type' => {
-          'type' => Optional[Aws_macie_s3_bucket_association_classification_type_418],
+          'type' => Optional[Array[Aws_macie_s3_bucket_association_classification_type_418]],
           'value' => undef
         },
         'member_account_id' => {
@@ -20444,10 +18776,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_macie_s3_bucket_association_classification_type_418 => {
       attributes => {
-        'aws_macie_s3_bucket_association_classification_type_418_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'continuous' => {
           'type' => Optional[String],
           'value' => undef
@@ -20499,7 +18827,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'hls_ingest' => {
-          'type' => Optional[Aws_media_package_channel_hls_ingest_419],
+          'type' => Optional[Array[Aws_media_package_channel_hls_ingest_419]],
           'value' => undef
         }
       }
@@ -20517,22 +18845,14 @@ type TerraformAws = TypeSet[{
     },
     Aws_media_package_channel_hls_ingest_419 => {
       attributes => {
-        'aws_media_package_channel_hls_ingest_419_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ingest_endpoints' => {
-          'type' => Optional[Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420],
+          'type' => Optional[Array[Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420]],
           'value' => undef
         }
       }
     },
     Aws_media_package_channel_hls_ingest_419_ingest_endpoints_420 => {
       attributes => {
-        'aws_media_package_channel_hls_ingest_419_ingest_endpoints_420_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'password' => {
           'type' => Optional[String],
           'value' => undef
@@ -20616,7 +18936,7 @@ type TerraformAws = TypeSet[{
         },
         'broker_name' => String,
         'configuration' => {
-          'type' => Optional[Aws_mq_broker_configuration_421],
+          'type' => Optional[Array[Aws_mq_broker_configuration_421]],
           'value' => undef
         },
         'deployment_mode' => {
@@ -20627,15 +18947,15 @@ type TerraformAws = TypeSet[{
         'engine_version' => String,
         'host_instance_type' => String,
         'instances' => {
-          'type' => Optional[Aws_mq_broker_instances_422],
+          'type' => Optional[Array[Aws_mq_broker_instances_422]],
           'value' => undef
         },
         'logs' => {
-          'type' => Optional[Aws_mq_broker_logs_423],
+          'type' => Optional[Array[Aws_mq_broker_logs_423]],
           'value' => undef
         },
         'maintenance_window_start_time' => {
-          'type' => Optional[Aws_mq_broker_maintenance_window_start_time_424],
+          'type' => Optional[Array[Aws_mq_broker_maintenance_window_start_time_424]],
           'value' => undef
         },
         'publicly_accessible' => {
@@ -20667,10 +18987,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_mq_broker_configuration_421 => {
       attributes => {
-        'aws_mq_broker_configuration_421_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'id' => {
           'type' => Optional[String],
           'value' => undef
@@ -20683,10 +18999,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_mq_broker_instances_422 => {
       attributes => {
-        'aws_mq_broker_instances_422_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'console_url' => {
           'type' => Optional[String],
           'value' => undef
@@ -20703,10 +19015,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_mq_broker_logs_423 => {
       attributes => {
-        'aws_mq_broker_logs_423_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'audit' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -20719,10 +19027,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_mq_broker_maintenance_window_start_time_424 => {
       attributes => {
-        'aws_mq_broker_maintenance_window_start_time_424_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'day_of_week' => String,
         'time_of_day' => String,
         'time_zone' => String
@@ -20730,10 +19034,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_mq_broker_user_425 => {
       attributes => {
-        'aws_mq_broker_user_425_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'console_access' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -21108,10 +19408,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_neptune_cluster_parameter_group_parameter_426 => {
       attributes => {
-        'aws_neptune_cluster_parameter_group_parameter_426_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'apply_method' => {
           'type' => Optional[String],
           'value' => undef
@@ -21288,10 +19584,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_neptune_parameter_group_parameter_427 => {
       attributes => {
-        'aws_neptune_parameter_group_parameter_427_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'apply_method' => {
           'type' => Optional[String],
           'value' => undef
@@ -21386,10 +19678,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_network_acl_egress_428 => {
       attributes => {
-        'aws_network_acl_egress_428_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => String,
         'cidr_block' => {
           'type' => Optional[String],
@@ -21415,10 +19703,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_network_acl_ingress_429 => {
       attributes => {
-        'aws_network_acl_ingress_429_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => String,
         'cidr_block' => {
           'type' => Optional[String],
@@ -21581,10 +19865,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_network_interface_attachment_430 => {
       attributes => {
-        'aws_network_interface_attachment_430_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'attachment_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -21621,7 +19901,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'app_source' => {
-          'type' => Optional[Aws_opsworks_application_app_source_431],
+          'type' => Optional[Array[Aws_opsworks_application_app_source_431]],
           'value' => undef
         },
         'auto_bundle_on_deploy' => {
@@ -21674,7 +19954,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'ssl_configuration' => {
-          'type' => Optional[Aws_opsworks_application_ssl_configuration_433],
+          'type' => Optional[Array[Aws_opsworks_application_ssl_configuration_433]],
           'value' => undef
         },
         'stack_id' => String,
@@ -21694,10 +19974,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_application_app_source_431 => {
       attributes => {
-        'aws_opsworks_application_app_source_431_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'password' => {
           'type' => Optional[String],
           'value' => undef
@@ -21723,10 +19999,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_application_environment_432 => {
       attributes => {
-        'aws_opsworks_application_environment_432_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'secure' => {
           'type' => Optional[Boolean],
@@ -21737,10 +20009,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_application_ssl_configuration_433 => {
       attributes => {
-        'aws_opsworks_application_ssl_configuration_433_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'certificate' => String,
         'chain' => {
           'type' => Optional[String],
@@ -21845,10 +20113,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_custom_layer_ebs_volume_434 => {
       attributes => {
-        'aws_opsworks_custom_layer_ebs_volume_434_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -21973,10 +20237,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_ganglia_layer_ebs_volume_435 => {
       attributes => {
-        'aws_opsworks_ganglia_layer_ebs_volume_435_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -22113,10 +20373,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_haproxy_layer_ebs_volume_436 => {
       attributes => {
-        'aws_opsworks_haproxy_layer_ebs_volume_436_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -22329,10 +20585,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_instance_ebs_block_device_437 => {
       attributes => {
-        'aws_opsworks_instance_ebs_block_device_437_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -22358,20 +20610,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_instance_ephemeral_block_device_438 => {
       attributes => {
-        'aws_opsworks_instance_ephemeral_block_device_438_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => String,
         'virtual_name' => String
       }
     },
     Aws_opsworks_instance_root_block_device_439 => {
       attributes => {
-        'aws_opsworks_instance_root_block_device_439_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -22508,10 +20752,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_java_app_layer_ebs_volume_440 => {
       attributes => {
-        'aws_opsworks_java_app_layer_ebs_volume_440_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -22631,10 +20871,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_memcached_layer_ebs_volume_441 => {
       attributes => {
-        'aws_opsworks_memcached_layer_ebs_volume_441_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -22758,10 +20994,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_mysql_layer_ebs_volume_442 => {
       attributes => {
-        'aws_opsworks_mysql_layer_ebs_volume_442_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -22881,10 +21113,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_nodejs_app_layer_ebs_volume_443 => {
       attributes => {
-        'aws_opsworks_nodejs_app_layer_ebs_volume_443_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -23036,10 +21264,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_php_app_layer_ebs_volume_444 => {
       attributes => {
-        'aws_opsworks_php_app_layer_ebs_volume_444_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -23179,10 +21403,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_rails_app_layer_ebs_volume_445 => {
       attributes => {
-        'aws_opsworks_rails_app_layer_ebs_volume_445_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -23254,7 +21474,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'custom_cookbooks_source' => {
-          'type' => Optional[Aws_opsworks_stack_custom_cookbooks_source_446],
+          'type' => Optional[Array[Aws_opsworks_stack_custom_cookbooks_source_446]],
           'value' => undef
         },
         'custom_json' => {
@@ -23328,10 +21548,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_stack_custom_cookbooks_source_446 => {
       attributes => {
-        'aws_opsworks_stack_custom_cookbooks_source_446_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'password' => {
           'type' => Optional[String],
           'value' => undef
@@ -23450,10 +21666,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_opsworks_static_web_layer_ebs_volume_447 => {
       attributes => {
-        'aws_opsworks_static_web_layer_ebs_volume_447_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'iops' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -23887,11 +22099,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'campaign_hook' => {
-          'type' => Optional[Aws_pinpoint_app_campaign_hook_448],
+          'type' => Optional[Array[Aws_pinpoint_app_campaign_hook_448]],
           'value' => undef
         },
         'limits' => {
-          'type' => Optional[Aws_pinpoint_app_limits_449],
+          'type' => Optional[Array[Aws_pinpoint_app_limits_449]],
           'value' => undef
         },
         'name' => {
@@ -23903,7 +22115,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'quiet_time' => {
-          'type' => Optional[Aws_pinpoint_app_quiet_time_450],
+          'type' => Optional[Array[Aws_pinpoint_app_quiet_time_450]],
           'value' => undef
         }
       }
@@ -23921,10 +22133,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_pinpoint_app_campaign_hook_448 => {
       attributes => {
-        'aws_pinpoint_app_campaign_hook_448_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'lambda_function_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -23941,10 +22149,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_pinpoint_app_limits_449 => {
       attributes => {
-        'aws_pinpoint_app_limits_449_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'daily' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -23965,10 +22169,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_pinpoint_app_quiet_time_450 => {
       attributes => {
-        'aws_pinpoint_app_quiet_time_450_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'end' => {
           'type' => Optional[String],
           'value' => undef
@@ -24324,11 +22524,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         's3_import' => {
-          'type' => Optional[Aws_rds_cluster_s3_import_451],
+          'type' => Optional[Array[Aws_rds_cluster_s3_import_451]],
           'value' => undef
         },
         'scaling_configuration' => {
-          'type' => Optional[Aws_rds_cluster_scaling_configuration_452],
+          'type' => Optional[Array[Aws_rds_cluster_scaling_configuration_452]],
           'value' => undef
         },
         'skip_final_snapshot' => {
@@ -24577,10 +22777,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_rds_cluster_parameter_group_parameter_453 => {
       attributes => {
-        'aws_rds_cluster_parameter_group_parameter_453_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'apply_method' => {
           'type' => Optional[String],
           'value' => undef
@@ -24591,10 +22787,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_rds_cluster_s3_import_451 => {
       attributes => {
-        'aws_rds_cluster_s3_import_451_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_name' => String,
         'bucket_prefix' => {
           'type' => Optional[String],
@@ -24607,10 +22799,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_rds_cluster_scaling_configuration_452 => {
       attributes => {
-        'aws_rds_cluster_scaling_configuration_452_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_pause' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -24769,7 +22957,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'logging' => {
-          'type' => Optional[Aws_redshift_cluster_logging_454],
+          'type' => Optional[Array[Aws_redshift_cluster_logging_454]],
           'value' => undef
         },
         'master_password' => {
@@ -24814,7 +23002,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'snapshot_copy' => {
-          'type' => Optional[Aws_redshift_cluster_snapshot_copy_455],
+          'type' => Optional[Array[Aws_redshift_cluster_snapshot_copy_455]],
           'value' => undef
         },
         'snapshot_identifier' => {
@@ -24844,10 +23032,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_redshift_cluster_logging_454 => {
       attributes => {
-        'aws_redshift_cluster_logging_454_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -24861,10 +23045,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_redshift_cluster_snapshot_copy_455 => {
       attributes => {
-        'aws_redshift_cluster_snapshot_copy_455_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'destination_region' => String,
         'grant_name' => {
           'type' => Optional[String],
@@ -24960,10 +23140,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_redshift_parameter_group_parameter_456 => {
       attributes => {
-        'aws_redshift_parameter_group_parameter_456_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => String
       }
@@ -24995,10 +23171,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_redshift_security_group_ingress_457 => {
       attributes => {
-        'aws_redshift_security_group_ingress_457_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr' => {
           'type' => Optional[String],
           'value' => undef
@@ -25085,7 +23257,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'name' => String,
-        'resource_query' => Aws_resourcegroups_group_resource_query_458
+        'resource_query' => Array[Aws_resourcegroups_group_resource_query_458]
       }
     },
     Aws_resourcegroups_groupHandler => {
@@ -25101,10 +23273,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_resourcegroups_group_resource_query_458 => {
       attributes => {
-        'aws_resourcegroups_group_resource_query_458_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'query' => String,
         'type' => {
           'type' => Optional[String],
@@ -25332,7 +23500,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'failover_routing_policy' => {
-          'type' => Optional[Aws_route53_record_failover_routing_policy_460],
+          'type' => Optional[Array[Aws_route53_record_failover_routing_policy_460]],
           'value' => undef
         },
         'fqdn' => {
@@ -25340,7 +23508,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'geolocation_routing_policy' => {
-          'type' => Optional[Aws_route53_record_geolocation_routing_policy_461],
+          'type' => Optional[Array[Aws_route53_record_geolocation_routing_policy_461]],
           'value' => undef
         },
         'health_check_id' => {
@@ -25348,7 +23516,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'latency_routing_policy' => {
-          'type' => Optional[Aws_route53_record_latency_routing_policy_462],
+          'type' => Optional[Array[Aws_route53_record_latency_routing_policy_462]],
           'value' => undef
         },
         'multivalue_answer_routing_policy' => {
@@ -25374,7 +23542,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'weighted_routing_policy' => {
-          'type' => Optional[Aws_route53_record_weighted_routing_policy_463],
+          'type' => Optional[Array[Aws_route53_record_weighted_routing_policy_463]],
           'value' => undef
         },
         'zone_id' => String
@@ -25393,10 +23561,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_route53_record_alias_459 => {
       attributes => {
-        'aws_route53_record_alias_459_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'evaluate_target_health' => Boolean,
         'name' => String,
         'zone_id' => String
@@ -25404,19 +23568,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_route53_record_failover_routing_policy_460 => {
       attributes => {
-        'aws_route53_record_failover_routing_policy_460_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_route53_record_geolocation_routing_policy_461 => {
       attributes => {
-        'aws_route53_record_geolocation_routing_policy_461_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'continent' => {
           'type' => Optional[String],
           'value' => undef
@@ -25433,19 +23589,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_route53_record_latency_routing_policy_462 => {
       attributes => {
-        'aws_route53_record_latency_routing_policy_462_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'region' => String
       }
     },
     Aws_route53_record_weighted_routing_policy_463 => {
       attributes => {
-        'aws_route53_record_weighted_routing_policy_463_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'weight' => Integer
       }
     },
@@ -25532,10 +23680,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_route53_zone_vpc_464 => {
       attributes => {
-        'aws_route53_zone_vpc_464_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'vpc_id' => String,
         'vpc_region' => {
           'type' => Optional[String],
@@ -25613,10 +23757,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_route_table_route_465 => {
       attributes => {
-        'aws_route_table_route_465_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_block' => {
           'type' => Optional[String],
           'value' => undef
@@ -25729,7 +23869,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'cors_rule' => {
-          'type' => Optional[Aws_s3_bucket_cors_rule_466],
+          'type' => Optional[Array[Aws_s3_bucket_cors_rule_466]],
           'value' => undef
         },
         'force_destroy' => {
@@ -25741,7 +23881,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'lifecycle_rule' => {
-          'type' => Optional[Aws_s3_bucket_lifecycle_rule_467],
+          'type' => Optional[Array[Aws_s3_bucket_lifecycle_rule_467]],
           'value' => undef
         },
         'logging' => {
@@ -25749,7 +23889,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'object_lock_configuration' => {
-          'type' => Optional[Aws_s3_bucket_object_lock_configuration_473],
+          'type' => Optional[Array[Aws_s3_bucket_object_lock_configuration_473]],
           'value' => undef
         },
         'policy' => {
@@ -25761,7 +23901,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'replication_configuration' => {
-          'type' => Optional[Aws_s3_bucket_replication_configuration_476],
+          'type' => Optional[Array[Aws_s3_bucket_replication_configuration_476]],
           'value' => undef
         },
         'request_payer' => {
@@ -25769,7 +23909,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'server_side_encryption_configuration' => {
-          'type' => Optional[Aws_s3_bucket_server_side_encryption_configuration_483],
+          'type' => Optional[Array[Aws_s3_bucket_server_side_encryption_configuration_483]],
           'value' => undef
         },
         'tags' => {
@@ -25777,11 +23917,11 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'versioning' => {
-          'type' => Optional[Aws_s3_bucket_versioning_486],
+          'type' => Optional[Array[Aws_s3_bucket_versioning_486]],
           'value' => undef
         },
         'website' => {
-          'type' => Optional[Aws_s3_bucket_website_487],
+          'type' => Optional[Array[Aws_s3_bucket_website_487]],
           'value' => undef
         },
         'website_domain' => {
@@ -25807,10 +23947,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_cors_rule_466 => {
       attributes => {
-        'aws_s3_bucket_cors_rule_466_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allowed_headers' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -25834,13 +23970,13 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'bucket' => String,
-        'destination' => Aws_s3_bucket_inventory_destination_488,
+        'destination' => Array[Aws_s3_bucket_inventory_destination_488],
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'filter' => {
-          'type' => Optional[Aws_s3_bucket_inventory_filter_493],
+          'type' => Optional[Array[Aws_s3_bucket_inventory_filter_493]],
           'value' => undef
         },
         'included_object_versions' => String,
@@ -25849,7 +23985,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[Array[String]],
           'value' => undef
         },
-        'schedule' => Aws_s3_bucket_inventory_schedule_494
+        'schedule' => Array[Aws_s3_bucket_inventory_schedule_494]
       }
     },
     Aws_s3_bucket_inventoryHandler => {
@@ -25865,26 +24001,18 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_inventory_destination_488 => {
       attributes => {
-        'aws_s3_bucket_inventory_destination_488_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'bucket' => Aws_s3_bucket_inventory_destination_488_bucket_489
+        'bucket' => Array[Aws_s3_bucket_inventory_destination_488_bucket_489]
       }
     },
     Aws_s3_bucket_inventory_destination_488_bucket_489 => {
       attributes => {
-        'aws_s3_bucket_inventory_destination_488_bucket_489_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'account_id' => {
           'type' => Optional[String],
           'value' => undef
         },
         'bucket_arn' => String,
         'encryption' => {
-          'type' => Optional[Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490],
+          'type' => Optional[Array[Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490]],
           'value' => undef
         },
         'format' => String,
@@ -25896,43 +24024,25 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490 => {
       attributes => {
-        'aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'sse_kms' => {
-          'type' => Optional[Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491],
+          'type' => Optional[Array[Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491]],
           'value' => undef
         },
         'sse_s3' => {
-          'type' => Optional[Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492],
+          'type' => Optional[Array[Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492]],
           'value' => undef
         }
       }
     },
     Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491 => {
       attributes => {
-        'aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_kms_491_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key_id' => String
       }
     },
     Aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492 => {
-      attributes => {
-        'aws_s3_bucket_inventory_destination_488_bucket_489_encryption_490_sse_s3_492_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        }
-      }
     },
     Aws_s3_bucket_inventory_filter_493 => {
       attributes => {
-        'aws_s3_bucket_inventory_filter_493_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'prefix' => {
           'type' => Optional[String],
           'value' => undef
@@ -25941,19 +24051,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_inventory_schedule_494 => {
       attributes => {
-        'aws_s3_bucket_inventory_schedule_494_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'frequency' => String
       }
     },
     Aws_s3_bucket_lifecycle_rule_467 => {
       attributes => {
-        'aws_s3_bucket_lifecycle_rule_467_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'abort_incomplete_multipart_upload_days' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -25991,10 +24093,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_lifecycle_rule_467_expiration_468 => {
       attributes => {
-        'aws_s3_bucket_lifecycle_rule_467_expiration_468_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'date' => {
           'type' => Optional[String],
           'value' => undef
@@ -26011,10 +24109,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_expiration_469 => {
       attributes => {
-        'aws_s3_bucket_lifecycle_rule_467_noncurrent_version_expiration_469_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'days' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -26023,10 +24117,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_lifecycle_rule_467_noncurrent_version_transition_470 => {
       attributes => {
-        'aws_s3_bucket_lifecycle_rule_467_noncurrent_version_transition_470_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'days' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -26036,10 +24126,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_lifecycle_rule_467_transition_471 => {
       attributes => {
-        'aws_s3_bucket_lifecycle_rule_467_transition_471_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'date' => {
           'type' => Optional[String],
           'value' => undef
@@ -26053,10 +24139,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_logging_472 => {
       attributes => {
-        'aws_s3_bucket_logging_472_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'target_bucket' => String,
         'target_prefix' => {
           'type' => Optional[String],
@@ -26072,7 +24154,7 @@ type TerraformAws = TypeSet[{
         },
         'bucket' => String,
         'filter' => {
-          'type' => Optional[Aws_s3_bucket_metric_filter_495],
+          'type' => Optional[Array[Aws_s3_bucket_metric_filter_495]],
           'value' => undef
         },
         'name' => String
@@ -26091,10 +24173,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_metric_filter_495 => {
       attributes => {
-        'aws_s3_bucket_metric_filter_495_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'prefix' => {
           'type' => Optional[String],
           'value' => undef
@@ -26113,15 +24191,15 @@ type TerraformAws = TypeSet[{
         },
         'bucket' => String,
         'lambda_function' => {
-          'type' => Optional[Aws_s3_bucket_notification_lambda_function_496],
+          'type' => Optional[Array[Aws_s3_bucket_notification_lambda_function_496]],
           'value' => undef
         },
         'queue' => {
-          'type' => Optional[Aws_s3_bucket_notification_queue_497],
+          'type' => Optional[Array[Aws_s3_bucket_notification_queue_497]],
           'value' => undef
         },
         'topic' => {
-          'type' => Optional[Aws_s3_bucket_notification_topic_498],
+          'type' => Optional[Array[Aws_s3_bucket_notification_topic_498]],
           'value' => undef
         }
       }
@@ -26139,10 +24217,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_notification_lambda_function_496 => {
       attributes => {
-        'aws_s3_bucket_notification_lambda_function_496_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'events' => Array[String],
         'filter_prefix' => {
           'type' => Optional[String],
@@ -26164,10 +24238,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_notification_queue_497 => {
       attributes => {
-        'aws_s3_bucket_notification_queue_497_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'events' => Array[String],
         'filter_prefix' => {
           'type' => Optional[String],
@@ -26186,10 +24256,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_notification_topic_498 => {
       attributes => {
-        'aws_s3_bucket_notification_topic_498_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'events' => Array[String],
         'filter_prefix' => {
           'type' => Optional[String],
@@ -26293,32 +24359,20 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_object_lock_configuration_473 => {
       attributes => {
-        'aws_s3_bucket_object_lock_configuration_473_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'object_lock_enabled' => String,
         'rule' => {
-          'type' => Optional[Aws_s3_bucket_object_lock_configuration_473_rule_474],
+          'type' => Optional[Array[Aws_s3_bucket_object_lock_configuration_473_rule_474]],
           'value' => undef
         }
       }
     },
     Aws_s3_bucket_object_lock_configuration_473_rule_474 => {
       attributes => {
-        'aws_s3_bucket_object_lock_configuration_473_rule_474_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'default_retention' => Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475
+        'default_retention' => Array[Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475]
       }
     },
     Aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475 => {
       attributes => {
-        'aws_s3_bucket_object_lock_configuration_473_rule_474_default_retention_475_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'days' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -26389,23 +24443,15 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_replication_configuration_476 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'role' => String,
         'rules' => Aws_s3_bucket_replication_configuration_476_rules_477
       }
     },
     Aws_s3_bucket_replication_configuration_476_rules_477 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_rules_477_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'destination' => Aws_s3_bucket_replication_configuration_476_rules_477_destination_478,
         'filter' => {
-          'type' => Optional[Aws_s3_bucket_replication_configuration_476_rules_477_filter_480],
+          'type' => Optional[Array[Aws_s3_bucket_replication_configuration_476_rules_477_filter_480]],
           'value' => undef
         },
         'id' => {
@@ -26429,12 +24475,8 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_replication_configuration_476_rules_477_destination_478 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_rules_477_destination_478_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_control_translation' => {
-          'type' => Optional[Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479],
+          'type' => Optional[Array[Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479]],
           'value' => undef
         },
         'account_id' => {
@@ -26454,19 +24496,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_rules_477_destination_478_access_control_translation_479_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'owner' => String
       }
     },
     Aws_s3_bucket_replication_configuration_476_rules_477_filter_480 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_rules_477_filter_480_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'prefix' => {
           'type' => Optional[String],
           'value' => undef
@@ -26479,10 +24513,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'sse_kms_encrypted_objects' => {
           'type' => Optional[Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_sse_kms_encrypted_objects_482],
           'value' => undef
@@ -26491,37 +24521,21 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_sse_kms_encrypted_objects_482 => {
       attributes => {
-        'aws_s3_bucket_replication_configuration_476_rules_477_source_selection_criteria_481_sse_kms_encrypted_objects_482_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean
       }
     },
     Aws_s3_bucket_server_side_encryption_configuration_483 => {
       attributes => {
-        'aws_s3_bucket_server_side_encryption_configuration_483_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'rule' => Aws_s3_bucket_server_side_encryption_configuration_483_rule_484
+        'rule' => Array[Aws_s3_bucket_server_side_encryption_configuration_483_rule_484]
       }
     },
     Aws_s3_bucket_server_side_encryption_configuration_483_rule_484 => {
       attributes => {
-        'aws_s3_bucket_server_side_encryption_configuration_483_rule_484_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'apply_server_side_encryption_by_default' => Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485
+        'apply_server_side_encryption_by_default' => Array[Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485]
       }
     },
     Aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485 => {
       attributes => {
-        'aws_s3_bucket_server_side_encryption_configuration_483_rule_484_apply_server_side_encryption_by_default_485_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'kms_master_key_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -26531,10 +24545,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_versioning_486 => {
       attributes => {
-        'aws_s3_bucket_versioning_486_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -26547,10 +24557,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_s3_bucket_website_487 => {
       attributes => {
-        'aws_s3_bucket_website_487_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'error_document' => {
           'type' => Optional[String],
           'value' => undef
@@ -26654,7 +24660,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'rotation_rules' => {
-          'type' => Optional[Aws_secretsmanager_secret_rotation_rules_499],
+          'type' => Optional[Array[Aws_secretsmanager_secret_rotation_rules_499]],
           'value' => undef
         },
         'tags' => {
@@ -26676,10 +24682,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_secretsmanager_secret_rotation_rules_499 => {
       attributes => {
-        'aws_secretsmanager_secret_rotation_rules_499_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'automatically_after_days' => Integer
       }
     },
@@ -26784,10 +24786,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_security_group_egress_500 => {
       attributes => {
-        'aws_security_group_egress_500_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_blocks' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -26819,10 +24817,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_security_group_ingress_501 => {
       attributes => {
-        'aws_security_group_ingress_501_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_blocks' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -27070,13 +25064,13 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'dns_config' => Aws_service_discovery_service_dns_config_502,
+        'dns_config' => Array[Aws_service_discovery_service_dns_config_502],
         'health_check_config' => {
-          'type' => Optional[Aws_service_discovery_service_health_check_config_504],
+          'type' => Optional[Array[Aws_service_discovery_service_health_check_config_504]],
           'value' => undef
         },
         'health_check_custom_config' => {
-          'type' => Optional[Aws_service_discovery_service_health_check_custom_config_505],
+          'type' => Optional[Array[Aws_service_discovery_service_health_check_custom_config_505]],
           'value' => undef
         },
         'name' => String
@@ -27095,11 +25089,7 @@ type TerraformAws = TypeSet[{
     },
     Aws_service_discovery_service_dns_config_502 => {
       attributes => {
-        'aws_service_discovery_service_dns_config_502_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'dns_records' => Aws_service_discovery_service_dns_config_502_dns_records_503,
+        'dns_records' => Array[Aws_service_discovery_service_dns_config_502_dns_records_503],
         'namespace_id' => String,
         'routing_policy' => {
           'type' => Optional[String],
@@ -27109,20 +25099,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_service_discovery_service_dns_config_502_dns_records_503 => {
       attributes => {
-        'aws_service_discovery_service_dns_config_502_dns_records_503_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ttl' => Integer,
         'type' => String
       }
     },
     Aws_service_discovery_service_health_check_config_504 => {
       attributes => {
-        'aws_service_discovery_service_health_check_config_504_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'failure_threshold' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -27139,10 +25121,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_service_discovery_service_health_check_custom_config_505 => {
       attributes => {
-        'aws_service_discovery_service_health_check_custom_config_505_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'failure_threshold' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -27370,10 +25348,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_event_destination_cloudwatch_destination_506 => {
       attributes => {
-        'aws_ses_event_destination_cloudwatch_destination_506_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_value' => String,
         'dimension_name' => String,
         'value_source' => String
@@ -27381,20 +25355,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_event_destination_kinesis_destination_507 => {
       attributes => {
-        'aws_ses_event_destination_kinesis_destination_507_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'role_arn' => String,
         'stream_arn' => String
       }
     },
     Aws_ses_event_destination_sns_destination_508 => {
       attributes => {
-        'aws_ses_event_destination_sns_destination_508_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'topic_arn' => String
       }
     },
@@ -27516,10 +25482,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_receipt_rule_add_header_action_509 => {
       attributes => {
-        'aws_ses_receipt_rule_add_header_action_509_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'header_name' => String,
         'header_value' => String,
         'position' => Integer
@@ -27527,10 +25489,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_receipt_rule_bounce_action_510 => {
       attributes => {
-        'aws_ses_receipt_rule_bounce_action_510_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'message' => String,
         'position' => Integer,
         'sender' => String,
@@ -27547,10 +25505,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_receipt_rule_lambda_action_511 => {
       attributes => {
-        'aws_ses_receipt_rule_lambda_action_511_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'function_arn' => String,
         'invocation_type' => {
           'type' => Optional[String],
@@ -27565,10 +25519,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_receipt_rule_s3_action_512 => {
       attributes => {
-        'aws_ses_receipt_rule_s3_action_512_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_name' => String,
         'kms_key_arn' => {
           'type' => Optional[String],
@@ -27607,20 +25557,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_receipt_rule_sns_action_513 => {
       attributes => {
-        'aws_ses_receipt_rule_sns_action_513_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'position' => Integer,
         'topic_arn' => String
       }
     },
     Aws_ses_receipt_rule_stop_action_514 => {
       attributes => {
-        'aws_ses_receipt_rule_stop_action_514_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'position' => Integer,
         'scope' => String,
         'topic_arn' => {
@@ -27631,10 +25573,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ses_receipt_rule_workmail_action_515 => {
       attributes => {
-        'aws_ses_receipt_rule_workmail_action_515_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'organization_arn' => String,
         'position' => Integer,
         'topic_arn' => {
@@ -28149,10 +26087,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_fleet_request_launch_specification_516 => {
       attributes => {
-        'aws_spot_fleet_request_launch_specification_516_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ami' => String,
         'associate_public_ip_address' => {
           'type' => Optional[Boolean],
@@ -28231,10 +26165,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_fleet_request_launch_specification_516_ebs_block_device_517 => {
       attributes => {
-        'aws_spot_fleet_request_launch_specification_516_ebs_block_device_517_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -28264,20 +26194,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_fleet_request_launch_specification_516_ephemeral_block_device_518 => {
       attributes => {
-        'aws_spot_fleet_request_launch_specification_516_ephemeral_block_device_518_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => String,
         'virtual_name' => String
       }
     },
     Aws_spot_fleet_request_launch_specification_516_root_block_device_519 => {
       attributes => {
-        'aws_spot_fleet_request_launch_specification_516_root_block_device_519_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -28332,7 +26254,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'credit_specification' => {
-          'type' => Optional[Aws_spot_instance_request_credit_specification_520],
+          'type' => Optional[Array[Aws_spot_instance_request_credit_specification_520]],
           'value' => undef
         },
         'disable_api_termination' => {
@@ -28433,7 +26355,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'root_block_device' => {
-          'type' => Optional[Aws_spot_instance_request_root_block_device_524],
+          'type' => Optional[Array[Aws_spot_instance_request_root_block_device_524]],
           'value' => undef
         },
         'security_groups' => {
@@ -28519,10 +26441,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_instance_request_credit_specification_520 => {
       attributes => {
-        'aws_spot_instance_request_credit_specification_520_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu_credits' => {
           'type' => Optional[String],
           'value' => undef
@@ -28531,10 +26449,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_instance_request_ebs_block_device_521 => {
       attributes => {
-        'aws_spot_instance_request_ebs_block_device_521_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -28568,10 +26482,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_instance_request_ephemeral_block_device_522 => {
       attributes => {
-        'aws_spot_instance_request_ephemeral_block_device_522_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => String,
         'no_device' => {
           'type' => Optional[Boolean],
@@ -28585,10 +26495,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_instance_request_network_interface_523 => {
       attributes => {
-        'aws_spot_instance_request_network_interface_523_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -28599,10 +26505,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_spot_instance_request_root_block_device_524 => {
       attributes => {
-        'aws_spot_instance_request_root_block_device_524_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delete_on_termination' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -28797,7 +26699,7 @@ type TerraformAws = TypeSet[{
         },
         'name' => String,
         'output_location' => {
-          'type' => Optional[Aws_ssm_association_output_location_525],
+          'type' => Optional[Array[Aws_ssm_association_output_location_525]],
           'value' => undef
         },
         'parameters' => {
@@ -28809,7 +26711,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'targets' => {
-          'type' => Optional[Aws_ssm_association_targets_526],
+          'type' => Optional[Array[Aws_ssm_association_targets_526]],
           'value' => undef
         }
       }
@@ -28827,10 +26729,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_association_output_location_525 => {
       attributes => {
-        'aws_ssm_association_output_location_525_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         's3_bucket_name' => String,
         's3_key_prefix' => {
           'type' => Optional[String],
@@ -28840,10 +26738,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_association_targets_526 => {
       attributes => {
-        'aws_ssm_association_targets_526_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'values' => Array[String]
       }
@@ -28894,7 +26788,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'parameter' => {
-          'type' => Optional[Aws_ssm_document_parameter_527],
+          'type' => Optional[Array[Aws_ssm_document_parameter_527]],
           'value' => undef
         },
         'permissions' => {
@@ -28932,10 +26826,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_document_parameter_527 => {
       attributes => {
-        'aws_ssm_document_parameter_527_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_value' => {
           'type' => Optional[String],
           'value' => undef
@@ -29008,7 +26898,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'resource_type' => String,
-        'targets' => Aws_ssm_maintenance_window_target_targets_528,
+        'targets' => Array[Aws_ssm_maintenance_window_target_targets_528],
         'window_id' => String
       }
     },
@@ -29025,10 +26915,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_maintenance_window_target_targets_528 => {
       attributes => {
-        'aws_ssm_maintenance_window_target_targets_528_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'values' => Array[String]
       }
@@ -29044,7 +26930,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'logging_info' => {
-          'type' => Optional[Aws_ssm_maintenance_window_task_logging_info_529],
+          'type' => Optional[Array[Aws_ssm_maintenance_window_task_logging_info_529]],
           'value' => undef
         },
         'max_concurrency' => String,
@@ -29058,10 +26944,10 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'service_role_arn' => String,
-        'targets' => Aws_ssm_maintenance_window_task_targets_530,
+        'targets' => Array[Aws_ssm_maintenance_window_task_targets_530],
         'task_arn' => String,
         'task_parameters' => {
-          'type' => Optional[Aws_ssm_maintenance_window_task_task_parameters_531],
+          'type' => Optional[Array[Aws_ssm_maintenance_window_task_task_parameters_531]],
           'value' => undef
         },
         'task_type' => String,
@@ -29081,10 +26967,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_maintenance_window_task_logging_info_529 => {
       attributes => {
-        'aws_ssm_maintenance_window_task_logging_info_529_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         's3_bucket_name' => String,
         's3_bucket_prefix' => {
           'type' => Optional[String],
@@ -29095,20 +26977,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_maintenance_window_task_targets_530 => {
       attributes => {
-        'aws_ssm_maintenance_window_task_targets_530_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'values' => Array[String]
       }
     },
     Aws_ssm_maintenance_window_task_task_parameters_531 => {
       attributes => {
-        'aws_ssm_maintenance_window_task_task_parameters_531_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'values' => Array[String]
       }
@@ -29166,7 +27040,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'approval_rule' => {
-          'type' => Optional[Aws_ssm_patch_baseline_approval_rule_532],
+          'type' => Optional[Array[Aws_ssm_patch_baseline_approval_rule_532]],
           'value' => undef
         },
         'approved_patches' => {
@@ -29182,7 +27056,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'global_filter' => {
-          'type' => Optional[Aws_ssm_patch_baseline_global_filter_534],
+          'type' => Optional[Array[Aws_ssm_patch_baseline_global_filter_534]],
           'value' => undef
         },
         'name' => String,
@@ -29209,10 +27083,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_patch_baseline_approval_rule_532 => {
       attributes => {
-        'aws_ssm_patch_baseline_approval_rule_532_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'approve_after_days' => Integer,
         'compliance_level' => {
           'type' => Optional[String],
@@ -29222,25 +27092,17 @@ type TerraformAws = TypeSet[{
           'type' => Optional[Boolean],
           'value' => undef
         },
-        'patch_filter' => Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533
+        'patch_filter' => Array[Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533]
       }
     },
     Aws_ssm_patch_baseline_approval_rule_532_patch_filter_533 => {
       attributes => {
-        'aws_ssm_patch_baseline_approval_rule_532_patch_filter_533_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'values' => Array[String]
       }
     },
     Aws_ssm_patch_baseline_global_filter_534 => {
       attributes => {
-        'aws_ssm_patch_baseline_global_filter_534_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => String,
         'values' => Array[String]
       }
@@ -29273,7 +27135,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'name' => String,
-        's3_destination' => Aws_ssm_resource_data_sync_s3_destination_535
+        's3_destination' => Array[Aws_ssm_resource_data_sync_s3_destination_535]
       }
     },
     Aws_ssm_resource_data_syncHandler => {
@@ -29289,10 +27151,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_ssm_resource_data_sync_s3_destination_535 => {
       attributes => {
-        'aws_ssm_resource_data_sync_s3_destination_535_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket_name' => String,
         'kms_key_arn' => {
           'type' => Optional[String],
@@ -29422,7 +27280,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'smb_active_directory_settings' => {
-          'type' => Optional[Aws_storagegateway_gateway_smb_active_directory_settings_536],
+          'type' => Optional[Array[Aws_storagegateway_gateway_smb_active_directory_settings_536]],
           'value' => undef
         },
         'smb_guest_password' => {
@@ -29448,10 +27306,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_storagegateway_gateway_smb_active_directory_settings_536 => {
       attributes => {
-        'aws_storagegateway_gateway_smb_active_directory_settings_536_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'domain_name' => String,
         'password' => String,
         'username' => String
@@ -29491,7 +27345,7 @@ type TerraformAws = TypeSet[{
         },
         'location_arn' => String,
         'nfs_file_share_defaults' => {
-          'type' => Optional[Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537],
+          'type' => Optional[Array[Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537]],
           'value' => undef
         },
         'object_acl' => {
@@ -29526,10 +27380,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537 => {
       attributes => {
-        'aws_storagegateway_nfs_file_share_nfs_file_share_defaults_537_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'directory_mode' => {
           'type' => Optional[String],
           'value' => undef
@@ -30057,7 +27907,7 @@ type TerraformAws = TypeSet[{
           'value' => undef
         },
         'dns_entry' => {
-          'type' => Optional[Aws_vpc_endpoint_dns_entry_538],
+          'type' => Optional[Array[Aws_vpc_endpoint_dns_entry_538]],
           'value' => undef
         },
         'network_interface_ids' => {
@@ -30150,10 +28000,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_endpoint_dns_entry_538 => {
       attributes => {
-        'aws_vpc_endpoint_dns_entry_538_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dns_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -30404,10 +28250,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_peering_connection_accepter_539 => {
       attributes => {
-        'aws_vpc_peering_connection_accepter_539_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_classic_link_to_remote_vpc' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -30424,10 +28266,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_peering_connection_accepter_accepter_541 => {
       attributes => {
-        'aws_vpc_peering_connection_accepter_accepter_541_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_classic_link_to_remote_vpc' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -30444,10 +28282,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_peering_connection_accepter_requester_542 => {
       attributes => {
-        'aws_vpc_peering_connection_accepter_requester_542_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_classic_link_to_remote_vpc' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -30492,10 +28326,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_peering_connection_options_accepter_543 => {
       attributes => {
-        'aws_vpc_peering_connection_options_accepter_543_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_classic_link_to_remote_vpc' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -30512,10 +28342,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_peering_connection_options_requester_544 => {
       attributes => {
-        'aws_vpc_peering_connection_options_requester_544_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_classic_link_to_remote_vpc' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -30532,10 +28358,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpc_peering_connection_requester_540 => {
       attributes => {
-        'aws_vpc_peering_connection_requester_540_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_classic_link_to_remote_vpc' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -30678,10 +28500,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpn_connection_routes_545 => {
       attributes => {
-        'aws_vpn_connection_routes_545_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'destination_cidr_block' => {
           'type' => Optional[String],
           'value' => undef
@@ -30698,10 +28516,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_vpn_connection_vgw_telemetry_546 => {
       attributes => {
-        'aws_vpn_connection_vgw_telemetry_546_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'accepted_route_count' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -30827,10 +28641,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_byte_match_set_byte_match_tuples_547 => {
       attributes => {
-        'aws_waf_byte_match_set_byte_match_tuples_547_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field_to_match' => Aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548,
         'positional_constraint' => String,
         'target_string' => {
@@ -30842,10 +28652,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548 => {
       attributes => {
-        'aws_waf_byte_match_set_byte_match_tuples_547_field_to_match_548_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -30879,10 +28685,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_geo_match_set_geo_match_constraint_549 => {
       attributes => {
-        'aws_waf_geo_match_set_geo_match_constraint_549_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String,
         'value' => String
       }
@@ -30917,10 +28719,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_ipset_ip_set_descriptors_550 => {
       attributes => {
-        'aws_waf_ipset_ip_set_descriptors_550_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String,
         'value' => String
       }
@@ -30954,10 +28752,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_rate_based_rule_predicates_551 => {
       attributes => {
-        'aws_waf_rate_based_rule_predicates_551_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data_id' => String,
         'negated' => Boolean,
         'type' => String
@@ -30989,21 +28783,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_regex_match_set_regex_match_tuple_552 => {
       attributes => {
-        'aws_waf_regex_match_set_regex_match_tuple_552_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_to_match' => Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553,
+        'field_to_match' => Array[Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553],
         'regex_pattern_set_id' => String,
         'text_transformation' => String
       }
     },
     Aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553 => {
       attributes => {
-        'aws_waf_regex_match_set_regex_match_tuple_552_field_to_match_553_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31087,11 +28873,7 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_rule_group_activated_rule_555 => {
       attributes => {
-        'aws_waf_rule_group_activated_rule_555_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'action' => Aws_waf_rule_group_activated_rule_555_action_556,
+        'action' => Array[Aws_waf_rule_group_activated_rule_555_action_556],
         'priority' => Integer,
         'rule_id' => String,
         'type' => {
@@ -31102,19 +28884,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_rule_group_activated_rule_555_action_556 => {
       attributes => {
-        'aws_waf_rule_group_activated_rule_555_action_556_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_waf_rule_predicates_554 => {
       attributes => {
-        'aws_waf_rule_predicates_554_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data_id' => String,
         'negated' => Boolean,
         'type' => String
@@ -31146,10 +28920,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_size_constraint_set_size_constraints_557 => {
       attributes => {
-        'aws_waf_size_constraint_set_size_constraints_557_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'comparison_operator' => String,
         'field_to_match' => Aws_waf_size_constraint_set_size_constraints_557_field_to_match_558,
         'size' => Integer,
@@ -31158,10 +28928,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_size_constraint_set_size_constraints_557_field_to_match_558 => {
       attributes => {
-        'aws_waf_size_constraint_set_size_constraints_557_field_to_match_558_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31195,20 +28961,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559 => {
       attributes => {
-        'aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field_to_match' => Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_match_560,
         'text_transformation' => String
       }
     },
     Aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_match_560 => {
       attributes => {
-        'aws_waf_sql_injection_match_set_sql_injection_match_tuples_559_field_to_match_560_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31244,25 +29002,17 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_web_acl_default_action_561 => {
       attributes => {
-        'aws_waf_web_acl_default_action_561_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_waf_web_acl_rules_562 => {
       attributes => {
-        'aws_waf_web_acl_rules_562_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => {
-          'type' => Optional[Aws_waf_web_acl_rules_562_action_563],
+          'type' => Optional[Array[Aws_waf_web_acl_rules_562_action_563]],
           'value' => undef
         },
         'override_action' => {
-          'type' => Optional[Aws_waf_web_acl_rules_562_override_action_564],
+          'type' => Optional[Array[Aws_waf_web_acl_rules_562_override_action_564]],
           'value' => undef
         },
         'priority' => Integer,
@@ -31275,19 +29025,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_web_acl_rules_562_action_563 => {
       attributes => {
-        'aws_waf_web_acl_rules_562_action_563_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_waf_web_acl_rules_562_override_action_564 => {
       attributes => {
-        'aws_waf_web_acl_rules_562_override_action_564_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
@@ -31317,20 +29059,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_waf_xss_match_set_xss_match_tuples_565 => {
       attributes => {
-        'aws_waf_xss_match_set_xss_match_tuples_565_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field_to_match' => Aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566,
         'text_transformation' => String
       }
     },
     Aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566 => {
       attributes => {
-        'aws_waf_xss_match_set_xss_match_tuples_565_field_to_match_566_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31368,11 +29102,7 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_byte_match_set_byte_match_tuple_567 => {
       attributes => {
-        'aws_wafregional_byte_match_set_byte_match_tuple_567_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_to_match' => Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568,
+        'field_to_match' => Array[Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568],
         'positional_constraint' => String,
         'target_string' => {
           'type' => Optional[String],
@@ -31383,10 +29113,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568 => {
       attributes => {
-        'aws_wafregional_byte_match_set_byte_match_tuple_567_field_to_match_568_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31396,11 +29122,7 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_byte_match_set_byte_match_tuples_569 => {
       attributes => {
-        'aws_wafregional_byte_match_set_byte_match_tuples_569_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_to_match' => Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570,
+        'field_to_match' => Array[Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570],
         'positional_constraint' => String,
         'target_string' => {
           'type' => Optional[String],
@@ -31411,10 +29133,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570 => {
       attributes => {
-        'aws_wafregional_byte_match_set_byte_match_tuples_569_field_to_match_570_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31448,10 +29166,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_geo_match_set_geo_match_constraint_571 => {
       attributes => {
-        'aws_wafregional_geo_match_set_geo_match_constraint_571_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String,
         'value' => String
       }
@@ -31486,10 +29200,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_ipset_ip_set_descriptor_572 => {
       attributes => {
-        'aws_wafregional_ipset_ip_set_descriptor_572_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String,
         'value' => String
       }
@@ -31523,10 +29233,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_rate_based_rule_predicate_573 => {
       attributes => {
-        'aws_wafregional_rate_based_rule_predicate_573_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data_id' => String,
         'negated' => Boolean,
         'type' => String
@@ -31558,21 +29264,13 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_regex_match_set_regex_match_tuple_574 => {
       attributes => {
-        'aws_wafregional_regex_match_set_regex_match_tuple_574_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_to_match' => Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575,
+        'field_to_match' => Array[Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575],
         'regex_pattern_set_id' => String,
         'text_transformation' => String
       }
     },
     Aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575 => {
       attributes => {
-        'aws_wafregional_regex_match_set_regex_match_tuple_574_field_to_match_575_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31656,11 +29354,7 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_rule_group_activated_rule_577 => {
       attributes => {
-        'aws_wafregional_rule_group_activated_rule_577_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'action' => Aws_wafregional_rule_group_activated_rule_577_action_578,
+        'action' => Array[Aws_wafregional_rule_group_activated_rule_577_action_578],
         'priority' => Integer,
         'rule_id' => String,
         'type' => {
@@ -31671,19 +29365,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_rule_group_activated_rule_577_action_578 => {
       attributes => {
-        'aws_wafregional_rule_group_activated_rule_577_action_578_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_wafregional_rule_predicate_576 => {
       attributes => {
-        'aws_wafregional_rule_predicate_576_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data_id' => String,
         'negated' => Boolean,
         'type' => String
@@ -31715,10 +29401,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_size_constraint_set_size_constraints_579 => {
       attributes => {
-        'aws_wafregional_size_constraint_set_size_constraints_579_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'comparison_operator' => String,
         'field_to_match' => Aws_wafregional_size_constraint_set_size_constraints_579_field_to_match_580,
         'size' => Integer,
@@ -31727,10 +29409,6 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_size_constraint_set_size_constraints_579_field_to_match_580 => {
       attributes => {
-        'aws_wafregional_size_constraint_set_size_constraints_579_field_to_match_580_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31764,20 +29442,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581 => {
       attributes => {
-        'aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_to_match' => Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582,
+        'field_to_match' => Array[Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582],
         'text_transformation' => String
       }
     },
     Aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582 => {
       attributes => {
-        'aws_wafregional_sql_injection_match_set_sql_injection_match_tuple_581_field_to_match_582_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef
@@ -31791,7 +29461,7 @@ type TerraformAws = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'default_action' => Aws_wafregional_web_acl_default_action_583,
+        'default_action' => Array[Aws_wafregional_web_acl_default_action_583],
         'metric_name' => String,
         'name' => String,
         'rule' => {
@@ -31834,25 +29504,17 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_web_acl_default_action_583 => {
       attributes => {
-        'aws_wafregional_web_acl_default_action_583_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_wafregional_web_acl_rule_584 => {
       attributes => {
-        'aws_wafregional_web_acl_rule_584_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => {
-          'type' => Optional[Aws_wafregional_web_acl_rule_584_action_585],
+          'type' => Optional[Array[Aws_wafregional_web_acl_rule_584_action_585]],
           'value' => undef
         },
         'override_action' => {
-          'type' => Optional[Aws_wafregional_web_acl_rule_584_override_action_586],
+          'type' => Optional[Array[Aws_wafregional_web_acl_rule_584_override_action_586]],
           'value' => undef
         },
         'priority' => Integer,
@@ -31865,19 +29527,11 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_web_acl_rule_584_action_585 => {
       attributes => {
-        'aws_wafregional_web_acl_rule_584_action_585_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
     Aws_wafregional_web_acl_rule_584_override_action_586 => {
       attributes => {
-        'aws_wafregional_web_acl_rule_584_override_action_586_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'type' => String
       }
     },
@@ -31907,20 +29561,12 @@ type TerraformAws = TypeSet[{
     },
     Aws_wafregional_xss_match_set_xss_match_tuple_587 => {
       attributes => {
-        'aws_wafregional_xss_match_set_xss_match_tuple_587_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'field_to_match' => Aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588,
         'text_transformation' => String
       }
     },
     Aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588 => {
       attributes => {
-        'aws_wafregional_xss_match_set_xss_match_tuple_587_field_to_match_588_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'data' => {
           'type' => Optional[String],
           'value' => undef

--- a/plugins/aaa-terraform-google.pp
+++ b/plugins/aaa-terraform-google.pp
@@ -31,7 +31,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'feature_settings' => {
-          'type' => Optional[Google_app_engine_application_feature_settings_1532],
+          'type' => Optional[Array[Google_app_engine_application_feature_settings_1532]],
           'value' => undef
         },
         'gcr_domain' => {
@@ -52,7 +52,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'url_dispatch_rule' => {
-          'type' => Optional[Google_app_engine_application_url_dispatch_rule_1533],
+          'type' => Optional[Array[Google_app_engine_application_url_dispatch_rule_1533]],
           'value' => undef
         }
       }
@@ -70,10 +70,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_app_engine_application_feature_settings_1532 => {
       attributes => {
-        'google_app_engine_application_feature_settings_1532_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'split_health_checks' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -82,10 +78,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_app_engine_application_url_dispatch_rule_1533 => {
       attributes => {
-        'google_app_engine_application_url_dispatch_rule_1533_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'domain' => {
           'type' => Optional[String],
           'value' => undef
@@ -107,7 +99,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'access' => {
-          'type' => Optional[Google_bigquery_dataset_access_1534],
+          'type' => Optional[Array[Google_bigquery_dataset_access_1534]],
           'value' => undef
         },
         'creation_time' => {
@@ -166,10 +158,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_bigquery_dataset_access_1534 => {
       attributes => {
-        'google_bigquery_dataset_access_1534_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'domain' => {
           'type' => Optional[String],
           'value' => undef
@@ -191,17 +179,13 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'view' => {
-          'type' => Optional[Google_bigquery_dataset_access_1534_view_1535],
+          'type' => Optional[Array[Google_bigquery_dataset_access_1534_view_1535]],
           'value' => undef
         }
       }
     },
     Google_bigquery_dataset_access_1534_view_1535 => {
       attributes => {
-        'google_bigquery_dataset_access_1534_view_1535_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_id' => String,
         'project_id' => String,
         'table_id' => String
@@ -272,7 +256,7 @@ type TerraformGoogle = TypeSet[{
         },
         'table_id' => String,
         'time_partitioning' => {
-          'type' => Optional[Google_bigquery_table_time_partitioning_1536],
+          'type' => Optional[Array[Google_bigquery_table_time_partitioning_1536]],
           'value' => undef
         },
         'type' => {
@@ -280,7 +264,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'view' => {
-          'type' => Optional[Google_bigquery_table_view_1537],
+          'type' => Optional[Array[Google_bigquery_table_view_1537]],
           'value' => undef
         }
       }
@@ -298,10 +282,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_bigquery_table_time_partitioning_1536 => {
       attributes => {
-        'google_bigquery_table_time_partitioning_1536_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'expiration_ms' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -315,10 +295,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_bigquery_table_view_1537 => {
       attributes => {
-        'google_bigquery_table_view_1537_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'query' => String,
         'use_legacy_sql' => {
           'type' => Optional[Boolean],
@@ -380,10 +356,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_bigtable_instance_cluster_1538 => {
       attributes => {
-        'google_bigtable_instance_cluster_1538_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cluster_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -514,7 +486,7 @@ type TerraformGoogle = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'attestation_authority_note' => Google_binary_authorization_attestor_attestation_authority_note_1539,
+        'attestation_authority_note' => Array[Google_binary_authorization_attestor_attestation_authority_note_1539],
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -539,27 +511,19 @@ type TerraformGoogle = TypeSet[{
     },
     Google_binary_authorization_attestor_attestation_authority_note_1539 => {
       attributes => {
-        'google_binary_authorization_attestor_attestation_authority_note_1539_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'delegation_service_account_email' => {
           'type' => Optional[String],
           'value' => undef
         },
         'note_reference' => String,
         'public_keys' => {
-          'type' => Optional[Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540],
+          'type' => Optional[Array[Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540]],
           'value' => undef
         }
       }
     },
     Google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540 => {
       attributes => {
-        'google_binary_authorization_attestor_attestation_authority_note_1539_public_keys_1540_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ascii_armored_pgp_public_key' => String,
         'comment' => {
           'type' => Optional[String],
@@ -578,14 +542,14 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'admission_whitelist_patterns' => {
-          'type' => Optional[Google_binary_authorization_policy_admission_whitelist_patterns_1541],
+          'type' => Optional[Array[Google_binary_authorization_policy_admission_whitelist_patterns_1541]],
           'value' => undef
         },
         'cluster_admission_rules' => {
           'type' => Optional[Google_binary_authorization_policy_cluster_admission_rules_1542],
           'value' => undef
         },
-        'default_admission_rule' => Google_binary_authorization_policy_default_admission_rule_1543,
+        'default_admission_rule' => Array[Google_binary_authorization_policy_default_admission_rule_1543],
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -609,10 +573,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_binary_authorization_policy_admission_whitelist_patterns_1541 => {
       attributes => {
-        'google_binary_authorization_policy_admission_whitelist_patterns_1541_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name_pattern' => {
           'type' => Optional[String],
           'value' => undef
@@ -621,10 +581,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_binary_authorization_policy_cluster_admission_rules_1542 => {
       attributes => {
-        'google_binary_authorization_policy_cluster_admission_rules_1542_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cluster' => String,
         'enforcement_mode' => {
           'type' => Optional[String],
@@ -642,10 +598,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_binary_authorization_policy_default_admission_rule_1543 => {
       attributes => {
-        'google_binary_authorization_policy_default_admission_rule_1543_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enforcement_mode' => String,
         'evaluation_mode' => String,
         'require_attestations_by' => {
@@ -661,7 +613,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'build' => {
-          'type' => Optional[Google_cloudbuild_trigger_build_1544],
+          'type' => Optional[Array[Google_cloudbuild_trigger_build_1544]],
           'value' => undef
         },
         'description' => {
@@ -681,7 +633,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'trigger_template' => {
-          'type' => Optional[Google_cloudbuild_trigger_trigger_template_1546],
+          'type' => Optional[Array[Google_cloudbuild_trigger_trigger_template_1546]],
           'value' => undef
         }
       }
@@ -699,16 +651,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_cloudbuild_trigger_build_1544 => {
       attributes => {
-        'google_cloudbuild_trigger_build_1544_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'images' => {
           'type' => Optional[Array[String]],
           'value' => undef
         },
         'step' => {
-          'type' => Optional[Google_cloudbuild_trigger_build_1544_step_1545],
+          'type' => Optional[Array[Google_cloudbuild_trigger_build_1544_step_1545]],
           'value' => undef
         },
         'tags' => {
@@ -719,10 +667,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_cloudbuild_trigger_build_1544_step_1545 => {
       attributes => {
-        'google_cloudbuild_trigger_build_1544_step_1545_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[String],
           'value' => undef
@@ -735,10 +679,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_cloudbuild_trigger_trigger_template_1546 => {
       attributes => {
-        'google_cloudbuild_trigger_trigger_template_1546_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'branch_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -788,7 +728,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'event_trigger' => {
-          'type' => Optional[Google_cloudfunctions_function_event_trigger_1547],
+          'type' => Optional[Array[Google_cloudfunctions_function_event_trigger_1547]],
           'value' => undef
         },
         'https_trigger_url' => {
@@ -849,13 +789,9 @@ type TerraformGoogle = TypeSet[{
     },
     Google_cloudfunctions_function_event_trigger_1547 => {
       attributes => {
-        'google_cloudfunctions_function_event_trigger_1547_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'event_type' => String,
         'failure_policy' => {
-          'type' => Optional[Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548],
+          'type' => Optional[Array[Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548]],
           'value' => undef
         },
         'resource' => String
@@ -863,10 +799,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_cloudfunctions_function_event_trigger_1547_failure_policy_1548 => {
       attributes => {
-        'google_cloudfunctions_function_event_trigger_1547_failure_policy_1548_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'retry' => Boolean
       }
     },
@@ -877,7 +809,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'credentials' => {
-          'type' => Optional[Google_cloudiot_registry_credentials_1549],
+          'type' => Optional[Array[Google_cloudiot_registry_credentials_1549]],
           'value' => undef
         },
         'event_notification_config' => {
@@ -920,10 +852,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_cloudiot_registry_credentials_1549 => {
       attributes => {
-        'google_cloudiot_registry_credentials_1549_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'public_key_certificate' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -937,7 +865,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'config' => {
-          'type' => Optional[Google_composer_environment_config_1550],
+          'type' => Optional[Array[Google_composer_environment_config_1550]],
           'value' => undef
         },
         'labels' => {
@@ -968,10 +896,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_composer_environment_config_1550 => {
       attributes => {
-        'google_composer_environment_config_1550_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'airflow_uri' => {
           'type' => Optional[String],
           'value' => undef
@@ -985,7 +909,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'node_config' => {
-          'type' => Optional[Google_composer_environment_config_1550_node_config_1551],
+          'type' => Optional[Array[Google_composer_environment_config_1550_node_config_1551]],
           'value' => undef
         },
         'node_count' => {
@@ -993,17 +917,13 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'software_config' => {
-          'type' => Optional[Google_composer_environment_config_1550_software_config_1552],
+          'type' => Optional[Array[Google_composer_environment_config_1550_software_config_1552]],
           'value' => undef
         }
       }
     },
     Google_composer_environment_config_1550_node_config_1551 => {
       attributes => {
-        'google_composer_environment_config_1550_node_config_1551_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -1040,10 +960,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_composer_environment_config_1550_software_config_1552 => {
       attributes => {
-        'google_composer_environment_config_1550_software_config_1552_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'airflow_config_overrides' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -1173,7 +1089,7 @@ type TerraformGoogle = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'autoscaling_policy' => Google_compute_autoscaler_autoscaling_policy_1553,
+        'autoscaling_policy' => Array[Google_compute_autoscaler_autoscaling_policy_1553],
         'creation_timestamp' => {
           'type' => Optional[String],
           'value' => undef
@@ -1211,25 +1127,21 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_autoscaler_autoscaling_policy_1553 => {
       attributes => {
-        'google_compute_autoscaler_autoscaling_policy_1553_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cooldown_period' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'cpu_utilization' => {
-          'type' => Optional[Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554],
+          'type' => Optional[Array[Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554]],
           'value' => undef
         },
         'load_balancing_utilization' => {
-          'type' => Optional[Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555],
+          'type' => Optional[Array[Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555]],
           'value' => undef
         },
         'max_replicas' => Integer,
         'metric' => {
-          'type' => Optional[Google_compute_autoscaler_autoscaling_policy_1553_metric_1556],
+          'type' => Optional[Array[Google_compute_autoscaler_autoscaling_policy_1553_metric_1556]],
           'value' => undef
         },
         'min_replicas' => Integer
@@ -1237,28 +1149,16 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554 => {
       attributes => {
-        'google_compute_autoscaler_autoscaling_policy_1553_cpu_utilization_1554_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'target' => Float
       }
     },
     Google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555 => {
       attributes => {
-        'google_compute_autoscaler_autoscaling_policy_1553_load_balancing_utilization_1555_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'target' => Float
       }
     },
     Google_compute_autoscaler_autoscaling_policy_1553_metric_1556 => {
       attributes => {
-        'google_compute_autoscaler_autoscaling_policy_1553_metric_1556_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'target' => Float,
         'type' => String
@@ -1316,7 +1216,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'cdn_policy' => {
-          'type' => Optional[Google_compute_backend_service_cdn_policy_1558],
+          'type' => Optional[Array[Google_compute_backend_service_cdn_policy_1558]],
           'value' => undef
         },
         'connection_draining_timeout_sec' => {
@@ -1341,7 +1241,7 @@ type TerraformGoogle = TypeSet[{
         },
         'health_checks' => Array[String],
         'iap' => {
-          'type' => Optional[Google_compute_backend_service_iap_1560],
+          'type' => Optional[Array[Google_compute_backend_service_iap_1560]],
           'value' => undef
         },
         'name' => String,
@@ -1392,10 +1292,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_backend_service_backend_1557 => {
       attributes => {
-        'google_compute_backend_service_backend_1557_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'balancing_mode' => {
           'type' => Optional[String],
           'value' => undef
@@ -1436,22 +1332,14 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_backend_service_cdn_policy_1558 => {
       attributes => {
-        'google_compute_backend_service_cdn_policy_1558_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cache_key_policy' => {
-          'type' => Optional[Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559],
+          'type' => Optional[Array[Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559]],
           'value' => undef
         }
       }
     },
     Google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559 => {
       attributes => {
-        'google_compute_backend_service_cdn_policy_1558_cache_key_policy_1559_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'include_host' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -1476,10 +1364,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_backend_service_iap_1560 => {
       attributes => {
-        'google_compute_backend_service_iap_1560_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'oauth2_client_id' => String,
         'oauth2_client_secret' => String
       }
@@ -1499,7 +1383,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'disk_encryption_key' => {
-          'type' => Optional[Google_compute_disk_disk_encryption_key_1561],
+          'type' => Optional[Array[Google_compute_disk_disk_encryption_key_1561]],
           'value' => undef
         },
         'disk_encryption_key_raw' => {
@@ -1548,7 +1432,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'source_image_encryption_key' => {
-          'type' => Optional[Google_compute_disk_source_image_encryption_key_1562],
+          'type' => Optional[Array[Google_compute_disk_source_image_encryption_key_1562]],
           'value' => undef
         },
         'source_image_id' => {
@@ -1556,7 +1440,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'source_snapshot_encryption_key' => {
-          'type' => Optional[Google_compute_disk_source_snapshot_encryption_key_1563],
+          'type' => Optional[Array[Google_compute_disk_source_snapshot_encryption_key_1563]],
           'value' => undef
         },
         'source_snapshot_id' => {
@@ -1590,10 +1474,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_disk_disk_encryption_key_1561 => {
       attributes => {
-        'google_compute_disk_disk_encryption_key_1561_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -1606,10 +1486,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_disk_source_image_encryption_key_1562 => {
       attributes => {
-        'google_compute_disk_source_image_encryption_key_1562_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -1622,10 +1498,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_disk_source_snapshot_encryption_key_1563 => {
       attributes => {
-        'google_compute_disk_source_snapshot_encryption_key_1563_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -1723,10 +1595,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_firewall_allow_1564 => {
       attributes => {
-        'google_compute_firewall_allow_1564_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ports' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1736,10 +1604,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_firewall_deny_1565 => {
       attributes => {
-        'google_compute_firewall_deny_1565_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ports' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1999,11 +1863,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'http_health_check' => {
-          'type' => Optional[Google_compute_health_check_http_health_check_1566],
+          'type' => Optional[Array[Google_compute_health_check_http_health_check_1566]],
           'value' => undef
         },
         'https_health_check' => {
-          'type' => Optional[Google_compute_health_check_https_health_check_1567],
+          'type' => Optional[Array[Google_compute_health_check_https_health_check_1567]],
           'value' => undef
         },
         'name' => String,
@@ -2016,11 +1880,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'ssl_health_check' => {
-          'type' => Optional[Google_compute_health_check_ssl_health_check_1568],
+          'type' => Optional[Array[Google_compute_health_check_ssl_health_check_1568]],
           'value' => undef
         },
         'tcp_health_check' => {
-          'type' => Optional[Google_compute_health_check_tcp_health_check_1569],
+          'type' => Optional[Array[Google_compute_health_check_tcp_health_check_1569]],
           'value' => undef
         },
         'timeout_sec' => {
@@ -2050,10 +1914,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_health_check_http_health_check_1566 => {
       attributes => {
-        'google_compute_health_check_http_health_check_1566_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
@@ -2078,10 +1938,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_health_check_https_health_check_1567 => {
       attributes => {
-        'google_compute_health_check_https_health_check_1567_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
@@ -2106,10 +1962,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_health_check_ssl_health_check_1568 => {
       attributes => {
-        'google_compute_health_check_ssl_health_check_1568_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -2130,10 +1982,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_health_check_tcp_health_check_1569 => {
       attributes => {
-        'google_compute_health_check_tcp_health_check_1569_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -2316,7 +2164,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'raw_disk' => {
-          'type' => Optional[Google_compute_image_raw_disk_1570],
+          'type' => Optional[Array[Google_compute_image_raw_disk_1570]],
           'value' => undef
         },
         'self_link' => {
@@ -2342,10 +2190,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_image_raw_disk_1570 => {
       attributes => {
-        'google_compute_image_raw_disk_1570_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2368,10 +2212,10 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'attached_disk' => {
-          'type' => Optional[Google_compute_instance_attached_disk_1571],
+          'type' => Optional[Array[Google_compute_instance_attached_disk_1571]],
           'value' => undef
         },
-        'boot_disk' => Google_compute_instance_boot_disk_1572,
+        'boot_disk' => Array[Google_compute_instance_boot_disk_1572],
         'can_ip_forward' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2393,11 +2237,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'disk' => {
-          'type' => Optional[Google_compute_instance_disk_1574],
+          'type' => Optional[Array[Google_compute_instance_disk_1574]],
           'value' => undef
         },
         'guest_accelerator' => {
-          'type' => Optional[Google_compute_instance_guest_accelerator_1575],
+          'type' => Optional[Array[Google_compute_instance_guest_accelerator_1575]],
           'value' => undef
         },
         'instance_id' => {
@@ -2431,20 +2275,20 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'network' => {
-          'type' => Optional[Google_compute_instance_network_1576],
+          'type' => Optional[Array[Google_compute_instance_network_1576]],
           'value' => undef
         },
-        'network_interface' => Google_compute_instance_network_interface_1577,
+        'network_interface' => Array[Google_compute_instance_network_interface_1577],
         'project' => {
           'type' => Optional[String],
           'value' => undef
         },
         'scheduling' => {
-          'type' => Optional[Google_compute_instance_scheduling_1580],
+          'type' => Optional[Array[Google_compute_instance_scheduling_1580]],
           'value' => undef
         },
         'scratch_disk' => {
-          'type' => Optional[Google_compute_instance_scratch_disk_1581],
+          'type' => Optional[Array[Google_compute_instance_scratch_disk_1581]],
           'value' => undef
         },
         'self_link' => {
@@ -2452,7 +2296,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'service_account' => {
-          'type' => Optional[Google_compute_instance_service_account_1582],
+          'type' => Optional[Array[Google_compute_instance_service_account_1582]],
           'value' => undef
         },
         'tags' => {
@@ -2482,10 +2326,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_attached_disk_1571 => {
       attributes => {
-        'google_compute_instance_attached_disk_1571_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2507,10 +2347,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_boot_disk_1572 => {
       attributes => {
-        'google_compute_instance_boot_disk_1572_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_delete' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2528,7 +2364,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'initialize_params' => {
-          'type' => Optional[Google_compute_instance_boot_disk_1572_initialize_params_1573],
+          'type' => Optional[Array[Google_compute_instance_boot_disk_1572_initialize_params_1573]],
           'value' => undef
         },
         'source' => {
@@ -2539,10 +2375,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_boot_disk_1572_initialize_params_1573 => {
       attributes => {
-        'google_compute_instance_boot_disk_1572_initialize_params_1573_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'image' => {
           'type' => Optional[String],
           'value' => undef
@@ -2559,10 +2391,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_disk_1574 => {
       attributes => {
-        'google_compute_instance_disk_1574_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_delete' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2612,11 +2440,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'attached_disk' => {
-          'type' => Optional[Google_compute_instance_from_template_attached_disk_1583],
+          'type' => Optional[Array[Google_compute_instance_from_template_attached_disk_1583]],
           'value' => undef
         },
         'boot_disk' => {
-          'type' => Optional[Google_compute_instance_from_template_boot_disk_1584],
+          'type' => Optional[Array[Google_compute_instance_from_template_boot_disk_1584]],
           'value' => undef
         },
         'can_ip_forward' => {
@@ -2636,7 +2464,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'guest_accelerator' => {
-          'type' => Optional[Google_compute_instance_from_template_guest_accelerator_1586],
+          'type' => Optional[Array[Google_compute_instance_from_template_guest_accelerator_1586]],
           'value' => undef
         },
         'instance_id' => {
@@ -2673,7 +2501,7 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'network_interface' => {
-          'type' => Optional[Google_compute_instance_from_template_network_interface_1587],
+          'type' => Optional[Array[Google_compute_instance_from_template_network_interface_1587]],
           'value' => undef
         },
         'project' => {
@@ -2681,11 +2509,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'scheduling' => {
-          'type' => Optional[Google_compute_instance_from_template_scheduling_1590],
+          'type' => Optional[Array[Google_compute_instance_from_template_scheduling_1590]],
           'value' => undef
         },
         'scratch_disk' => {
-          'type' => Optional[Google_compute_instance_from_template_scratch_disk_1591],
+          'type' => Optional[Array[Google_compute_instance_from_template_scratch_disk_1591]],
           'value' => undef
         },
         'self_link' => {
@@ -2693,7 +2521,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'service_account' => {
-          'type' => Optional[Google_compute_instance_from_template_service_account_1592],
+          'type' => Optional[Array[Google_compute_instance_from_template_service_account_1592]],
           'value' => undef
         },
         'source_instance_template' => String,
@@ -2724,10 +2552,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_attached_disk_1583 => {
       attributes => {
-        'google_compute_instance_from_template_attached_disk_1583_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'device_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2749,10 +2573,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_boot_disk_1584 => {
       attributes => {
-        'google_compute_instance_from_template_boot_disk_1584_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_delete' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2770,7 +2590,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'initialize_params' => {
-          'type' => Optional[Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585],
+          'type' => Optional[Array[Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585]],
           'value' => undef
         },
         'source' => {
@@ -2781,10 +2601,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_boot_disk_1584_initialize_params_1585 => {
       attributes => {
-        'google_compute_instance_from_template_boot_disk_1584_initialize_params_1585_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'image' => {
           'type' => Optional[String],
           'value' => undef
@@ -2801,22 +2617,14 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_guest_accelerator_1586 => {
       attributes => {
-        'google_compute_instance_from_template_guest_accelerator_1586_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer,
         'type' => String
       }
     },
     Google_compute_instance_from_template_network_interface_1587 => {
       attributes => {
-        'google_compute_instance_from_template_network_interface_1587_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_config' => {
-          'type' => Optional[Google_compute_instance_from_template_network_interface_1587_access_config_1588],
+          'type' => Optional[Array[Google_compute_instance_from_template_network_interface_1587_access_config_1588]],
           'value' => undef
         },
         'address' => {
@@ -2824,7 +2632,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'alias_ip_range' => {
-          'type' => Optional[Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589],
+          'type' => Optional[Array[Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589]],
           'value' => undef
         },
         'name' => {
@@ -2851,10 +2659,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_network_interface_1587_access_config_1588 => {
       attributes => {
-        'google_compute_instance_from_template_network_interface_1587_access_config_1588_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'assigned_nat_ip' => {
           'type' => Optional[String],
           'value' => undef
@@ -2875,10 +2679,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589 => {
       attributes => {
-        'google_compute_instance_from_template_network_interface_1587_alias_ip_range_1589_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_cidr_range' => String,
         'subnetwork_range_name' => {
           'type' => Optional[String],
@@ -2888,10 +2688,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_scheduling_1590 => {
       attributes => {
-        'google_compute_instance_from_template_scheduling_1590_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'automatic_restart' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2908,10 +2704,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_scratch_disk_1591 => {
       attributes => {
-        'google_compute_instance_from_template_scratch_disk_1591_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'interface' => {
           'type' => Optional[String],
           'value' => undef
@@ -2920,10 +2712,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_from_template_service_account_1592 => {
       attributes => {
-        'google_compute_instance_from_template_service_account_1592_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'email' => {
           'type' => Optional[String],
           'value' => undef
@@ -2947,7 +2735,7 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'named_port' => {
-          'type' => Optional[Google_compute_instance_group_named_port_1593],
+          'type' => Optional[Array[Google_compute_instance_group_named_port_1593]],
           'value' => undef
         },
         'network' => {
@@ -2990,7 +2778,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'auto_healing_policies' => {
-          'type' => Optional[Google_compute_instance_group_manager_auto_healing_policies_1594],
+          'type' => Optional[Array[Google_compute_instance_group_manager_auto_healing_policies_1594]],
           'value' => undef
         },
         'base_instance_name' => String,
@@ -3012,7 +2800,7 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'named_port' => {
-          'type' => Optional[Google_compute_instance_group_manager_named_port_1595],
+          'type' => Optional[Array[Google_compute_instance_group_manager_named_port_1595]],
           'value' => undef
         },
         'project' => {
@@ -3020,7 +2808,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'rolling_update_policy' => {
-          'type' => Optional[Google_compute_instance_group_manager_rolling_update_policy_1596],
+          'type' => Optional[Array[Google_compute_instance_group_manager_rolling_update_policy_1596]],
           'value' => undef
         },
         'self_link' => {
@@ -3040,7 +2828,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'version' => {
-          'type' => Optional[Google_compute_instance_group_manager_version_1597],
+          'type' => Optional[Array[Google_compute_instance_group_manager_version_1597]],
           'value' => undef
         },
         'wait_for_instances' => {
@@ -3066,30 +2854,18 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_group_manager_auto_healing_policies_1594 => {
       attributes => {
-        'google_compute_instance_group_manager_auto_healing_policies_1594_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'health_check' => String,
         'initial_delay_sec' => Integer
       }
     },
     Google_compute_instance_group_manager_named_port_1595 => {
       attributes => {
-        'google_compute_instance_group_manager_named_port_1595_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'port' => Integer
       }
     },
     Google_compute_instance_group_manager_rolling_update_policy_1596 => {
       attributes => {
-        'google_compute_instance_group_manager_rolling_update_policy_1596_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_surge_fixed' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -3116,24 +2892,16 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_group_manager_version_1597 => {
       attributes => {
-        'google_compute_instance_group_manager_version_1597_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'instance_template' => String,
         'name' => String,
         'target_size' => {
-          'type' => Optional[Google_compute_instance_group_manager_version_1597_target_size_1598],
+          'type' => Optional[Array[Google_compute_instance_group_manager_version_1597_target_size_1598]],
           'value' => undef
         }
       }
     },
     Google_compute_instance_group_manager_version_1597_target_size_1598 => {
       attributes => {
-        'google_compute_instance_group_manager_version_1597_target_size_1598_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fixed' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -3146,30 +2914,18 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_group_named_port_1593 => {
       attributes => {
-        'google_compute_instance_group_named_port_1593_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'port' => Integer
       }
     },
     Google_compute_instance_guest_accelerator_1575 => {
       attributes => {
-        'google_compute_instance_guest_accelerator_1575_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer,
         'type' => String
       }
     },
     Google_compute_instance_network_1576 => {
       attributes => {
-        'google_compute_instance_network_1576_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'address' => {
           'type' => Optional[String],
           'value' => undef
@@ -3191,12 +2947,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_network_interface_1577 => {
       attributes => {
-        'google_compute_instance_network_interface_1577_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_config' => {
-          'type' => Optional[Google_compute_instance_network_interface_1577_access_config_1578],
+          'type' => Optional[Array[Google_compute_instance_network_interface_1577_access_config_1578]],
           'value' => undef
         },
         'address' => {
@@ -3204,7 +2956,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'alias_ip_range' => {
-          'type' => Optional[Google_compute_instance_network_interface_1577_alias_ip_range_1579],
+          'type' => Optional[Array[Google_compute_instance_network_interface_1577_alias_ip_range_1579]],
           'value' => undef
         },
         'name' => {
@@ -3231,10 +2983,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_network_interface_1577_access_config_1578 => {
       attributes => {
-        'google_compute_instance_network_interface_1577_access_config_1578_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'assigned_nat_ip' => {
           'type' => Optional[String],
           'value' => undef
@@ -3255,10 +3003,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_network_interface_1577_alias_ip_range_1579 => {
       attributes => {
-        'google_compute_instance_network_interface_1577_alias_ip_range_1579_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_cidr_range' => String,
         'subnetwork_range_name' => {
           'type' => Optional[String],
@@ -3268,10 +3012,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_scheduling_1580 => {
       attributes => {
-        'google_compute_instance_scheduling_1580_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'automatic_restart' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -3288,10 +3028,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_scratch_disk_1581 => {
       attributes => {
-        'google_compute_instance_scratch_disk_1581_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'interface' => {
           'type' => Optional[String],
           'value' => undef
@@ -3300,10 +3036,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_service_account_1582 => {
       attributes => {
-        'google_compute_instance_service_account_1582_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'email' => {
           'type' => Optional[String],
           'value' => undef
@@ -3329,9 +3061,9 @@ type TerraformGoogle = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'disk' => Google_compute_instance_template_disk_1599,
+        'disk' => Array[Google_compute_instance_template_disk_1599],
         'guest_accelerator' => {
-          'type' => Optional[Google_compute_instance_template_guest_accelerator_1601],
+          'type' => Optional[Array[Google_compute_instance_template_guest_accelerator_1601]],
           'value' => undef
         },
         'instance_description' => {
@@ -3368,7 +3100,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'network_interface' => {
-          'type' => Optional[Google_compute_instance_template_network_interface_1602],
+          'type' => Optional[Array[Google_compute_instance_template_network_interface_1602]],
           'value' => undef
         },
         'on_host_maintenance' => {
@@ -3384,7 +3116,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'scheduling' => {
-          'type' => Optional[Google_compute_instance_template_scheduling_1605],
+          'type' => Optional[Array[Google_compute_instance_template_scheduling_1605]],
           'value' => undef
         },
         'self_link' => {
@@ -3392,7 +3124,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'service_account' => {
-          'type' => Optional[Google_compute_instance_template_service_account_1606],
+          'type' => Optional[Array[Google_compute_instance_template_service_account_1606]],
           'value' => undef
         },
         'tags' => {
@@ -3418,10 +3150,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_disk_1599 => {
       attributes => {
-        'google_compute_instance_template_disk_1599_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_delete' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -3435,7 +3163,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'disk_encryption_key' => {
-          'type' => Optional[Google_compute_instance_template_disk_1599_disk_encryption_key_1600],
+          'type' => Optional[Array[Google_compute_instance_template_disk_1599_disk_encryption_key_1600]],
           'value' => undef
         },
         'disk_name' => {
@@ -3474,10 +3202,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_disk_1599_disk_encryption_key_1600 => {
       attributes => {
-        'google_compute_instance_template_disk_1599_disk_encryption_key_1600_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'kms_key_self_link' => {
           'type' => Optional[String],
           'value' => undef
@@ -3486,22 +3210,14 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_guest_accelerator_1601 => {
       attributes => {
-        'google_compute_instance_template_guest_accelerator_1601_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer,
         'type' => String
       }
     },
     Google_compute_instance_template_network_interface_1602 => {
       attributes => {
-        'google_compute_instance_template_network_interface_1602_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_config' => {
-          'type' => Optional[Google_compute_instance_template_network_interface_1602_access_config_1603],
+          'type' => Optional[Array[Google_compute_instance_template_network_interface_1602_access_config_1603]],
           'value' => undef
         },
         'address' => {
@@ -3509,7 +3225,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'alias_ip_range' => {
-          'type' => Optional[Google_compute_instance_template_network_interface_1602_alias_ip_range_1604],
+          'type' => Optional[Array[Google_compute_instance_template_network_interface_1602_alias_ip_range_1604]],
           'value' => undef
         },
         'network' => {
@@ -3532,10 +3248,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_network_interface_1602_access_config_1603 => {
       attributes => {
-        'google_compute_instance_template_network_interface_1602_access_config_1603_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'assigned_nat_ip' => {
           'type' => Optional[String],
           'value' => undef
@@ -3552,10 +3264,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_network_interface_1602_alias_ip_range_1604 => {
       attributes => {
-        'google_compute_instance_template_network_interface_1602_alias_ip_range_1604_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_cidr_range' => String,
         'subnetwork_range_name' => {
           'type' => Optional[String],
@@ -3565,10 +3273,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_scheduling_1605 => {
       attributes => {
-        'google_compute_instance_template_scheduling_1605_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'automatic_restart' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -3585,10 +3289,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_instance_template_service_account_1606 => {
       attributes => {
-        'google_compute_instance_template_service_account_1606_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'email' => {
           'type' => Optional[String],
           'value' => undef
@@ -3625,7 +3325,7 @@ type TerraformGoogle = TypeSet[{
         'interconnect' => String,
         'name' => String,
         'private_interconnect_info' => {
-          'type' => Optional[Google_compute_interconnect_attachment_private_interconnect_info_1607],
+          'type' => Optional[Array[Google_compute_interconnect_attachment_private_interconnect_info_1607]],
           'value' => undef
         },
         'project' => {
@@ -3656,10 +3356,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_interconnect_attachment_private_interconnect_info_1607 => {
       attributes => {
-        'google_compute_interconnect_attachment_private_interconnect_info_1607_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'tag8021q' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -3803,7 +3499,7 @@ type TerraformGoogle = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'autoscaling_policy' => Google_compute_region_autoscaler_autoscaling_policy_1608,
+        'autoscaling_policy' => Array[Google_compute_region_autoscaler_autoscaling_policy_1608],
         'creation_timestamp' => {
           'type' => Optional[String],
           'value' => undef
@@ -3841,25 +3537,21 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_autoscaler_autoscaling_policy_1608 => {
       attributes => {
-        'google_compute_region_autoscaler_autoscaling_policy_1608_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cooldown_period' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'cpu_utilization' => {
-          'type' => Optional[Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609],
+          'type' => Optional[Array[Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609]],
           'value' => undef
         },
         'load_balancing_utilization' => {
-          'type' => Optional[Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610],
+          'type' => Optional[Array[Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610]],
           'value' => undef
         },
         'max_replicas' => Integer,
         'metric' => {
-          'type' => Optional[Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611],
+          'type' => Optional[Array[Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611]],
           'value' => undef
         },
         'min_replicas' => Integer
@@ -3867,28 +3559,16 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609 => {
       attributes => {
-        'google_compute_region_autoscaler_autoscaling_policy_1608_cpu_utilization_1609_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'target' => Float
       }
     },
     Google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610 => {
       attributes => {
-        'google_compute_region_autoscaler_autoscaling_policy_1608_load_balancing_utilization_1610_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'target' => Float
       }
     },
     Google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611 => {
       attributes => {
-        'google_compute_region_autoscaler_autoscaling_policy_1608_metric_1611_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'target' => Float,
         'type' => String
@@ -3957,10 +3637,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_backend_service_backend_1612 => {
       attributes => {
-        'google_compute_region_backend_service_backend_1612_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -3986,7 +3662,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'disk_encryption_key' => {
-          'type' => Optional[Google_compute_region_disk_disk_encryption_key_1613],
+          'type' => Optional[Array[Google_compute_region_disk_disk_encryption_key_1613]],
           'value' => undef
         },
         'label_fingerprint' => {
@@ -4028,7 +3704,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'source_snapshot_encryption_key' => {
-          'type' => Optional[Google_compute_region_disk_source_snapshot_encryption_key_1614],
+          'type' => Optional[Array[Google_compute_region_disk_source_snapshot_encryption_key_1614]],
           'value' => undef
         },
         'source_snapshot_id' => {
@@ -4058,10 +3734,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_disk_disk_encryption_key_1613 => {
       attributes => {
-        'google_compute_region_disk_disk_encryption_key_1613_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -4074,10 +3746,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_disk_source_snapshot_encryption_key_1614 => {
       attributes => {
-        'google_compute_region_disk_source_snapshot_encryption_key_1614_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -4095,7 +3763,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'auto_healing_policies' => {
-          'type' => Optional[Google_compute_region_instance_group_manager_auto_healing_policies_1615],
+          'type' => Optional[Array[Google_compute_region_instance_group_manager_auto_healing_policies_1615]],
           'value' => undef
         },
         'base_instance_name' => String,
@@ -4121,7 +3789,7 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'named_port' => {
-          'type' => Optional[Google_compute_region_instance_group_manager_named_port_1616],
+          'type' => Optional[Array[Google_compute_region_instance_group_manager_named_port_1616]],
           'value' => undef
         },
         'project' => {
@@ -4130,7 +3798,7 @@ type TerraformGoogle = TypeSet[{
         },
         'region' => String,
         'rolling_update_policy' => {
-          'type' => Optional[Google_compute_region_instance_group_manager_rolling_update_policy_1617],
+          'type' => Optional[Array[Google_compute_region_instance_group_manager_rolling_update_policy_1617]],
           'value' => undef
         },
         'self_link' => {
@@ -4150,7 +3818,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'version' => {
-          'type' => Optional[Google_compute_region_instance_group_manager_version_1618],
+          'type' => Optional[Array[Google_compute_region_instance_group_manager_version_1618]],
           'value' => undef
         },
         'wait_for_instances' => {
@@ -4172,30 +3840,18 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_instance_group_manager_auto_healing_policies_1615 => {
       attributes => {
-        'google_compute_region_instance_group_manager_auto_healing_policies_1615_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'health_check' => String,
         'initial_delay_sec' => Integer
       }
     },
     Google_compute_region_instance_group_manager_named_port_1616 => {
       attributes => {
-        'google_compute_region_instance_group_manager_named_port_1616_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'port' => Integer
       }
     },
     Google_compute_region_instance_group_manager_rolling_update_policy_1617 => {
       attributes => {
-        'google_compute_region_instance_group_manager_rolling_update_policy_1617_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_surge_fixed' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -4222,24 +3878,16 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_region_instance_group_manager_version_1618 => {
       attributes => {
-        'google_compute_region_instance_group_manager_version_1618_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'instance_template' => String,
         'name' => String,
         'target_size' => {
-          'type' => Optional[Google_compute_region_instance_group_manager_version_1618_target_size_1619],
+          'type' => Optional[Array[Google_compute_region_instance_group_manager_version_1618_target_size_1619]],
           'value' => undef
         }
       }
     },
     Google_compute_region_instance_group_manager_version_1618_target_size_1619 => {
       attributes => {
-        'google_compute_region_instance_group_manager_version_1618_target_size_1619_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fixed' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -4323,7 +3971,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'bgp' => {
-          'type' => Optional[Google_compute_router_bgp_1620],
+          'type' => Optional[Array[Google_compute_router_bgp_1620]],
           'value' => undef
         },
         'creation_timestamp' => {
@@ -4363,10 +4011,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_router_bgp_1620 => {
       attributes => {
-        'google_compute_router_bgp_1620_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'advertise_mode' => {
           'type' => Optional[String],
           'value' => undef
@@ -4376,7 +4020,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'advertised_ip_ranges' => {
-          'type' => Optional[Google_compute_router_bgp_1620_advertised_ip_ranges_1621],
+          'type' => Optional[Array[Google_compute_router_bgp_1620_advertised_ip_ranges_1621]],
           'value' => undef
         },
         'asn' => Integer
@@ -4384,10 +4028,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_router_bgp_1620_advertised_ip_ranges_1621 => {
       attributes => {
-        'google_compute_router_bgp_1620_advertised_ip_ranges_1621_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -4496,10 +4136,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_router_nat_subnetwork_1622 => {
       attributes => {
-        'google_compute_router_nat_subnetwork_1622_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'secondary_ip_range_names' => {
           'type' => Optional[Array[String]],
@@ -4596,16 +4232,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_security_policy_rule_1623 => {
       attributes => {
-        'google_compute_security_policy_rule_1623_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => String,
         'description' => {
           'type' => Optional[String],
           'value' => undef
         },
-        'match' => Google_compute_security_policy_rule_1623_match_1624,
+        'match' => Array[Google_compute_security_policy_rule_1623_match_1624],
         'preview' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -4615,20 +4247,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_security_policy_rule_1623_match_1624 => {
       attributes => {
-        'google_compute_security_policy_rule_1623_match_1624_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'config' => Google_compute_security_policy_rule_1623_match_1624_config_1625,
+        'config' => Array[Google_compute_security_policy_rule_1623_match_1624_config_1625],
         'versioned_expr' => String
       }
     },
     Google_compute_security_policy_rule_1623_match_1624_config_1625 => {
       attributes => {
-        'google_compute_security_policy_rule_1623_match_1624_config_1625_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'src_ip_ranges' => Array[String]
       }
     },
@@ -4713,7 +4337,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'snapshot_encryption_key' => {
-          'type' => Optional[Google_compute_snapshot_snapshot_encryption_key_1626],
+          'type' => Optional[Array[Google_compute_snapshot_snapshot_encryption_key_1626]],
           'value' => undef
         },
         'snapshot_encryption_key_raw' => {
@@ -4730,7 +4354,7 @@ type TerraformGoogle = TypeSet[{
         },
         'source_disk' => String,
         'source_disk_encryption_key' => {
-          'type' => Optional[Google_compute_snapshot_source_disk_encryption_key_1627],
+          'type' => Optional[Array[Google_compute_snapshot_source_disk_encryption_key_1627]],
           'value' => undef
         },
         'source_disk_encryption_key_raw' => {
@@ -4768,10 +4392,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_snapshot_snapshot_encryption_key_1626 => {
       attributes => {
-        'google_compute_snapshot_snapshot_encryption_key_1626_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -4784,10 +4404,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_snapshot_source_disk_encryption_key_1627 => {
       attributes => {
-        'google_compute_snapshot_source_disk_encryption_key_1627_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'raw_key' => {
           'type' => Optional[String],
           'value' => undef
@@ -4941,7 +4557,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'secondary_ip_range' => {
-          'type' => Optional[Google_compute_subnetwork_secondary_ip_range_1628],
+          'type' => Optional[Array[Google_compute_subnetwork_secondary_ip_range_1628]],
           'value' => undef
         },
         'self_link' => {
@@ -5064,10 +4680,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_subnetwork_secondary_ip_range_1628 => {
       attributes => {
-        'google_compute_subnetwork_secondary_ip_range_1628_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_cidr_range' => String,
         'range_name' => String
       }
@@ -5339,7 +4951,7 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'path_matcher' => {
-          'type' => Optional[Google_compute_url_map_path_matcher_1630],
+          'type' => Optional[Array[Google_compute_url_map_path_matcher_1630]],
           'value' => undef
         },
         'project' => {
@@ -5351,7 +4963,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'test' => {
-          'type' => Optional[Google_compute_url_map_test_1632],
+          'type' => Optional[Array[Google_compute_url_map_test_1632]],
           'value' => undef
         }
       }
@@ -5369,10 +4981,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_url_map_host_rule_1629 => {
       attributes => {
-        'google_compute_url_map_host_rule_1629_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -5383,10 +4991,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_compute_url_map_path_matcher_1630 => {
       attributes => {
-        'google_compute_url_map_path_matcher_1630_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_service' => String,
         'description' => {
           'type' => Optional[String],
@@ -5394,27 +4998,19 @@ type TerraformGoogle = TypeSet[{
         },
         'name' => String,
         'path_rule' => {
-          'type' => Optional[Google_compute_url_map_path_matcher_1630_path_rule_1631],
+          'type' => Optional[Array[Google_compute_url_map_path_matcher_1630_path_rule_1631]],
           'value' => undef
         }
       }
     },
     Google_compute_url_map_path_matcher_1630_path_rule_1631 => {
       attributes => {
-        'google_compute_url_map_path_matcher_1630_path_rule_1631_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'paths' => Array[String],
         'service' => String
       }
     },
     Google_compute_url_map_test_1632 => {
       attributes => {
-        'google_compute_url_map_test_1632_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'description' => {
           'type' => Optional[String],
           'value' => undef
@@ -5546,7 +5142,7 @@ type TerraformGoogle = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'attestation_authority' => Google_container_analysis_note_attestation_authority_1633,
+        'attestation_authority' => Array[Google_container_analysis_note_attestation_authority_1633],
         'name' => String,
         'project' => {
           'type' => Optional[String],
@@ -5567,19 +5163,11 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_analysis_note_attestation_authority_1633 => {
       attributes => {
-        'google_container_analysis_note_attestation_authority_1633_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'hint' => Google_container_analysis_note_attestation_authority_1633_hint_1634
+        'hint' => Array[Google_container_analysis_note_attestation_authority_1633_hint_1634]
       }
     },
     Google_container_analysis_note_attestation_authority_1633_hint_1634 => {
       attributes => {
-        'google_container_analysis_note_attestation_authority_1633_hint_1634_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'human_readable_name' => String
       }
     },
@@ -5594,11 +5182,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'addons_config' => {
-          'type' => Optional[Google_container_cluster_addons_config_1635],
+          'type' => Optional[Array[Google_container_cluster_addons_config_1635]],
           'value' => undef
         },
         'cluster_autoscaling' => {
-          'type' => Optional[Google_container_cluster_cluster_autoscaling_1640],
+          'type' => Optional[Array[Google_container_cluster_cluster_autoscaling_1640]],
           'value' => undef
         },
         'cluster_ipv4_cidr' => {
@@ -5638,7 +5226,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'ip_allocation_policy' => {
-          'type' => Optional[Google_container_cluster_ip_allocation_policy_1642],
+          'type' => Optional[Array[Google_container_cluster_ip_allocation_policy_1642]],
           'value' => undef
         },
         'logging_service' => {
@@ -5646,15 +5234,15 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'maintenance_policy' => {
-          'type' => Optional[Google_container_cluster_maintenance_policy_1643],
+          'type' => Optional[Array[Google_container_cluster_maintenance_policy_1643]],
           'value' => undef
         },
         'master_auth' => {
-          'type' => Optional[Google_container_cluster_master_auth_1645],
+          'type' => Optional[Array[Google_container_cluster_master_auth_1645]],
           'value' => undef
         },
         'master_authorized_networks_config' => {
-          'type' => Optional[Google_container_cluster_master_authorized_networks_config_1647],
+          'type' => Optional[Array[Google_container_cluster_master_authorized_networks_config_1647]],
           'value' => undef
         },
         'master_ipv4_cidr_block' => {
@@ -5679,15 +5267,15 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'network_policy' => {
-          'type' => Optional[Google_container_cluster_network_policy_1649],
+          'type' => Optional[Array[Google_container_cluster_network_policy_1649]],
           'value' => undef
         },
         'node_config' => {
-          'type' => Optional[Google_container_cluster_node_config_1650],
+          'type' => Optional[Array[Google_container_cluster_node_config_1650]],
           'value' => undef
         },
         'node_pool' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654]],
           'value' => undef
         },
         'node_version' => {
@@ -5695,7 +5283,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'pod_security_policy_config' => {
-          'type' => Optional[Google_container_cluster_pod_security_policy_config_1661],
+          'type' => Optional[Array[Google_container_cluster_pod_security_policy_config_1661]],
           'value' => undef
         },
         'private_cluster' => {
@@ -5703,7 +5291,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'private_cluster_config' => {
-          'type' => Optional[Google_container_cluster_private_cluster_config_1662],
+          'type' => Optional[Array[Google_container_cluster_private_cluster_config_1662]],
           'value' => undef
         },
         'project' => {
@@ -5745,34 +5333,26 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_addons_config_1635 => {
       attributes => {
-        'google_container_cluster_addons_config_1635_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'horizontal_pod_autoscaling' => {
-          'type' => Optional[Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636],
+          'type' => Optional[Array[Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636]],
           'value' => undef
         },
         'http_load_balancing' => {
-          'type' => Optional[Google_container_cluster_addons_config_1635_http_load_balancing_1637],
+          'type' => Optional[Array[Google_container_cluster_addons_config_1635_http_load_balancing_1637]],
           'value' => undef
         },
         'kubernetes_dashboard' => {
-          'type' => Optional[Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638],
+          'type' => Optional[Array[Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638]],
           'value' => undef
         },
         'network_policy_config' => {
-          'type' => Optional[Google_container_cluster_addons_config_1635_network_policy_config_1639],
+          'type' => Optional[Array[Google_container_cluster_addons_config_1635_network_policy_config_1639]],
           'value' => undef
         }
       }
     },
     Google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636 => {
       attributes => {
-        'google_container_cluster_addons_config_1635_horizontal_pod_autoscaling_1636_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5781,10 +5361,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_addons_config_1635_http_load_balancing_1637 => {
       attributes => {
-        'google_container_cluster_addons_config_1635_http_load_balancing_1637_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5793,10 +5369,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_addons_config_1635_kubernetes_dashboard_1638 => {
       attributes => {
-        'google_container_cluster_addons_config_1635_kubernetes_dashboard_1638_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5805,10 +5377,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_addons_config_1635_network_policy_config_1639 => {
       attributes => {
-        'google_container_cluster_addons_config_1635_network_policy_config_1639_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5817,23 +5385,15 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_cluster_autoscaling_1640 => {
       attributes => {
-        'google_container_cluster_cluster_autoscaling_1640_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean,
         'resource_limits' => {
-          'type' => Optional[Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641],
+          'type' => Optional[Array[Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641]],
           'value' => undef
         }
       }
     },
     Google_container_cluster_cluster_autoscaling_1640_resource_limits_1641 => {
       attributes => {
-        'google_container_cluster_cluster_autoscaling_1640_resource_limits_1641_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'maximum' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -5847,10 +5407,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_ip_allocation_policy_1642 => {
       attributes => {
-        'google_container_cluster_ip_allocation_policy_1642_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cluster_ipv4_cidr_block' => {
           'type' => Optional[String],
           'value' => undef
@@ -5879,19 +5435,11 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_maintenance_policy_1643 => {
       attributes => {
-        'google_container_cluster_maintenance_policy_1643_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'daily_maintenance_window' => Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644
+        'daily_maintenance_window' => Array[Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644]
       }
     },
     Google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644 => {
       attributes => {
-        'google_container_cluster_maintenance_policy_1643_daily_maintenance_window_1644_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'duration' => {
           'type' => Optional[String],
           'value' => undef
@@ -5901,16 +5449,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_master_auth_1645 => {
       attributes => {
-        'google_container_cluster_master_auth_1645_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'client_certificate' => {
           'type' => Optional[String],
           'value' => undef
         },
         'client_certificate_config' => {
-          'type' => Optional[Google_container_cluster_master_auth_1645_client_certificate_config_1646],
+          'type' => Optional[Array[Google_container_cluster_master_auth_1645_client_certificate_config_1646]],
           'value' => undef
         },
         'client_key' => {
@@ -5927,19 +5471,11 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_master_auth_1645_client_certificate_config_1646 => {
       attributes => {
-        'google_container_cluster_master_auth_1645_client_certificate_config_1646_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'issue_client_certificate' => Boolean
       }
     },
     Google_container_cluster_master_authorized_networks_config_1647 => {
       attributes => {
-        'google_container_cluster_master_authorized_networks_config_1647_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_blocks' => {
           'type' => Optional[Google_container_cluster_master_authorized_networks_config_1647_cidr_blocks_1648],
           'value' => undef
@@ -5948,10 +5484,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_master_authorized_networks_config_1647_cidr_blocks_1648 => {
       attributes => {
-        'google_container_cluster_master_authorized_networks_config_1647_cidr_blocks_1648_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr_block' => String,
         'display_name' => {
           'type' => Optional[String],
@@ -5961,10 +5493,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_network_policy_1649 => {
       attributes => {
-        'google_container_cluster_network_policy_1649_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -5977,10 +5505,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_node_config_1650 => {
       attributes => {
-        'google_container_cluster_node_config_1650_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -5990,7 +5514,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'guest_accelerator' => {
-          'type' => Optional[Google_container_cluster_node_config_1650_guest_accelerator_1651],
+          'type' => Optional[Array[Google_container_cluster_node_config_1650_guest_accelerator_1651]],
           'value' => undef
         },
         'image_type' => {
@@ -6034,31 +5558,23 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'taint' => {
-          'type' => Optional[Google_container_cluster_node_config_1650_taint_1652],
+          'type' => Optional[Array[Google_container_cluster_node_config_1650_taint_1652]],
           'value' => undef
         },
         'workload_metadata_config' => {
-          'type' => Optional[Google_container_cluster_node_config_1650_workload_metadata_config_1653],
+          'type' => Optional[Array[Google_container_cluster_node_config_1650_workload_metadata_config_1653]],
           'value' => undef
         }
       }
     },
     Google_container_cluster_node_config_1650_guest_accelerator_1651 => {
       attributes => {
-        'google_container_cluster_node_config_1650_guest_accelerator_1651_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer,
         'type' => String
       }
     },
     Google_container_cluster_node_config_1650_taint_1652 => {
       attributes => {
-        'google_container_cluster_node_config_1650_taint_1652_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'effect' => String,
         'key' => String,
         'value' => String
@@ -6066,21 +5582,13 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_node_config_1650_workload_metadata_config_1653 => {
       attributes => {
-        'google_container_cluster_node_config_1650_workload_metadata_config_1653_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'node_metadata' => String
       }
     },
     Google_container_cluster_node_pool_1654 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'autoscaling' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654_autoscaling_1655],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654_autoscaling_1655]],
           'value' => undef
         },
         'initial_node_count' => {
@@ -6092,7 +5600,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'management' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654_management_1656],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654_management_1656]],
           'value' => undef
         },
         'max_pods_per_node' => {
@@ -6108,7 +5616,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'node_config' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654_node_config_1657],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654_node_config_1657]],
           'value' => undef
         },
         'node_count' => {
@@ -6123,20 +5631,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_node_pool_1654_autoscaling_1655 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_autoscaling_1655_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_node_count' => Integer,
         'min_node_count' => Integer
       }
     },
     Google_container_cluster_node_pool_1654_management_1656 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_management_1656_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_repair' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6149,10 +5649,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_node_pool_1654_node_config_1657 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_node_config_1657_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6162,7 +5658,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'guest_accelerator' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658]],
           'value' => undef
         },
         'image_type' => {
@@ -6206,31 +5702,23 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'taint' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654_node_config_1657_taint_1659],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654_node_config_1657_taint_1659]],
           'value' => undef
         },
         'workload_metadata_config' => {
-          'type' => Optional[Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660],
+          'type' => Optional[Array[Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660]],
           'value' => undef
         }
       }
     },
     Google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_node_config_1657_guest_accelerator_1658_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer,
         'type' => String
       }
     },
     Google_container_cluster_node_pool_1654_node_config_1657_taint_1659 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_node_config_1657_taint_1659_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'effect' => String,
         'key' => String,
         'value' => String
@@ -6238,28 +5726,16 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660 => {
       attributes => {
-        'google_container_cluster_node_pool_1654_node_config_1657_workload_metadata_config_1660_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'node_metadata' => String
       }
     },
     Google_container_cluster_pod_security_policy_config_1661 => {
       attributes => {
-        'google_container_cluster_pod_security_policy_config_1661_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => Boolean
       }
     },
     Google_container_cluster_private_cluster_config_1662 => {
       attributes => {
-        'google_container_cluster_private_cluster_config_1662_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enable_private_endpoint' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6289,7 +5765,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'autoscaling' => {
-          'type' => Optional[Google_container_node_pool_autoscaling_1663],
+          'type' => Optional[Array[Google_container_node_pool_autoscaling_1663]],
           'value' => undef
         },
         'cluster' => String,
@@ -6302,7 +5778,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'management' => {
-          'type' => Optional[Google_container_node_pool_management_1664],
+          'type' => Optional[Array[Google_container_node_pool_management_1664]],
           'value' => undef
         },
         'max_pods_per_node' => {
@@ -6318,7 +5794,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'node_config' => {
-          'type' => Optional[Google_container_node_pool_node_config_1665],
+          'type' => Optional[Array[Google_container_node_pool_node_config_1665]],
           'value' => undef
         },
         'node_count' => {
@@ -6356,20 +5832,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_node_pool_autoscaling_1663 => {
       attributes => {
-        'google_container_node_pool_autoscaling_1663_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_node_count' => Integer,
         'min_node_count' => Integer
       }
     },
     Google_container_node_pool_management_1664 => {
       attributes => {
-        'google_container_node_pool_management_1664_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auto_repair' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6382,10 +5850,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_node_pool_node_config_1665 => {
       attributes => {
-        'google_container_node_pool_node_config_1665_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6395,7 +5859,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'guest_accelerator' => {
-          'type' => Optional[Google_container_node_pool_node_config_1665_guest_accelerator_1666],
+          'type' => Optional[Array[Google_container_node_pool_node_config_1665_guest_accelerator_1666]],
           'value' => undef
         },
         'image_type' => {
@@ -6439,31 +5903,23 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'taint' => {
-          'type' => Optional[Google_container_node_pool_node_config_1665_taint_1667],
+          'type' => Optional[Array[Google_container_node_pool_node_config_1665_taint_1667]],
           'value' => undef
         },
         'workload_metadata_config' => {
-          'type' => Optional[Google_container_node_pool_node_config_1665_workload_metadata_config_1668],
+          'type' => Optional[Array[Google_container_node_pool_node_config_1665_workload_metadata_config_1668]],
           'value' => undef
         }
       }
     },
     Google_container_node_pool_node_config_1665_guest_accelerator_1666 => {
       attributes => {
-        'google_container_node_pool_node_config_1665_guest_accelerator_1666_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => Integer,
         'type' => String
       }
     },
     Google_container_node_pool_node_config_1665_taint_1667 => {
       attributes => {
-        'google_container_node_pool_node_config_1665_taint_1667_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'effect' => String,
         'key' => String,
         'value' => String
@@ -6471,10 +5927,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_container_node_pool_node_config_1665_workload_metadata_config_1668 => {
       attributes => {
-        'google_container_node_pool_node_config_1665_workload_metadata_config_1668_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'node_metadata' => String
       }
     },
@@ -6535,7 +5987,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'cluster_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669]],
           'value' => undef
         },
         'labels' => {
@@ -6566,10 +6018,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'bucket' => {
           'type' => Optional[String],
           'value' => undef
@@ -6579,23 +6027,23 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'gce_cluster_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670]],
           'value' => undef
         },
         'initialization_action' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_initialization_action_1671],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_initialization_action_1671]],
           'value' => undef
         },
         'master_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_master_config_1672],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_master_config_1672]],
           'value' => undef
         },
         'preemptible_worker_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674]],
           'value' => undef
         },
         'software_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_software_config_1676],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_software_config_1676]],
           'value' => undef
         },
         'staging_bucket' => {
@@ -6603,17 +6051,13 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'worker_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_worker_config_1677],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_worker_config_1677]],
           'value' => undef
         }
       }
     },
     Google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_gce_cluster_config_1670_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'internal_ip_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6650,10 +6094,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_initialization_action_1671 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_initialization_action_1671_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'script' => String,
         'timeout_sec' => {
           'type' => Optional[Integer],
@@ -6663,12 +6103,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_master_config_1672 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_master_config_1672_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673]],
           'value' => undef
         },
         'instance_names' => {
@@ -6687,10 +6123,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_master_config_1672_disk_config_1673_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'boot_disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6707,12 +6139,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675]],
           'value' => undef
         },
         'instance_names' => {
@@ -6727,10 +6155,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_preemptible_worker_config_1674_disk_config_1675_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'boot_disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6739,10 +6163,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_software_config_1676 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_software_config_1676_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'image_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -6759,12 +6179,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_worker_config_1677 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_worker_config_1677_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'disk_config' => {
-          'type' => Optional[Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678],
+          'type' => Optional[Array[Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678]],
           'value' => undef
         },
         'instance_names' => {
@@ -6783,10 +6199,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678 => {
       attributes => {
-        'google_dataproc_cluster_cluster_config_1669_worker_config_1677_disk_config_1678_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'boot_disk_size_gb' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6820,11 +6232,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'hadoop_config' => {
-          'type' => Optional[Google_dataproc_job_hadoop_config_1679],
+          'type' => Optional[Array[Google_dataproc_job_hadoop_config_1679]],
           'value' => undef
         },
         'hive_config' => {
-          'type' => Optional[Google_dataproc_job_hive_config_1681],
+          'type' => Optional[Array[Google_dataproc_job_hive_config_1681]],
           'value' => undef
         },
         'labels' => {
@@ -6832,20 +6244,20 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'pig_config' => {
-          'type' => Optional[Google_dataproc_job_pig_config_1682],
+          'type' => Optional[Array[Google_dataproc_job_pig_config_1682]],
           'value' => undef
         },
-        'placement' => Google_dataproc_job_placement_1684,
+        'placement' => Array[Google_dataproc_job_placement_1684],
         'project' => {
           'type' => Optional[String],
           'value' => undef
         },
         'pyspark_config' => {
-          'type' => Optional[Google_dataproc_job_pyspark_config_1685],
+          'type' => Optional[Array[Google_dataproc_job_pyspark_config_1685]],
           'value' => undef
         },
         'reference' => {
-          'type' => Optional[Google_dataproc_job_reference_1687],
+          'type' => Optional[Array[Google_dataproc_job_reference_1687]],
           'value' => undef
         },
         'region' => {
@@ -6853,19 +6265,19 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'scheduling' => {
-          'type' => Optional[Google_dataproc_job_scheduling_1688],
+          'type' => Optional[Array[Google_dataproc_job_scheduling_1688]],
           'value' => undef
         },
         'spark_config' => {
-          'type' => Optional[Google_dataproc_job_spark_config_1689],
+          'type' => Optional[Array[Google_dataproc_job_spark_config_1689]],
           'value' => undef
         },
         'sparksql_config' => {
-          'type' => Optional[Google_dataproc_job_sparksql_config_1691],
+          'type' => Optional[Array[Google_dataproc_job_sparksql_config_1691]],
           'value' => undef
         },
         'status' => {
-          'type' => Optional[Google_dataproc_job_status_1693],
+          'type' => Optional[Array[Google_dataproc_job_status_1693]],
           'value' => undef
         }
       }
@@ -6883,10 +6295,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_hadoop_config_1679 => {
       attributes => {
-        'google_dataproc_job_hadoop_config_1679_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'archive_uris' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -6904,7 +6312,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'logging_config' => {
-          'type' => Optional[Google_dataproc_job_hadoop_config_1679_logging_config_1680],
+          'type' => Optional[Array[Google_dataproc_job_hadoop_config_1679_logging_config_1680]],
           'value' => undef
         },
         'main_class' => {
@@ -6923,10 +6331,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_hadoop_config_1679_logging_config_1680 => {
       attributes => {
-        'google_dataproc_job_hadoop_config_1679_logging_config_1680_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver_log_levels' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -6935,10 +6339,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_hive_config_1681 => {
       attributes => {
-        'google_dataproc_job_hive_config_1681_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'continue_on_failure' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6967,10 +6367,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_pig_config_1682 => {
       attributes => {
-        'google_dataproc_job_pig_config_1682_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'continue_on_failure' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6980,7 +6376,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'logging_config' => {
-          'type' => Optional[Google_dataproc_job_pig_config_1682_logging_config_1683],
+          'type' => Optional[Array[Google_dataproc_job_pig_config_1682_logging_config_1683]],
           'value' => undef
         },
         'properties' => {
@@ -7003,10 +6399,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_pig_config_1682_logging_config_1683 => {
       attributes => {
-        'google_dataproc_job_pig_config_1682_logging_config_1683_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver_log_levels' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -7015,10 +6407,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_placement_1684 => {
       attributes => {
-        'google_dataproc_job_placement_1684_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cluster_name' => String,
         'cluster_uuid' => {
           'type' => Optional[String],
@@ -7028,10 +6416,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_pyspark_config_1685 => {
       attributes => {
-        'google_dataproc_job_pyspark_config_1685_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'archive_uris' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7049,7 +6433,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'logging_config' => {
-          'type' => Optional[Google_dataproc_job_pyspark_config_1685_logging_config_1686],
+          'type' => Optional[Array[Google_dataproc_job_pyspark_config_1685_logging_config_1686]],
           'value' => undef
         },
         'main_python_file_uri' => String,
@@ -7065,10 +6449,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_pyspark_config_1685_logging_config_1686 => {
       attributes => {
-        'google_dataproc_job_pyspark_config_1685_logging_config_1686_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver_log_levels' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -7077,10 +6457,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_reference_1687 => {
       attributes => {
-        'google_dataproc_job_reference_1687_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'job_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -7089,10 +6465,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_scheduling_1688 => {
       attributes => {
-        'google_dataproc_job_scheduling_1688_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_failures_per_hour' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -7101,10 +6473,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_spark_config_1689 => {
       attributes => {
-        'google_dataproc_job_spark_config_1689_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'archive_uris' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7122,7 +6490,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'logging_config' => {
-          'type' => Optional[Google_dataproc_job_spark_config_1689_logging_config_1690],
+          'type' => Optional[Array[Google_dataproc_job_spark_config_1689_logging_config_1690]],
           'value' => undef
         },
         'main_class' => {
@@ -7141,10 +6509,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_spark_config_1689_logging_config_1690 => {
       attributes => {
-        'google_dataproc_job_spark_config_1689_logging_config_1690_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver_log_levels' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -7153,16 +6517,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_sparksql_config_1691 => {
       attributes => {
-        'google_dataproc_job_sparksql_config_1691_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'jar_file_uris' => {
           'type' => Optional[Array[String]],
           'value' => undef
         },
         'logging_config' => {
-          'type' => Optional[Google_dataproc_job_sparksql_config_1691_logging_config_1692],
+          'type' => Optional[Array[Google_dataproc_job_sparksql_config_1691_logging_config_1692]],
           'value' => undef
         },
         'properties' => {
@@ -7185,10 +6545,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_sparksql_config_1691_logging_config_1692 => {
       attributes => {
-        'google_dataproc_job_sparksql_config_1691_logging_config_1692_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver_log_levels' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -7197,10 +6553,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_dataproc_job_status_1693 => {
       attributes => {
-        'google_dataproc_job_status_1693_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'details' => {
           'type' => Optional[String],
           'value' => undef
@@ -7291,7 +6643,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'apis' => {
-          'type' => Optional[Google_endpoints_service_apis_1694],
+          'type' => Optional[Array[Google_endpoints_service_apis_1694]],
           'value' => undef
         },
         'config_id' => {
@@ -7303,7 +6655,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'endpoints' => {
-          'type' => Optional[Google_endpoints_service_endpoints_1696],
+          'type' => Optional[Array[Google_endpoints_service_endpoints_1696]],
           'value' => undef
         },
         'grpc_config' => {
@@ -7342,12 +6694,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_endpoints_service_apis_1694 => {
       attributes => {
-        'google_endpoints_service_apis_1694_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'methods' => {
-          'type' => Optional[Google_endpoints_service_apis_1694_methods_1695],
+          'type' => Optional[Array[Google_endpoints_service_apis_1694_methods_1695]],
           'value' => undef
         },
         'name' => {
@@ -7366,10 +6714,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_endpoints_service_apis_1694_methods_1695 => {
       attributes => {
-        'google_endpoints_service_apis_1694_methods_1695_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7390,10 +6734,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_endpoints_service_endpoints_1696 => {
       attributes => {
-        'google_endpoints_service_endpoints_1696_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'address' => {
           'type' => Optional[String],
           'value' => undef
@@ -7422,13 +6762,13 @@ type TerraformGoogle = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'file_shares' => Google_filestore_instance_file_shares_1697,
+        'file_shares' => Array[Google_filestore_instance_file_shares_1697],
         'labels' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
         },
         'name' => String,
-        'networks' => Google_filestore_instance_networks_1698,
+        'networks' => Array[Google_filestore_instance_networks_1698],
         'project' => {
           'type' => Optional[String],
           'value' => undef
@@ -7450,20 +6790,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_filestore_instance_file_shares_1697 => {
       attributes => {
-        'google_filestore_instance_file_shares_1697_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'capacity_gb' => Integer,
         'name' => String
       }
     },
     Google_filestore_instance_networks_1698 => {
       attributes => {
-        'google_filestore_instance_networks_1698_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_addresses' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7593,7 +6925,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'boolean_policy' => {
-          'type' => Optional[Google_folder_organization_policy_boolean_policy_1699],
+          'type' => Optional[Array[Google_folder_organization_policy_boolean_policy_1699]],
           'value' => undef
         },
         'constraint' => String,
@@ -7603,11 +6935,11 @@ type TerraformGoogle = TypeSet[{
         },
         'folder' => String,
         'list_policy' => {
-          'type' => Optional[Google_folder_organization_policy_list_policy_1700],
+          'type' => Optional[Array[Google_folder_organization_policy_list_policy_1700]],
           'value' => undef
         },
         'restore_policy' => {
-          'type' => Optional[Google_folder_organization_policy_restore_policy_1703],
+          'type' => Optional[Array[Google_folder_organization_policy_restore_policy_1703]],
           'value' => undef
         },
         'update_time' => {
@@ -7633,25 +6965,17 @@ type TerraformGoogle = TypeSet[{
     },
     Google_folder_organization_policy_boolean_policy_1699 => {
       attributes => {
-        'google_folder_organization_policy_boolean_policy_1699_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enforced' => Boolean
       }
     },
     Google_folder_organization_policy_list_policy_1700 => {
       attributes => {
-        'google_folder_organization_policy_list_policy_1700_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow' => {
-          'type' => Optional[Google_folder_organization_policy_list_policy_1700_allow_1701],
+          'type' => Optional[Array[Google_folder_organization_policy_list_policy_1700_allow_1701]],
           'value' => undef
         },
         'deny' => {
-          'type' => Optional[Google_folder_organization_policy_list_policy_1700_deny_1702],
+          'type' => Optional[Array[Google_folder_organization_policy_list_policy_1700_deny_1702]],
           'value' => undef
         },
         'suggested_value' => {
@@ -7662,10 +6986,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_folder_organization_policy_list_policy_1700_allow_1701 => {
       attributes => {
-        'google_folder_organization_policy_list_policy_1700_allow_1701_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -7678,10 +6998,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_folder_organization_policy_list_policy_1700_deny_1702 => {
       attributes => {
-        'google_folder_organization_policy_list_policy_1700_deny_1702_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -7694,10 +7010,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_folder_organization_policy_restore_policy_1703 => {
       attributes => {
-        'google_folder_organization_policy_restore_policy_1703_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default' => Boolean
       }
     },
@@ -8153,9 +7465,9 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'combiner' => String,
-        'conditions' => Google_monitoring_alert_policy_conditions_1704,
+        'conditions' => Array[Google_monitoring_alert_policy_conditions_1704],
         'creation_record' => {
-          'type' => Optional[Google_monitoring_alert_policy_creation_record_1712],
+          'type' => Optional[Array[Google_monitoring_alert_policy_creation_record_1712]],
           'value' => undef
         },
         'display_name' => String,
@@ -8191,16 +7503,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_conditions_1704 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'condition_absent' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_absent_1705],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_absent_1705]],
           'value' => undef
         },
         'condition_threshold' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708]],
           'value' => undef
         },
         'display_name' => String,
@@ -8212,12 +7520,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_conditions_1704_condition_absent_1705 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_absent_1705_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aggregations' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706]],
           'value' => undef
         },
         'duration' => String,
@@ -8226,17 +7530,13 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'trigger' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707]],
           'value' => undef
         }
       }
     },
     Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_absent_1705_aggregations_1706_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'alignment_period' => {
           'type' => Optional[String],
           'value' => undef
@@ -8257,10 +7557,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_absent_1705_trigger_1707_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -8273,17 +7569,13 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aggregations' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709]],
           'value' => undef
         },
         'comparison' => String,
         'denominator_aggregations' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710]],
           'value' => undef
         },
         'denominator_filter' => {
@@ -8300,17 +7592,13 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'trigger' => {
-          'type' => Optional[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711],
+          'type' => Optional[Array[Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711]],
           'value' => undef
         }
       }
     },
     Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_aggregations_1709_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'alignment_period' => {
           'type' => Optional[String],
           'value' => undef
@@ -8331,10 +7619,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_denominator_aggregations_1710_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'alignment_period' => {
           'type' => Optional[String],
           'value' => undef
@@ -8355,10 +7639,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711 => {
       attributes => {
-        'google_monitoring_alert_policy_conditions_1704_condition_threshold_1708_trigger_1711_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'count' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -8371,10 +7651,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_alert_policy_creation_record_1712 => {
       attributes => {
-        'google_monitoring_alert_policy_creation_record_1712_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mutate_time' => {
           'type' => Optional[String],
           'value' => undef
@@ -8478,16 +7754,16 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'content_matchers' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_content_matchers_1713],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_content_matchers_1713]],
           'value' => undef
         },
         'display_name' => String,
         'http_check' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_http_check_1714],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_http_check_1714]],
           'value' => undef
         },
         'internal_checkers' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_internal_checkers_1716],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_internal_checkers_1716]],
           'value' => undef
         },
         'is_internal' => {
@@ -8495,7 +7771,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'monitored_resource' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_monitored_resource_1717],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_monitored_resource_1717]],
           'value' => undef
         },
         'name' => {
@@ -8511,7 +7787,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'resource_group' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_resource_group_1718],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_resource_group_1718]],
           'value' => undef
         },
         'selected_regions' => {
@@ -8519,7 +7795,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'tcp_check' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_tcp_check_1719],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_tcp_check_1719]],
           'value' => undef
         },
         'timeout' => String
@@ -8538,10 +7814,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_uptime_check_config_content_matchers_1713 => {
       attributes => {
-        'google_monitoring_uptime_check_config_content_matchers_1713_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'content' => {
           'type' => Optional[String],
           'value' => undef
@@ -8550,12 +7822,8 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_uptime_check_config_http_check_1714 => {
       attributes => {
-        'google_monitoring_uptime_check_config_http_check_1714_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auth_info' => {
-          'type' => Optional[Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715],
+          'type' => Optional[Array[Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715]],
           'value' => undef
         },
         'headers' => {
@@ -8582,10 +7850,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_uptime_check_config_http_check_1714_auth_info_1715 => {
       attributes => {
-        'google_monitoring_uptime_check_config_http_check_1714_auth_info_1715_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'password' => {
           'type' => Optional[String],
           'value' => undef
@@ -8598,10 +7862,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_uptime_check_config_internal_checkers_1716 => {
       attributes => {
-        'google_monitoring_uptime_check_config_internal_checkers_1716_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'display_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -8626,20 +7886,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_uptime_check_config_monitored_resource_1717 => {
       attributes => {
-        'google_monitoring_uptime_check_config_monitored_resource_1717_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'labels' => Hash[String, String],
         'type' => String
       }
     },
     Google_monitoring_uptime_check_config_resource_group_1718 => {
       attributes => {
-        'google_monitoring_uptime_check_config_resource_group_1718_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group_id' => {
           'type' => Optional[String],
           'value' => undef
@@ -8652,10 +7904,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_monitoring_uptime_check_config_tcp_check_1719 => {
       attributes => {
-        'google_monitoring_uptime_check_config_tcp_check_1719_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => Integer
       }
     },
@@ -8778,7 +8026,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'boolean_policy' => {
-          'type' => Optional[Google_organization_policy_boolean_policy_1720],
+          'type' => Optional[Array[Google_organization_policy_boolean_policy_1720]],
           'value' => undef
         },
         'constraint' => String,
@@ -8787,12 +8035,12 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'list_policy' => {
-          'type' => Optional[Google_organization_policy_list_policy_1721],
+          'type' => Optional[Array[Google_organization_policy_list_policy_1721]],
           'value' => undef
         },
         'org_id' => String,
         'restore_policy' => {
-          'type' => Optional[Google_organization_policy_restore_policy_1724],
+          'type' => Optional[Array[Google_organization_policy_restore_policy_1724]],
           'value' => undef
         },
         'update_time' => {
@@ -8818,25 +8066,17 @@ type TerraformGoogle = TypeSet[{
     },
     Google_organization_policy_boolean_policy_1720 => {
       attributes => {
-        'google_organization_policy_boolean_policy_1720_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enforced' => Boolean
       }
     },
     Google_organization_policy_list_policy_1721 => {
       attributes => {
-        'google_organization_policy_list_policy_1721_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow' => {
-          'type' => Optional[Google_organization_policy_list_policy_1721_allow_1722],
+          'type' => Optional[Array[Google_organization_policy_list_policy_1721_allow_1722]],
           'value' => undef
         },
         'deny' => {
-          'type' => Optional[Google_organization_policy_list_policy_1721_deny_1723],
+          'type' => Optional[Array[Google_organization_policy_list_policy_1721_deny_1723]],
           'value' => undef
         },
         'suggested_value' => {
@@ -8847,10 +8087,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_organization_policy_list_policy_1721_allow_1722 => {
       attributes => {
-        'google_organization_policy_list_policy_1721_allow_1722_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -8863,10 +8099,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_organization_policy_list_policy_1721_deny_1723 => {
       attributes => {
-        'google_organization_policy_list_policy_1721_deny_1723_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -8879,10 +8111,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_organization_policy_restore_policy_1724 => {
       attributes => {
-        'google_organization_policy_restore_policy_1724_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default' => Boolean
       }
     },
@@ -8893,7 +8121,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'app_engine' => {
-          'type' => Optional[Google_project_app_engine_1725],
+          'type' => Optional[Array[Google_project_app_engine_1725]],
           'value' => undef
         },
         'auto_create_network' => {
@@ -8949,10 +8177,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_project_app_engine_1725 => {
       attributes => {
-        'google_project_app_engine_1725_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'auth_domain' => {
           'type' => Optional[String],
           'value' => undef
@@ -8970,7 +8194,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'feature_settings' => {
-          'type' => Optional[Google_project_app_engine_1725_feature_settings_1726],
+          'type' => Optional[Array[Google_project_app_engine_1725_feature_settings_1726]],
           'value' => undef
         },
         'gcr_domain' => {
@@ -8990,17 +8214,13 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'url_dispatch_rule' => {
-          'type' => Optional[Google_project_app_engine_1725_url_dispatch_rule_1727],
+          'type' => Optional[Array[Google_project_app_engine_1725_url_dispatch_rule_1727]],
           'value' => undef
         }
       }
     },
     Google_project_app_engine_1725_feature_settings_1726 => {
       attributes => {
-        'google_project_app_engine_1725_feature_settings_1726_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'split_health_checks' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -9009,10 +8229,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_project_app_engine_1725_url_dispatch_rule_1727 => {
       attributes => {
-        'google_project_app_engine_1725_url_dispatch_rule_1727_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'domain' => {
           'type' => Optional[String],
           'value' => undef
@@ -9170,7 +8386,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'boolean_policy' => {
-          'type' => Optional[Google_project_organization_policy_boolean_policy_1728],
+          'type' => Optional[Array[Google_project_organization_policy_boolean_policy_1728]],
           'value' => undef
         },
         'constraint' => String,
@@ -9179,12 +8395,12 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'list_policy' => {
-          'type' => Optional[Google_project_organization_policy_list_policy_1729],
+          'type' => Optional[Array[Google_project_organization_policy_list_policy_1729]],
           'value' => undef
         },
         'project' => String,
         'restore_policy' => {
-          'type' => Optional[Google_project_organization_policy_restore_policy_1732],
+          'type' => Optional[Array[Google_project_organization_policy_restore_policy_1732]],
           'value' => undef
         },
         'update_time' => {
@@ -9210,25 +8426,17 @@ type TerraformGoogle = TypeSet[{
     },
     Google_project_organization_policy_boolean_policy_1728 => {
       attributes => {
-        'google_project_organization_policy_boolean_policy_1728_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enforced' => Boolean
       }
     },
     Google_project_organization_policy_list_policy_1729 => {
       attributes => {
-        'google_project_organization_policy_list_policy_1729_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow' => {
-          'type' => Optional[Google_project_organization_policy_list_policy_1729_allow_1730],
+          'type' => Optional[Array[Google_project_organization_policy_list_policy_1729_allow_1730]],
           'value' => undef
         },
         'deny' => {
-          'type' => Optional[Google_project_organization_policy_list_policy_1729_deny_1731],
+          'type' => Optional[Array[Google_project_organization_policy_list_policy_1729_deny_1731]],
           'value' => undef
         },
         'suggested_value' => {
@@ -9239,10 +8447,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_project_organization_policy_list_policy_1729_allow_1730 => {
       attributes => {
-        'google_project_organization_policy_list_policy_1729_allow_1730_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -9255,10 +8459,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_project_organization_policy_list_policy_1729_deny_1731 => {
       attributes => {
-        'google_project_organization_policy_list_policy_1729_deny_1731_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'all' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -9271,10 +8471,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_project_organization_policy_restore_policy_1732 => {
       attributes => {
-        'google_project_organization_policy_restore_policy_1732_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default' => Boolean
       }
     },
@@ -9382,7 +8578,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'push_config' => {
-          'type' => Optional[Google_pubsub_subscription_push_config_1733],
+          'type' => Optional[Array[Google_pubsub_subscription_push_config_1733]],
           'value' => undef
         },
         'topic' => String
@@ -9490,10 +8686,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_pubsub_subscription_push_config_1733 => {
       attributes => {
-        'google_pubsub_subscription_push_config_1733_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'attributes' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -10319,7 +9511,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'ip_address' => {
-          'type' => Optional[Google_sql_database_instance_ip_address_1734],
+          'type' => Optional[Array[Google_sql_database_instance_ip_address_1734]],
           'value' => undef
         },
         'master_instance_name' => {
@@ -10339,7 +9531,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'replica_configuration' => {
-          'type' => Optional[Google_sql_database_instance_replica_configuration_1735],
+          'type' => Optional[Array[Google_sql_database_instance_replica_configuration_1735]],
           'value' => undef
         },
         'self_link' => {
@@ -10347,14 +9539,14 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'server_ca_cert' => {
-          'type' => Optional[Google_sql_database_instance_server_ca_cert_1736],
+          'type' => Optional[Array[Google_sql_database_instance_server_ca_cert_1736]],
           'value' => undef
         },
         'service_account_email_address' => {
           'type' => Optional[String],
           'value' => undef
         },
-        'settings' => Google_sql_database_instance_settings_1737
+        'settings' => Array[Google_sql_database_instance_settings_1737]
       }
     },
     Google_sql_database_instanceHandler => {
@@ -10370,10 +9562,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_ip_address_1734 => {
       attributes => {
-        'google_sql_database_instance_ip_address_1734_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_address' => {
           'type' => Optional[String],
           'value' => undef
@@ -10386,10 +9574,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_replica_configuration_1735 => {
       attributes => {
-        'google_sql_database_instance_replica_configuration_1735_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ca_certificate' => {
           'type' => Optional[String],
           'value' => undef
@@ -10438,10 +9622,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_server_ca_cert_1736 => {
       attributes => {
-        'google_sql_database_instance_server_ca_cert_1736_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cert' => {
           'type' => Optional[String],
           'value' => undef
@@ -10466,10 +9646,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'activation_policy' => {
           'type' => Optional[String],
           'value' => undef
@@ -10483,7 +9659,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'backup_configuration' => {
-          'type' => Optional[Google_sql_database_instance_settings_1737_backup_configuration_1738],
+          'type' => Optional[Array[Google_sql_database_instance_settings_1737_backup_configuration_1738]],
           'value' => undef
         },
         'crash_safe_replication' => {
@@ -10491,7 +9667,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'database_flags' => {
-          'type' => Optional[Google_sql_database_instance_settings_1737_database_flags_1739],
+          'type' => Optional[Array[Google_sql_database_instance_settings_1737_database_flags_1739]],
           'value' => undef
         },
         'disk_autoresize' => {
@@ -10507,15 +9683,15 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'ip_configuration' => {
-          'type' => Optional[Google_sql_database_instance_settings_1737_ip_configuration_1740],
+          'type' => Optional[Array[Google_sql_database_instance_settings_1737_ip_configuration_1740]],
           'value' => undef
         },
         'location_preference' => {
-          'type' => Optional[Google_sql_database_instance_settings_1737_location_preference_1742],
+          'type' => Optional[Array[Google_sql_database_instance_settings_1737_location_preference_1742]],
           'value' => undef
         },
         'maintenance_window' => {
-          'type' => Optional[Google_sql_database_instance_settings_1737_maintenance_window_1743],
+          'type' => Optional[Array[Google_sql_database_instance_settings_1737_maintenance_window_1743]],
           'value' => undef
         },
         'pricing_plan' => {
@@ -10539,10 +9715,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737_backup_configuration_1738 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_backup_configuration_1738_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'binary_log_enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -10559,10 +9731,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737_database_flags_1739 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_database_flags_1739_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10575,10 +9743,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737_ip_configuration_1740 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_ip_configuration_1740_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'authorized_networks' => {
           'type' => Optional[Google_sql_database_instance_settings_1737_ip_configuration_1740_authorized_networks_1741],
           'value' => undef
@@ -10599,10 +9763,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737_ip_configuration_1740_authorized_networks_1741 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_ip_configuration_1740_authorized_networks_1741_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'expiration_time' => {
           'type' => Optional[String],
           'value' => undef
@@ -10619,10 +9779,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737_location_preference_1742 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_location_preference_1742_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'follow_gae_application' => {
           'type' => Optional[String],
           'value' => undef
@@ -10635,10 +9791,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_sql_database_instance_settings_1737_maintenance_window_1743 => {
       attributes => {
-        'google_sql_database_instance_settings_1737_maintenance_window_1743_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'day' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -10742,11 +9894,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'cors' => {
-          'type' => Optional[Google_storage_bucket_cors_1744],
+          'type' => Optional[Array[Google_storage_bucket_cors_1744]],
           'value' => undef
         },
         'encryption' => {
-          'type' => Optional[Google_storage_bucket_encryption_1745],
+          'type' => Optional[Array[Google_storage_bucket_encryption_1745]],
           'value' => undef
         },
         'force_destroy' => {
@@ -10758,7 +9910,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'lifecycle_rule' => {
-          'type' => Optional[Google_storage_bucket_lifecycle_rule_1746],
+          'type' => Optional[Array[Google_storage_bucket_lifecycle_rule_1746]],
           'value' => undef
         },
         'location' => {
@@ -10766,7 +9918,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'logging' => {
-          'type' => Optional[Google_storage_bucket_logging_1749],
+          'type' => Optional[Array[Google_storage_bucket_logging_1749]],
           'value' => undef
         },
         'name' => String,
@@ -10791,11 +9943,11 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'versioning' => {
-          'type' => Optional[Google_storage_bucket_versioning_1750],
+          'type' => Optional[Array[Google_storage_bucket_versioning_1750]],
           'value' => undef
         },
         'website' => {
-          'type' => Optional[Google_storage_bucket_website_1751],
+          'type' => Optional[Array[Google_storage_bucket_website_1751]],
           'value' => undef
         }
       }
@@ -10845,10 +9997,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_cors_1744 => {
       attributes => {
-        'google_storage_bucket_cors_1744_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_age_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -10869,10 +10017,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_encryption_1745 => {
       attributes => {
-        'google_storage_bucket_encryption_1745_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_kms_key_name' => String
       }
     },
@@ -10955,20 +10099,12 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_lifecycle_rule_1746 => {
       attributes => {
-        'google_storage_bucket_lifecycle_rule_1746_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'action' => Google_storage_bucket_lifecycle_rule_1746_action_1747,
         'condition' => Google_storage_bucket_lifecycle_rule_1746_condition_1748
       }
     },
     Google_storage_bucket_lifecycle_rule_1746_action_1747 => {
       attributes => {
-        'google_storage_bucket_lifecycle_rule_1746_action_1747_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'storage_class' => {
           'type' => Optional[String],
           'value' => undef
@@ -10978,10 +10114,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_lifecycle_rule_1746_condition_1748 => {
       attributes => {
-        'google_storage_bucket_lifecycle_rule_1746_condition_1748_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'age' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -11006,10 +10138,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_logging_1749 => {
       attributes => {
-        'google_storage_bucket_logging_1749_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'log_bucket' => String,
         'log_object_prefix' => {
           'type' => Optional[String],
@@ -11088,10 +10216,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_versioning_1750 => {
       attributes => {
-        'google_storage_bucket_versioning_1750_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'enabled' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -11100,10 +10224,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_bucket_website_1751 => {
       attributes => {
-        'google_storage_bucket_website_1751_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'main_page_suffix' => {
           'type' => Optional[String],
           'value' => undef
@@ -11143,7 +10263,7 @@ type TerraformGoogle = TypeSet[{
           'value' => undef
         },
         'project_team' => {
-          'type' => Optional[Google_storage_default_object_access_control_project_team_1752],
+          'type' => Optional[Array[Google_storage_default_object_access_control_project_team_1752]],
           'value' => undef
         },
         'role' => String
@@ -11162,10 +10282,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_default_object_access_control_project_team_1752 => {
       attributes => {
-        'google_storage_default_object_access_control_project_team_1752_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'project_number' => {
           'type' => Optional[String],
           'value' => undef
@@ -11264,7 +10380,7 @@ type TerraformGoogle = TypeSet[{
         },
         'object' => String,
         'project_team' => {
-          'type' => Optional[Google_storage_object_access_control_project_team_1753],
+          'type' => Optional[Array[Google_storage_object_access_control_project_team_1753]],
           'value' => undef
         },
         'role' => String
@@ -11283,10 +10399,6 @@ type TerraformGoogle = TypeSet[{
     },
     Google_storage_object_access_control_project_team_1753 => {
       attributes => {
-        'google_storage_object_access_control_project_team_1753_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'project_number' => {
           'type' => Optional[String],
           'value' => undef

--- a/plugins/aaa-terraform-kubernetes.pp
+++ b/plugins/aaa-terraform-kubernetes.pp
@@ -14,9 +14,9 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_cluster_role_binding_metadata_589,
+        'metadata' => Array[Kubernetes_cluster_role_binding_metadata_589],
         'role_ref' => Hash[String, String],
-        'subject' => Kubernetes_cluster_role_binding_subject_590
+        'subject' => Array[Kubernetes_cluster_role_binding_subject_590]
       }
     },
     Kubernetes_cluster_role_bindingHandler => {
@@ -32,10 +32,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_cluster_role_binding_metadata_589 => {
       attributes => {
-        'kubernetes_cluster_role_binding_metadata_589_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -68,10 +64,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_cluster_role_binding_subject_590 => {
       attributes => {
-        'kubernetes_cluster_role_binding_subject_590_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_group' => {
           'type' => Optional[String],
           'value' => undef
@@ -94,7 +86,7 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[Hash[String, String]],
           'value' => undef
         },
-        'metadata' => Kubernetes_config_map_metadata_591
+        'metadata' => Array[Kubernetes_config_map_metadata_591]
       }
     },
     Kubernetes_config_mapHandler => {
@@ -110,10 +102,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_config_map_metadata_591 => {
       attributes => {
-        'kubernetes_config_map_metadata_591_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -158,8 +146,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_deployment_metadata_592,
-        'spec' => Kubernetes_deployment_spec_593
+        'metadata' => Array[Kubernetes_deployment_metadata_592],
+        'spec' => Array[Kubernetes_deployment_spec_593]
       }
     },
     Kubernetes_deploymentHandler => {
@@ -175,10 +163,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_metadata_592 => {
       attributes => {
-        'kubernetes_deployment_metadata_592_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -219,10 +203,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593 => {
       attributes => {
-        'kubernetes_deployment_spec_593_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'min_ready_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -244,24 +224,20 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'selector' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_selector_594],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_selector_594]],
           'value' => undef
         },
         'strategy' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_strategy_596],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_strategy_596]],
           'value' => undef
         },
-        'template' => Kubernetes_deployment_spec_593_template_598
+        'template' => Array[Kubernetes_deployment_spec_593_template_598]
       }
     },
     Kubernetes_deployment_spec_593_selector_594 => {
       attributes => {
-        'kubernetes_deployment_spec_593_selector_594_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_selector_594_match_expressions_595],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_selector_594_match_expressions_595]],
           'value' => undef
         },
         'match_labels' => {
@@ -272,10 +248,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_selector_594_match_expressions_595 => {
       attributes => {
-        'kubernetes_deployment_spec_593_selector_594_match_expressions_595_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -292,12 +264,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_strategy_596 => {
       attributes => {
-        'kubernetes_deployment_spec_593_strategy_596_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'rolling_update' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_strategy_596_rolling_update_597],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_strategy_596_rolling_update_597]],
           'value' => undef
         },
         'type' => {
@@ -308,10 +276,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_strategy_596_rolling_update_597 => {
       attributes => {
-        'kubernetes_deployment_spec_593_strategy_596_rolling_update_597_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_surge' => {
           'type' => Optional[String],
           'value' => undef
@@ -324,20 +288,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'metadata' => Kubernetes_deployment_spec_593_template_598_metadata_599,
-        'spec' => Kubernetes_deployment_spec_593_template_598_spec_600
+        'metadata' => Array[Kubernetes_deployment_spec_593_template_598_metadata_599],
+        'spec' => Array[Kubernetes_deployment_spec_593_template_598_spec_600]
       }
     },
     Kubernetes_deployment_spec_593_template_598_metadata_599 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_metadata_599_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -378,16 +334,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'active_deadline_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'container' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601]],
           'value' => undef
         },
         'dns_policy' => {
@@ -411,11 +363,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'image_pull_secrets' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640]],
           'value' => undef
         },
         'init_container' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641]],
           'value' => undef
         },
         'node_name' => {
@@ -431,7 +383,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680]],
           'value' => undef
         },
         'service_account_name' => {
@@ -447,17 +399,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -467,11 +415,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608]],
           'value' => undef
         },
         'image' => {
@@ -483,28 +431,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636]],
           'value' => undef
         },
         'stdin' => {
@@ -524,7 +472,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639]],
           'value' => undef
         },
         'working_dir' => {
@@ -535,51 +483,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_config_map_key_ref_604_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -592,10 +528,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_field_ref_605_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -608,10 +540,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_resource_field_ref_606_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -621,10 +549,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_602_value_from_603_secret_key_ref_607_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -637,12 +561,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609]],
           'value' => undef
         },
         'prefix' => {
@@ -650,17 +570,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_config_map_ref_609_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -670,10 +586,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_env_from_608_secret_ref_610_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -683,46 +595,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_exec_613_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -731,16 +631,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615]],
           'value' => undef
         },
         'path' => {
@@ -759,10 +655,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_http_get_614_http_header_615_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -775,39 +667,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_post_start_612_tcp_socket_616_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_exec_618_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -816,16 +696,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620]],
           'value' => undef
         },
         'path' => {
@@ -844,10 +720,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_http_get_619_http_header_620_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -860,21 +732,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_lifecycle_611_pre_stop_617_tcp_socket_621_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -882,7 +746,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -898,7 +762,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -909,10 +773,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_exec_623_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -921,16 +781,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625]],
           'value' => undef
         },
         'path' => {
@@ -949,10 +805,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_http_get_624_http_header_625_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -965,19 +817,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_liveness_probe_622_tcp_socket_626_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_port_627_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -999,12 +843,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -1012,7 +852,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -1028,7 +868,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -1039,10 +879,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_exec_629_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1051,16 +887,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631]],
           'value' => undef
         },
         'path' => {
@@ -1079,10 +911,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_http_get_630_http_header_631_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1095,35 +923,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_readiness_probe_628_tcp_socket_632_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_limits_634_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -1136,10 +952,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_resources_633_requests_635_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -1152,16 +964,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637]],
           'value' => undef
         },
         'privileged' => {
@@ -1181,17 +989,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_capabilities_637_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1204,10 +1008,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_security_context_636_se_linux_options_638_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -1228,10 +1028,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_container_601_volume_mount_639_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -1246,19 +1042,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_image_pull_secrets_640_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1268,11 +1056,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648]],
           'value' => undef
         },
         'image' => {
@@ -1284,28 +1072,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676]],
           'value' => undef
         },
         'stdin' => {
@@ -1325,7 +1113,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679]],
           'value' => undef
         },
         'working_dir' => {
@@ -1336,51 +1124,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_config_map_key_ref_644_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -1393,10 +1169,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_field_ref_645_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -1409,10 +1181,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_resource_field_ref_646_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1422,10 +1190,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_642_value_from_643_secret_key_ref_647_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -1438,12 +1202,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649]],
           'value' => undef
         },
         'prefix' => {
@@ -1451,17 +1211,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_config_map_ref_649_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -1471,10 +1227,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_env_from_648_secret_ref_650_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -1484,46 +1236,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_exec_653_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1532,16 +1272,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655]],
           'value' => undef
         },
         'path' => {
@@ -1560,10 +1296,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_http_get_654_http_header_655_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1576,39 +1308,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_post_start_652_tcp_socket_656_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_exec_658_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1617,16 +1337,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660]],
           'value' => undef
         },
         'path' => {
@@ -1645,10 +1361,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_http_get_659_http_header_660_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1661,21 +1373,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_lifecycle_651_pre_stop_657_tcp_socket_661_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -1683,7 +1387,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -1699,7 +1403,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -1710,10 +1414,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_exec_663_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1722,16 +1422,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665]],
           'value' => undef
         },
         'path' => {
@@ -1750,10 +1446,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_http_get_664_http_header_665_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1766,19 +1458,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_liveness_probe_662_tcp_socket_666_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_port_667_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -1800,12 +1484,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -1813,7 +1493,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -1829,7 +1509,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -1840,10 +1520,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_exec_669_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -1852,16 +1528,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671]],
           'value' => undef
         },
         'path' => {
@@ -1880,10 +1552,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_http_get_670_http_header_671_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -1896,35 +1564,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_readiness_probe_668_tcp_socket_672_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_limits_674_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -1937,10 +1593,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_resources_673_requests_675_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -1953,16 +1605,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677]],
           'value' => undef
         },
         'privileged' => {
@@ -1982,17 +1630,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_capabilities_677_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -2005,10 +1649,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_security_context_676_se_linux_options_678_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -2029,10 +1669,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_init_container_641_volume_mount_679_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -2047,10 +1683,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_group' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -2064,7 +1696,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681]],
           'value' => undef
         },
         'supplemental_groups' => {
@@ -2075,10 +1707,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_security_context_680_se_linux_options_681_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -2099,76 +1727,72 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_elastic_block_store' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683]],
           'value' => undef
         },
         'azure_disk' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684]],
           'value' => undef
         },
         'azure_file' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685]],
           'value' => undef
         },
         'ceph_fs' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686]],
           'value' => undef
         },
         'cinder' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688]],
           'value' => undef
         },
         'config_map' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689]],
           'value' => undef
         },
         'downward_api' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691]],
           'value' => undef
         },
         'empty_dir' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695]],
           'value' => undef
         },
         'fc' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696]],
           'value' => undef
         },
         'flex_volume' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697]],
           'value' => undef
         },
         'flocker' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699]],
           'value' => undef
         },
         'gce_persistent_disk' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700]],
           'value' => undef
         },
         'git_repo' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701]],
           'value' => undef
         },
         'glusterfs' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702]],
           'value' => undef
         },
         'host_path' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703]],
           'value' => undef
         },
         'iscsi' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704]],
           'value' => undef
         },
         'local' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705]],
           'value' => undef
         },
         'name' => {
@@ -2176,41 +1800,37 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'nfs' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706]],
           'value' => undef
         },
         'persistent_volume_claim' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707]],
           'value' => undef
         },
         'photon_persistent_disk' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708]],
           'value' => undef
         },
         'quobyte' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709]],
           'value' => undef
         },
         'rbd' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710]],
           'value' => undef
         },
         'secret' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712]],
           'value' => undef
         },
         'vsphere_volume' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_aws_elastic_block_store_683_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2228,10 +1848,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_disk_684_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'caching_mode' => String,
         'data_disk_uri' => String,
         'disk_name' => String,
@@ -2247,10 +1863,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_azure_file_685_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'read_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -2261,10 +1873,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'monitors' => Array[String],
         'path' => {
           'type' => Optional[String],
@@ -2279,7 +1887,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687]],
           'value' => undef
         },
         'user' => {
@@ -2290,10 +1898,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_ceph_fs_686_secret_ref_687_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2302,10 +1906,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_cinder_688_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2319,16 +1919,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690]],
           'value' => undef
         },
         'name' => {
@@ -2339,10 +1935,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_config_map_689_items_690_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -2359,44 +1951,32 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_ref' => Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693,
+        'field_ref' => Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693],
         'mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'path' => String,
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_field_ref_693_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -2409,10 +1989,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_downward_api_691_items_692_resource_field_ref_694_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => String,
         'quantity' => {
           'type' => Optional[String],
@@ -2423,10 +1999,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_empty_dir_695_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'medium' => {
           'type' => Optional[String],
           'value' => undef
@@ -2435,10 +2007,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_fc_696_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2453,10 +2021,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver' => String,
         'fs_type' => {
           'type' => Optional[String],
@@ -2471,17 +2035,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flex_volume_697_secret_ref_698_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2490,10 +2050,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_flocker_699_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2506,10 +2062,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_gce_persistent_disk_700_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2527,10 +2079,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_git_repo_701_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'directory' => {
           'type' => Optional[String],
           'value' => undef
@@ -2547,10 +2095,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_glusterfs_702_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoints_name' => String,
         'path' => String,
         'read_only' => {
@@ -2561,10 +2105,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_host_path_703_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -2573,10 +2113,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_iscsi_704_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2599,10 +2135,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_local_705_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -2611,10 +2143,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_nfs_706_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String,
         'read_only' => {
           'type' => Optional[Boolean],
@@ -2625,10 +2153,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_persistent_volume_claim_707_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'claim_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2641,10 +2165,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_photon_persistent_disk_708_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2654,10 +2174,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_quobyte_709_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -2676,10 +2192,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ceph_monitors' => Array[String],
         'fs_type' => {
           'type' => Optional[String],
@@ -2703,17 +2215,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711]],
           'value' => undef
         }
       }
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_rbd_710_secret_ref_711_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -2722,16 +2230,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713],
+          'type' => Optional[Array[Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713]],
           'value' => undef
         },
         'optional' => {
@@ -2746,10 +2250,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_secret_712_items_713_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -2766,10 +2266,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714 => {
       attributes => {
-        'kubernetes_deployment_spec_593_template_598_spec_600_volume_682_vsphere_volume_714_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -2783,8 +2279,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_horizontal_pod_autoscaler_metadata_715,
-        'spec' => Kubernetes_horizontal_pod_autoscaler_spec_716
+        'metadata' => Array[Kubernetes_horizontal_pod_autoscaler_metadata_715],
+        'spec' => Array[Kubernetes_horizontal_pod_autoscaler_spec_716]
       }
     },
     Kubernetes_horizontal_pod_autoscalerHandler => {
@@ -2800,10 +2296,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_horizontal_pod_autoscaler_metadata_715 => {
       attributes => {
-        'kubernetes_horizontal_pod_autoscaler_metadata_715_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -2844,16 +2336,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_horizontal_pod_autoscaler_spec_716 => {
       attributes => {
-        'kubernetes_horizontal_pod_autoscaler_spec_716_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'max_replicas' => Integer,
         'min_replicas' => {
           'type' => Optional[Integer],
           'value' => undef
         },
-        'scale_target_ref' => Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717,
+        'scale_target_ref' => Array[Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717],
         'target_cpu_utilization_percentage' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -2862,10 +2350,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717 => {
       attributes => {
-        'kubernetes_horizontal_pod_autoscaler_spec_716_scale_target_ref_717_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -2880,9 +2364,9 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_limit_range_metadata_718,
+        'metadata' => Array[Kubernetes_limit_range_metadata_718],
         'spec' => {
-          'type' => Optional[Kubernetes_limit_range_spec_719],
+          'type' => Optional[Array[Kubernetes_limit_range_spec_719]],
           'value' => undef
         }
       }
@@ -2900,10 +2384,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_limit_range_metadata_718 => {
       attributes => {
-        'kubernetes_limit_range_metadata_718_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -2944,22 +2424,14 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_limit_range_spec_719 => {
       attributes => {
-        'kubernetes_limit_range_spec_719_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limit' => {
-          'type' => Optional[Kubernetes_limit_range_spec_719_limit_720],
+          'type' => Optional[Array[Kubernetes_limit_range_spec_719_limit_720]],
           'value' => undef
         }
       }
     },
     Kubernetes_limit_range_spec_719_limit_720 => {
       attributes => {
-        'kubernetes_limit_range_spec_719_limit_720_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -2992,7 +2464,7 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_namespace_metadata_721
+        'metadata' => Array[Kubernetes_namespace_metadata_721]
       }
     },
     Kubernetes_namespaceHandler => {
@@ -3008,10 +2480,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_namespace_metadata_721 => {
       attributes => {
-        'kubernetes_namespace_metadata_721_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -3052,8 +2520,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_network_policy_metadata_722,
-        'spec' => Kubernetes_network_policy_spec_723
+        'metadata' => Array[Kubernetes_network_policy_metadata_722],
+        'spec' => Array[Kubernetes_network_policy_spec_723]
       }
     },
     Kubernetes_network_policyHandler => {
@@ -3069,10 +2537,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_metadata_722 => {
       attributes => {
-        'kubernetes_network_policy_metadata_722_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -3113,44 +2577,32 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'egress' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724]],
           'value' => undef
         },
         'ingress' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732]],
           'value' => undef
         },
-        'pod_selector' => Kubernetes_network_policy_spec_723_pod_selector_740,
+        'pod_selector' => Array[Kubernetes_network_policy_spec_723_pod_selector_740],
         'policy_types' => Array[String]
       }
     },
     Kubernetes_network_policy_spec_723_egress_724 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ports' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_ports_725],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_ports_725]],
           'value' => undef
         },
         'to' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_to_726],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_to_726]],
           'value' => undef
         }
       }
     },
     Kubernetes_network_policy_spec_723_egress_724_ports_725 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_ports_725_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => {
           'type' => Optional[String],
           'value' => undef
@@ -3163,30 +2615,22 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_egress_724_to_726 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_to_726_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_block' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727]],
           'value' => undef
         },
         'namespace_selector' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728]],
           'value' => undef
         },
         'pod_selector' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730]],
           'value' => undef
         }
       }
     },
     Kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_to_726_ip_block_727_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr' => {
           'type' => Optional[String],
           'value' => undef
@@ -3199,12 +2643,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729]],
           'value' => undef
         },
         'match_labels' => {
@@ -3215,10 +2655,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_to_726_namespace_selector_728_match_expressions_729_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3235,12 +2671,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731]],
           'value' => undef
         },
         'match_labels' => {
@@ -3251,10 +2683,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_egress_724_to_726_pod_selector_730_match_expressions_731_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3271,46 +2699,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_ingress_732 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'from' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_from_733],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_from_733]],
           'value' => undef
         },
         'ports' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_ports_739],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_ports_739]],
           'value' => undef
         }
       }
     },
     Kubernetes_network_policy_spec_723_ingress_732_from_733 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_from_733_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ip_block' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734]],
           'value' => undef
         },
         'namespace_selector' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735]],
           'value' => undef
         },
         'pod_selector' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737]],
           'value' => undef
         }
       }
     },
     Kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_from_733_ip_block_734_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cidr' => {
           'type' => Optional[String],
           'value' => undef
@@ -3323,12 +2739,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736]],
           'value' => undef
         },
         'match_labels' => {
@@ -3339,10 +2751,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_from_733_namespace_selector_735_match_expressions_736_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3359,12 +2767,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738]],
           'value' => undef
         },
         'match_labels' => {
@@ -3375,10 +2779,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_from_733_pod_selector_737_match_expressions_738_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3395,10 +2795,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_ingress_732_ports_739 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_ingress_732_ports_739_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => {
           'type' => Optional[String],
           'value' => undef
@@ -3411,12 +2807,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_pod_selector_740 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_pod_selector_740_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741],
+          'type' => Optional[Array[Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741]],
           'value' => undef
         },
         'match_labels' => {
@@ -3427,10 +2819,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741 => {
       attributes => {
-        'kubernetes_network_policy_spec_723_pod_selector_740_match_expressions_741_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3451,8 +2839,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_persistent_volume_metadata_742,
-        'spec' => Kubernetes_persistent_volume_spec_743
+        'metadata' => Array[Kubernetes_persistent_volume_metadata_742],
+        'spec' => Array[Kubernetes_persistent_volume_spec_743]
       }
     },
     Kubernetes_persistent_volumeHandler => {
@@ -3472,8 +2860,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_persistent_volume_claim_metadata_771,
-        'spec' => Kubernetes_persistent_volume_claim_spec_772,
+        'metadata' => Array[Kubernetes_persistent_volume_claim_metadata_771],
+        'spec' => Array[Kubernetes_persistent_volume_claim_spec_772],
         'wait_until_bound' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -3493,10 +2881,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_claim_metadata_771 => {
       attributes => {
-        'kubernetes_persistent_volume_claim_metadata_771_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -3537,14 +2921,10 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_claim_spec_772 => {
       attributes => {
-        'kubernetes_persistent_volume_claim_spec_772_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_modes' => Array[String],
-        'resources' => Kubernetes_persistent_volume_claim_spec_772_resources_773,
+        'resources' => Array[Kubernetes_persistent_volume_claim_spec_772_resources_773],
         'selector' => {
-          'type' => Optional[Kubernetes_persistent_volume_claim_spec_772_selector_774],
+          'type' => Optional[Array[Kubernetes_persistent_volume_claim_spec_772_selector_774]],
           'value' => undef
         },
         'storage_class_name' => {
@@ -3559,10 +2939,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_claim_spec_772_resources_773 => {
       attributes => {
-        'kubernetes_persistent_volume_claim_spec_772_resources_773_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -3575,12 +2951,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_claim_spec_772_selector_774 => {
       attributes => {
-        'kubernetes_persistent_volume_claim_spec_772_selector_774_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775],
+          'type' => Optional[Array[Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775]],
           'value' => undef
         },
         'match_labels' => {
@@ -3591,10 +2963,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775 => {
       attributes => {
-        'kubernetes_persistent_volume_claim_spec_772_selector_774_match_expressions_775_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3611,10 +2979,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_metadata_742 => {
       attributes => {
-        'kubernetes_persistent_volume_metadata_742_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -3647,21 +3011,17 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_modes' => Array[String],
         'capacity' => Hash[String, String],
         'node_affinity' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_node_affinity_744],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_node_affinity_744]],
           'value' => undef
         },
         'persistent_volume_reclaim_policy' => {
           'type' => Optional[String],
           'value' => undef
         },
-        'persistent_volume_source' => Kubernetes_persistent_volume_spec_743_persistent_volume_source_749,
+        'persistent_volume_source' => Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749],
         'storage_class_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -3670,50 +3030,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_node_affinity_744 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_node_affinity_744_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'required' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745]],
           'value' => undef
         }
       }
     },
     Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'node_selector_term' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746]],
           'value' => undef
         }
       }
     },
     Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747]],
           'value' => undef
         },
         'match_fields' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748]],
           'value' => undef
         }
       }
     },
     Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_expressions_747_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3730,10 +3074,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_node_affinity_744_required_745_node_selector_term_746_match_fields_748_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -3750,90 +3090,82 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_elastic_block_store' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750]],
           'value' => undef
         },
         'azure_disk' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751]],
           'value' => undef
         },
         'azure_file' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752]],
           'value' => undef
         },
         'ceph_fs' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753]],
           'value' => undef
         },
         'cinder' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755]],
           'value' => undef
         },
         'fc' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756]],
           'value' => undef
         },
         'flex_volume' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757]],
           'value' => undef
         },
         'flocker' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759]],
           'value' => undef
         },
         'gce_persistent_disk' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760]],
           'value' => undef
         },
         'glusterfs' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761]],
           'value' => undef
         },
         'host_path' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762]],
           'value' => undef
         },
         'iscsi' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763]],
           'value' => undef
         },
         'local' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764]],
           'value' => undef
         },
         'nfs' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765]],
           'value' => undef
         },
         'photon_persistent_disk' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766]],
           'value' => undef
         },
         'quobyte' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767]],
           'value' => undef
         },
         'rbd' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768]],
           'value' => undef
         },
         'vsphere_volume' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770]],
           'value' => undef
         }
       }
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_aws_elastic_block_store_750_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -3851,10 +3183,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_disk_751_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'caching_mode' => String,
         'data_disk_uri' => String,
         'disk_name' => String,
@@ -3870,10 +3198,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_azure_file_752_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'read_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -3884,10 +3208,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'monitors' => Array[String],
         'path' => {
           'type' => Optional[String],
@@ -3902,7 +3222,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754]],
           'value' => undef
         },
         'user' => {
@@ -3913,10 +3233,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_ceph_fs_753_secret_ref_754_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -3925,10 +3241,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_cinder_755_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -3942,10 +3254,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_fc_756_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -3960,10 +3268,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver' => String,
         'fs_type' => {
           'type' => Optional[String],
@@ -3978,17 +3282,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758]],
           'value' => undef
         }
       }
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flex_volume_757_secret_ref_758_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -3997,10 +3297,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_flocker_759_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4013,10 +3309,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_gce_persistent_disk_760_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -4034,10 +3326,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_glusterfs_761_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoints_name' => String,
         'path' => String,
         'read_only' => {
@@ -4048,10 +3336,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_host_path_762_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -4060,10 +3344,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_iscsi_763_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -4086,10 +3366,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_local_764_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -4098,10 +3374,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_nfs_765_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String,
         'read_only' => {
           'type' => Optional[Boolean],
@@ -4112,10 +3384,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_photon_persistent_disk_766_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -4125,10 +3393,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_quobyte_767_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -4147,10 +3411,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ceph_monitors' => Array[String],
         'fs_type' => {
           'type' => Optional[String],
@@ -4174,17 +3434,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769],
+          'type' => Optional[Array[Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769]],
           'value' => undef
         }
       }
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_rbd_768_secret_ref_769_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4193,10 +3449,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770 => {
       attributes => {
-        'kubernetes_persistent_volume_spec_743_persistent_volume_source_749_vsphere_volume_770_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -4210,8 +3462,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_pod_metadata_776,
-        'spec' => Kubernetes_pod_spec_777
+        'metadata' => Array[Kubernetes_pod_metadata_776],
+        'spec' => Array[Kubernetes_pod_spec_777]
       }
     },
     Kubernetes_podHandler => {
@@ -4227,10 +3479,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_metadata_776 => {
       attributes => {
-        'kubernetes_pod_metadata_776_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -4271,16 +3519,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777 => {
       attributes => {
-        'kubernetes_pod_spec_777_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'active_deadline_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'container' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778]],
           'value' => undef
         },
         'dns_policy' => {
@@ -4304,11 +3548,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'image_pull_secrets' => {
-          'type' => Optional[Kubernetes_pod_spec_777_image_pull_secrets_817],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_image_pull_secrets_817]],
           'value' => undef
         },
         'init_container' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818]],
           'value' => undef
         },
         'node_name' => {
@@ -4324,7 +3568,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_pod_spec_777_security_context_857],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_security_context_857]],
           'value' => undef
         },
         'service_account_name' => {
@@ -4340,17 +3584,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -4360,11 +3600,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_779],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_779]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_from_785],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_from_785]],
           'value' => undef
         },
         'image' => {
@@ -4376,28 +3616,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_liveness_probe_799],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_liveness_probe_799]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_port_804],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_port_804]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_readiness_probe_805],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_readiness_probe_805]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_resources_810],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_resources_810]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_security_context_813],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_security_context_813]],
           'value' => undef
         },
         'stdin' => {
@@ -4417,7 +3657,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_volume_mount_816],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_volume_mount_816]],
           'value' => undef
         },
         'working_dir' => {
@@ -4428,51 +3668,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_env_779 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_779_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_779_value_from_780],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_779_value_from_780]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_env_779_value_from_780 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_779_value_from_780_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_779_value_from_780_config_map_key_ref_781_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -4485,10 +3713,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_779_value_from_780_field_ref_782_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -4501,10 +3725,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_779_value_from_780_resource_field_ref_783_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4514,10 +3734,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_779_value_from_780_secret_key_ref_784_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -4530,12 +3746,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_env_from_785 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_from_785_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786]],
           'value' => undef
         },
         'prefix' => {
@@ -4543,17 +3755,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_from_785_config_map_ref_786_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -4563,10 +3771,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_env_from_785_secret_ref_787_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -4576,46 +3780,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_exec_790_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -4624,16 +3816,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792]],
           'value' => undef
         },
         'path' => {
@@ -4652,10 +3840,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_http_get_791_http_header_792_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4668,39 +3852,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_post_start_789_tcp_socket_793_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_exec_795_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -4709,16 +3881,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797]],
           'value' => undef
         },
         'path' => {
@@ -4737,10 +3905,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_http_get_796_http_header_797_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4753,21 +3917,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_lifecycle_788_pre_stop_794_tcp_socket_798_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_container_778_liveness_probe_799 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_liveness_probe_799_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -4775,7 +3931,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -4791,7 +3947,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -4802,10 +3958,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_liveness_probe_799_exec_800_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -4814,16 +3966,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802]],
           'value' => undef
         },
         'path' => {
@@ -4842,10 +3990,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_liveness_probe_799_http_get_801_http_header_802_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4858,19 +4002,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_liveness_probe_799_tcp_socket_803_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_container_778_port_804 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_port_804_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -4892,12 +4028,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_readiness_probe_805 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_readiness_probe_805_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -4905,7 +4037,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -4921,7 +4053,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -4932,10 +4064,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_readiness_probe_805_exec_806_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -4944,16 +4072,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808]],
           'value' => undef
         },
         'path' => {
@@ -4972,10 +4096,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_readiness_probe_805_http_get_807_http_header_808_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -4988,35 +4108,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_readiness_probe_805_tcp_socket_809_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_container_778_resources_810 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_resources_810_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_resources_810_limits_811],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_resources_810_limits_811]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_resources_810_requests_812],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_resources_810_requests_812]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_resources_810_limits_811 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_resources_810_limits_811_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -5029,10 +4137,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_resources_810_requests_812 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_resources_810_requests_812_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -5045,16 +4149,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_security_context_813 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_security_context_813_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814]],
           'value' => undef
         },
         'privileged' => {
@@ -5074,17 +4174,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_security_context_813_capabilities_814_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5097,10 +4193,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_security_context_813_se_linux_options_815_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -5121,10 +4213,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_container_778_volume_mount_816 => {
       attributes => {
-        'kubernetes_pod_spec_777_container_778_volume_mount_816_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -5139,19 +4227,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_image_pull_secrets_817 => {
       attributes => {
-        'kubernetes_pod_spec_777_image_pull_secrets_817_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String
       }
     },
     Kubernetes_pod_spec_777_init_container_818 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5161,11 +4241,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_819],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_819]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_from_825],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_from_825]],
           'value' => undef
         },
         'image' => {
@@ -5177,28 +4257,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_port_844],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_port_844]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_resources_850],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_resources_850]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_security_context_853],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_security_context_853]],
           'value' => undef
         },
         'stdin' => {
@@ -5218,7 +4298,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_volume_mount_856],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_volume_mount_856]],
           'value' => undef
         },
         'working_dir' => {
@@ -5229,51 +4309,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_env_819 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_819_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_config_map_key_ref_821_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -5286,10 +4354,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_field_ref_822_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -5302,10 +4366,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_resource_field_ref_823_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -5315,10 +4375,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_819_value_from_820_secret_key_ref_824_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -5331,12 +4387,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_env_from_825 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_from_825_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826]],
           'value' => undef
         },
         'prefix' => {
@@ -5344,17 +4396,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_from_825_config_map_ref_826_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -5364,10 +4412,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_env_from_825_secret_ref_827_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -5377,46 +4421,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_exec_830_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5425,16 +4457,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832]],
           'value' => undef
         },
         'path' => {
@@ -5453,10 +4481,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_http_get_831_http_header_832_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -5469,39 +4493,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_post_start_829_tcp_socket_833_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_exec_835_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5510,16 +4522,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837]],
           'value' => undef
         },
         'path' => {
@@ -5538,10 +4546,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_http_get_836_http_header_837_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -5554,21 +4558,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_lifecycle_828_pre_stop_834_tcp_socket_838_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_init_container_818_liveness_probe_839 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_liveness_probe_839_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -5576,7 +4572,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -5592,7 +4588,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -5603,10 +4599,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_liveness_probe_839_exec_840_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5615,16 +4607,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842]],
           'value' => undef
         },
         'path' => {
@@ -5643,10 +4631,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_liveness_probe_839_http_get_841_http_header_842_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -5659,19 +4643,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_liveness_probe_839_tcp_socket_843_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_init_container_818_port_844 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_port_844_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -5693,12 +4669,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_readiness_probe_845 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_readiness_probe_845_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -5706,7 +4678,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -5722,7 +4694,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -5733,10 +4705,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_readiness_probe_845_exec_846_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5745,16 +4713,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848]],
           'value' => undef
         },
         'path' => {
@@ -5773,10 +4737,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_readiness_probe_845_http_get_847_http_header_848_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -5789,35 +4749,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_readiness_probe_845_tcp_socket_849_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_pod_spec_777_init_container_818_resources_850 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_resources_850_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_resources_850_limits_851 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_resources_850_limits_851_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -5830,10 +4778,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_resources_850_requests_852 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_resources_850_requests_852_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -5846,16 +4790,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_security_context_853 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_security_context_853_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854]],
           'value' => undef
         },
         'privileged' => {
@@ -5875,17 +4815,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_security_context_853_capabilities_854_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -5898,10 +4834,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_security_context_853_se_linux_options_855_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -5922,10 +4854,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_init_container_818_volume_mount_856 => {
       attributes => {
-        'kubernetes_pod_spec_777_init_container_818_volume_mount_856_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -5940,10 +4868,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_security_context_857 => {
       attributes => {
-        'kubernetes_pod_spec_777_security_context_857_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_group' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -5957,7 +4881,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_pod_spec_777_security_context_857_se_linux_options_858],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_security_context_857_se_linux_options_858]],
           'value' => undef
         },
         'supplemental_groups' => {
@@ -5968,10 +4892,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_security_context_857_se_linux_options_858 => {
       attributes => {
-        'kubernetes_pod_spec_777_security_context_857_se_linux_options_858_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -5992,76 +4912,72 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_elastic_block_store' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860]],
           'value' => undef
         },
         'azure_disk' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_azure_disk_861],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_azure_disk_861]],
           'value' => undef
         },
         'azure_file' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_azure_file_862],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_azure_file_862]],
           'value' => undef
         },
         'ceph_fs' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_ceph_fs_863],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_ceph_fs_863]],
           'value' => undef
         },
         'cinder' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_cinder_865],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_cinder_865]],
           'value' => undef
         },
         'config_map' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_config_map_866],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_config_map_866]],
           'value' => undef
         },
         'downward_api' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_downward_api_868],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_downward_api_868]],
           'value' => undef
         },
         'empty_dir' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_empty_dir_872],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_empty_dir_872]],
           'value' => undef
         },
         'fc' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_fc_873],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_fc_873]],
           'value' => undef
         },
         'flex_volume' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_flex_volume_874],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_flex_volume_874]],
           'value' => undef
         },
         'flocker' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_flocker_876],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_flocker_876]],
           'value' => undef
         },
         'gce_persistent_disk' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877]],
           'value' => undef
         },
         'git_repo' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_git_repo_878],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_git_repo_878]],
           'value' => undef
         },
         'glusterfs' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_glusterfs_879],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_glusterfs_879]],
           'value' => undef
         },
         'host_path' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_host_path_880],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_host_path_880]],
           'value' => undef
         },
         'iscsi' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_iscsi_881],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_iscsi_881]],
           'value' => undef
         },
         'local' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_local_882],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_local_882]],
           'value' => undef
         },
         'name' => {
@@ -6069,41 +4985,37 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'nfs' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_nfs_883],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_nfs_883]],
           'value' => undef
         },
         'persistent_volume_claim' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884]],
           'value' => undef
         },
         'photon_persistent_disk' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885]],
           'value' => undef
         },
         'quobyte' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_quobyte_886],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_quobyte_886]],
           'value' => undef
         },
         'rbd' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_rbd_887],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_rbd_887]],
           'value' => undef
         },
         'secret' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_secret_889],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_secret_889]],
           'value' => undef
         },
         'vsphere_volume' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_vsphere_volume_891],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_vsphere_volume_891]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_aws_elastic_block_store_860_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6121,10 +5033,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_azure_disk_861 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_azure_disk_861_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'caching_mode' => String,
         'data_disk_uri' => String,
         'disk_name' => String,
@@ -6140,10 +5048,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_azure_file_862 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_azure_file_862_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'read_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -6154,10 +5058,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_ceph_fs_863 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_ceph_fs_863_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'monitors' => Array[String],
         'path' => {
           'type' => Optional[String],
@@ -6172,7 +5072,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864]],
           'value' => undef
         },
         'user' => {
@@ -6183,10 +5083,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_ceph_fs_863_secret_ref_864_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6195,10 +5091,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_cinder_865 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_cinder_865_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6212,16 +5104,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_config_map_866 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_config_map_866_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_config_map_866_items_867],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_config_map_866_items_867]],
           'value' => undef
         },
         'name' => {
@@ -6232,10 +5120,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_config_map_866_items_867 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_config_map_866_items_867_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -6252,44 +5136,32 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_downward_api_868 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_downward_api_868_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_ref' => Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870,
+        'field_ref' => Array[Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870],
         'mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'path' => String,
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_field_ref_870_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -6302,10 +5174,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_downward_api_868_items_869_resource_field_ref_871_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => String,
         'quantity' => {
           'type' => Optional[String],
@@ -6316,10 +5184,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_empty_dir_872 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_empty_dir_872_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'medium' => {
           'type' => Optional[String],
           'value' => undef
@@ -6328,10 +5192,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_fc_873 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_fc_873_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6346,10 +5206,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_flex_volume_874 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_flex_volume_874_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver' => String,
         'fs_type' => {
           'type' => Optional[String],
@@ -6364,17 +5220,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_flex_volume_874_secret_ref_875_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6383,10 +5235,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_flocker_876 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_flocker_876_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6399,10 +5247,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_gce_persistent_disk_877_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6420,10 +5264,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_git_repo_878 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_git_repo_878_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'directory' => {
           'type' => Optional[String],
           'value' => undef
@@ -6440,10 +5280,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_glusterfs_879 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_glusterfs_879_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoints_name' => String,
         'path' => String,
         'read_only' => {
@@ -6454,10 +5290,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_host_path_880 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_host_path_880_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -6466,10 +5298,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_iscsi_881 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_iscsi_881_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6492,10 +5320,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_local_882 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_local_882_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -6504,10 +5328,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_nfs_883 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_nfs_883_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String,
         'read_only' => {
           'type' => Optional[Boolean],
@@ -6518,10 +5338,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_persistent_volume_claim_884_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'claim_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6534,10 +5350,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_photon_persistent_disk_885_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6547,10 +5359,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_quobyte_886 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_quobyte_886_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -6569,10 +5377,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_rbd_887 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_rbd_887_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ceph_monitors' => Array[String],
         'fs_type' => {
           'type' => Optional[String],
@@ -6596,17 +5400,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888]],
           'value' => undef
         }
       }
     },
     Kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_rbd_887_secret_ref_888_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -6615,16 +5415,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_secret_889 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_secret_889_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_pod_spec_777_volume_859_secret_889_items_890],
+          'type' => Optional[Array[Kubernetes_pod_spec_777_volume_859_secret_889_items_890]],
           'value' => undef
         },
         'optional' => {
@@ -6639,10 +5435,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_secret_889_items_890 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_secret_889_items_890_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -6659,10 +5451,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_pod_spec_777_volume_859_vsphere_volume_891 => {
       attributes => {
-        'kubernetes_pod_spec_777_volume_859_vsphere_volume_891_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -6676,8 +5464,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_replication_controller_metadata_892,
-        'spec' => Kubernetes_replication_controller_spec_893
+        'metadata' => Array[Kubernetes_replication_controller_metadata_892],
+        'spec' => Array[Kubernetes_replication_controller_spec_893]
       }
     },
     Kubernetes_replication_controllerHandler => {
@@ -6693,10 +5481,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_metadata_892 => {
       attributes => {
-        'kubernetes_replication_controller_metadata_892_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -6737,10 +5521,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'min_ready_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -6750,21 +5530,17 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'selector' => Hash[String, String],
-        'template' => Kubernetes_replication_controller_spec_893_template_894
+        'template' => Array[Kubernetes_replication_controller_spec_893_template_894]
       }
     },
     Kubernetes_replication_controller_spec_893_template_894 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'active_deadline_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'container' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895]],
           'value' => undef
         },
         'dns_policy' => {
@@ -6788,15 +5564,15 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'image_pull_secrets' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934]],
           'value' => undef
         },
         'init_container' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935]],
           'value' => undef
         },
         'metadata' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_metadata_974],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_metadata_974]],
           'value' => undef
         },
         'node_name' => {
@@ -6812,7 +5588,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_security_context_975],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_security_context_975]],
           'value' => undef
         },
         'service_account_name' => {
@@ -6820,7 +5596,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'spec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977]],
           'value' => undef
         },
         'subdomain' => {
@@ -6832,17 +5608,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -6852,11 +5624,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902]],
           'value' => undef
         },
         'image' => {
@@ -6868,28 +5640,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_port_921],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_port_921]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930]],
           'value' => undef
         },
         'stdin' => {
@@ -6909,7 +5681,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933]],
           'value' => undef
         },
         'working_dir' => {
@@ -6920,51 +5692,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_896 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_896_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_config_map_key_ref_898_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -6977,10 +5737,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_field_ref_899_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -6993,10 +5749,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_resource_field_ref_900_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7006,10 +5758,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_896_value_from_897_secret_key_ref_901_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -7022,12 +5770,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903]],
           'value' => undef
         },
         'prefix' => {
@@ -7035,17 +5779,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_config_map_ref_903_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -7055,10 +5795,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_env_from_902_secret_ref_904_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -7068,46 +5804,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_exec_907_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7116,16 +5840,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909]],
           'value' => undef
         },
         'path' => {
@@ -7144,10 +5864,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_http_get_908_http_header_909_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7160,39 +5876,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_post_start_906_tcp_socket_910_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_exec_912_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7201,16 +5905,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914]],
           'value' => undef
         },
         'path' => {
@@ -7229,10 +5929,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_http_get_913_http_header_914_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7245,21 +5941,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_lifecycle_905_pre_stop_911_tcp_socket_915_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -7267,7 +5955,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -7283,7 +5971,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -7294,10 +5982,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_exec_917_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7306,16 +5990,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919]],
           'value' => undef
         },
         'path' => {
@@ -7334,10 +6014,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_http_get_918_http_header_919_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7350,19 +6026,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_liveness_probe_916_tcp_socket_920_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_port_921 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_port_921_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -7384,12 +6052,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -7397,7 +6061,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -7413,7 +6077,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -7424,10 +6088,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_exec_923_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7436,16 +6096,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925]],
           'value' => undef
         },
         'path' => {
@@ -7464,10 +6120,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_http_get_924_http_header_925_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7480,35 +6132,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_readiness_probe_922_tcp_socket_926_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_limits_928_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -7521,10 +6161,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_resources_927_requests_929_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -7537,16 +6173,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931]],
           'value' => undef
         },
         'privileged' => {
@@ -7566,17 +6198,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_capabilities_931_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7589,10 +6217,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_security_context_930_se_linux_options_932_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -7613,10 +6237,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_container_895_volume_mount_933_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -7631,19 +6251,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_image_pull_secrets_934_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7653,11 +6265,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942]],
           'value' => undef
         },
         'image' => {
@@ -7669,28 +6281,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970]],
           'value' => undef
         },
         'stdin' => {
@@ -7710,7 +6322,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973]],
           'value' => undef
         },
         'working_dir' => {
@@ -7721,51 +6333,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_config_map_key_ref_938_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -7778,10 +6378,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_field_ref_939_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -7794,10 +6390,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_resource_field_ref_940_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7807,10 +6399,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_936_value_from_937_secret_key_ref_941_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -7823,12 +6411,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943]],
           'value' => undef
         },
         'prefix' => {
@@ -7836,17 +6420,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_config_map_ref_943_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -7856,10 +6436,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_env_from_942_secret_ref_944_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -7869,46 +6445,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_exec_947_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -7917,16 +6481,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949]],
           'value' => undef
         },
         'path' => {
@@ -7945,10 +6505,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_http_get_948_http_header_949_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -7961,39 +6517,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_post_start_946_tcp_socket_950_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_exec_952_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8002,16 +6546,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954]],
           'value' => undef
         },
         'path' => {
@@ -8030,10 +6570,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_http_get_953_http_header_954_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -8046,21 +6582,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_lifecycle_945_pre_stop_951_tcp_socket_955_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -8068,7 +6596,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -8084,7 +6612,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -8095,10 +6623,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_exec_957_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8107,16 +6631,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959]],
           'value' => undef
         },
         'path' => {
@@ -8135,10 +6655,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_http_get_958_http_header_959_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -8151,19 +6667,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_liveness_probe_956_tcp_socket_960_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_port_961_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -8185,12 +6693,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -8198,7 +6702,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -8214,7 +6718,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -8225,10 +6729,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_exec_963_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8237,16 +6737,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965]],
           'value' => undef
         },
         'path' => {
@@ -8265,10 +6761,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_http_get_964_http_header_965_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -8281,35 +6773,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_readiness_probe_962_tcp_socket_966_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_limits_968_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -8322,10 +6802,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_resources_967_requests_969_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -8338,16 +6814,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971]],
           'value' => undef
         },
         'privileged' => {
@@ -8367,17 +6839,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_capabilities_971_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8390,10 +6858,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_security_context_970_se_linux_options_972_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -8414,10 +6878,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_init_container_935_volume_mount_973_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -8432,10 +6892,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_metadata_974 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_metadata_974_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -8476,10 +6932,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_security_context_975 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_security_context_975_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_group' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -8493,7 +6945,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976]],
           'value' => undef
         },
         'supplemental_groups' => {
@@ -8504,10 +6956,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_security_context_975_se_linux_options_976_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -8528,16 +6976,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'active_deadline_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'container' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978]],
           'value' => undef
         },
         'dns_policy' => {
@@ -8561,11 +7005,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'image_pull_secrets' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017]],
           'value' => undef
         },
         'init_container' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018]],
           'value' => undef
         },
         'node_name' => {
@@ -8581,7 +7025,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057]],
           'value' => undef
         },
         'service_account_name' => {
@@ -8597,17 +7041,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8617,11 +7057,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985]],
           'value' => undef
         },
         'image' => {
@@ -8633,28 +7073,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013]],
           'value' => undef
         },
         'stdin' => {
@@ -8674,7 +7114,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016]],
           'value' => undef
         },
         'working_dir' => {
@@ -8685,51 +7125,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_config_map_key_ref_981_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -8742,10 +7170,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_field_ref_982_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -8758,10 +7182,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_resource_field_ref_983_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -8771,10 +7191,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_979_value_from_980_secret_key_ref_984_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -8787,12 +7203,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986]],
           'value' => undef
         },
         'prefix' => {
@@ -8800,17 +7212,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_config_map_ref_986_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -8820,10 +7228,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_env_from_985_secret_ref_987_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -8833,46 +7237,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_exec_990_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8881,16 +7273,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992]],
           'value' => undef
         },
         'path' => {
@@ -8909,10 +7297,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_http_get_991_http_header_992_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -8925,39 +7309,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_post_start_989_tcp_socket_993_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_exec_995_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -8966,16 +7338,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997]],
           'value' => undef
         },
         'path' => {
@@ -8994,10 +7362,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_http_get_996_http_header_997_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9010,21 +7374,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_lifecycle_988_pre_stop_994_tcp_socket_998_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -9032,7 +7388,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -9048,7 +7404,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -9059,10 +7415,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_exec_1000_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9071,16 +7423,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002]],
           'value' => undef
         },
         'path' => {
@@ -9099,10 +7447,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_http_get_1001_http_header_1002_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9115,19 +7459,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_liveness_probe_999_tcp_socket_1003_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_port_1004_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -9149,12 +7485,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -9162,7 +7494,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -9178,7 +7510,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -9189,10 +7521,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_exec_1006_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9201,16 +7529,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008]],
           'value' => undef
         },
         'path' => {
@@ -9229,10 +7553,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_http_get_1007_http_header_1008_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9245,35 +7565,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_readiness_probe_1005_tcp_socket_1009_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_limits_1011_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -9286,10 +7594,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_resources_1010_requests_1012_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -9302,16 +7606,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014]],
           'value' => undef
         },
         'privileged' => {
@@ -9331,17 +7631,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_capabilities_1014_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9354,10 +7650,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_security_context_1013_se_linux_options_1015_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -9378,10 +7670,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_container_978_volume_mount_1016_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -9396,19 +7684,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_image_pull_secrets_1017_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9418,11 +7698,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025]],
           'value' => undef
         },
         'image' => {
@@ -9434,28 +7714,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053]],
           'value' => undef
         },
         'stdin' => {
@@ -9475,7 +7755,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056]],
           'value' => undef
         },
         'working_dir' => {
@@ -9486,51 +7766,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_config_map_key_ref_1021_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -9543,10 +7811,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_field_ref_1022_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -9559,10 +7823,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_resource_field_ref_1023_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9572,10 +7832,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_1019_value_from_1020_secret_key_ref_1024_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -9588,12 +7844,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026]],
           'value' => undef
         },
         'prefix' => {
@@ -9601,17 +7853,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_config_map_ref_1026_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -9621,10 +7869,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_env_from_1025_secret_ref_1027_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -9634,46 +7878,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_exec_1030_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9682,16 +7914,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032]],
           'value' => undef
         },
         'path' => {
@@ -9710,10 +7938,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_http_get_1031_http_header_1032_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9726,39 +7950,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_post_start_1029_tcp_socket_1033_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_exec_1035_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9767,16 +7979,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037]],
           'value' => undef
         },
         'path' => {
@@ -9795,10 +8003,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_http_get_1036_http_header_1037_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9811,21 +8015,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_lifecycle_1028_pre_stop_1034_tcp_socket_1038_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -9833,7 +8029,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -9849,7 +8045,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -9860,10 +8056,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_exec_1040_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -9872,16 +8064,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042]],
           'value' => undef
         },
         'path' => {
@@ -9900,10 +8088,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_http_get_1041_http_header_1042_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -9916,19 +8100,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_liveness_probe_1039_tcp_socket_1043_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_port_1044_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -9950,12 +8126,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -9963,7 +8135,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -9979,7 +8151,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -9990,10 +8162,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_exec_1046_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -10002,16 +8170,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048]],
           'value' => undef
         },
         'path' => {
@@ -10030,10 +8194,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_http_get_1047_http_header_1048_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10046,35 +8206,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_readiness_probe_1045_tcp_socket_1049_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_limits_1051_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -10087,10 +8235,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_resources_1050_requests_1052_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -10103,16 +8247,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054]],
           'value' => undef
         },
         'privileged' => {
@@ -10132,17 +8272,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_capabilities_1054_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -10155,10 +8291,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_security_context_1053_se_linux_options_1055_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -10179,10 +8311,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_init_container_1018_volume_mount_1056_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -10197,10 +8325,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_group' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -10214,7 +8338,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058]],
           'value' => undef
         },
         'supplemental_groups' => {
@@ -10225,10 +8349,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_security_context_1057_se_linux_options_1058_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -10249,76 +8369,72 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_elastic_block_store' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060]],
           'value' => undef
         },
         'azure_disk' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061]],
           'value' => undef
         },
         'azure_file' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062]],
           'value' => undef
         },
         'ceph_fs' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063]],
           'value' => undef
         },
         'cinder' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065]],
           'value' => undef
         },
         'config_map' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066]],
           'value' => undef
         },
         'downward_api' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068]],
           'value' => undef
         },
         'empty_dir' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072]],
           'value' => undef
         },
         'fc' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073]],
           'value' => undef
         },
         'flex_volume' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074]],
           'value' => undef
         },
         'flocker' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076]],
           'value' => undef
         },
         'gce_persistent_disk' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077]],
           'value' => undef
         },
         'git_repo' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078]],
           'value' => undef
         },
         'glusterfs' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079]],
           'value' => undef
         },
         'host_path' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080]],
           'value' => undef
         },
         'iscsi' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081]],
           'value' => undef
         },
         'local' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082]],
           'value' => undef
         },
         'name' => {
@@ -10326,41 +8442,37 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'nfs' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083]],
           'value' => undef
         },
         'persistent_volume_claim' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084]],
           'value' => undef
         },
         'photon_persistent_disk' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085]],
           'value' => undef
         },
         'quobyte' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086]],
           'value' => undef
         },
         'rbd' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087]],
           'value' => undef
         },
         'secret' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089]],
           'value' => undef
         },
         'vsphere_volume' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_aws_elastic_block_store_1060_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10378,10 +8490,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_disk_1061_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'caching_mode' => String,
         'data_disk_uri' => String,
         'disk_name' => String,
@@ -10397,10 +8505,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_azure_file_1062_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'read_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -10411,10 +8515,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'monitors' => Array[String],
         'path' => {
           'type' => Optional[String],
@@ -10429,7 +8529,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064]],
           'value' => undef
         },
         'user' => {
@@ -10440,10 +8540,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_ceph_fs_1063_secret_ref_1064_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10452,10 +8548,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_cinder_1065_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10469,16 +8561,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067]],
           'value' => undef
         },
         'name' => {
@@ -10489,10 +8577,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_config_map_1066_items_1067_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -10509,44 +8593,32 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_ref' => Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070,
+        'field_ref' => Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070],
         'mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'path' => String,
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_field_ref_1070_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -10559,10 +8631,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_downward_api_1068_items_1069_resource_field_ref_1071_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => String,
         'quantity' => {
           'type' => Optional[String],
@@ -10573,10 +8641,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_empty_dir_1072_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'medium' => {
           'type' => Optional[String],
           'value' => undef
@@ -10585,10 +8649,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_fc_1073_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10603,10 +8663,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver' => String,
         'fs_type' => {
           'type' => Optional[String],
@@ -10621,17 +8677,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flex_volume_1074_secret_ref_1075_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10640,10 +8692,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_flocker_1076_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10656,10 +8704,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_gce_persistent_disk_1077_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10677,10 +8721,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_git_repo_1078_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'directory' => {
           'type' => Optional[String],
           'value' => undef
@@ -10697,10 +8737,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_glusterfs_1079_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoints_name' => String,
         'path' => String,
         'read_only' => {
@@ -10711,10 +8747,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_host_path_1080_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -10723,10 +8755,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_iscsi_1081_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10749,10 +8777,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_local_1082_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -10761,10 +8785,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_nfs_1083_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String,
         'read_only' => {
           'type' => Optional[Boolean],
@@ -10775,10 +8795,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_persistent_volume_claim_1084_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'claim_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10791,10 +8807,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_photon_persistent_disk_1085_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10804,10 +8816,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_quobyte_1086_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -10826,10 +8834,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ceph_monitors' => Array[String],
         'fs_type' => {
           'type' => Optional[String],
@@ -10853,17 +8857,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_rbd_1087_secret_ref_1088_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -10872,16 +8872,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090]],
           'value' => undef
         },
         'optional' => {
@@ -10896,10 +8892,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_secret_1089_items_1090_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -10916,10 +8908,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_spec_977_volume_1059_vsphere_volume_1091_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -10929,76 +8917,72 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_elastic_block_store' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093]],
           'value' => undef
         },
         'azure_disk' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094]],
           'value' => undef
         },
         'azure_file' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095]],
           'value' => undef
         },
         'ceph_fs' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096]],
           'value' => undef
         },
         'cinder' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098]],
           'value' => undef
         },
         'config_map' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099]],
           'value' => undef
         },
         'downward_api' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101]],
           'value' => undef
         },
         'empty_dir' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105]],
           'value' => undef
         },
         'fc' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106]],
           'value' => undef
         },
         'flex_volume' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107]],
           'value' => undef
         },
         'flocker' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109]],
           'value' => undef
         },
         'gce_persistent_disk' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110]],
           'value' => undef
         },
         'git_repo' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111]],
           'value' => undef
         },
         'glusterfs' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112]],
           'value' => undef
         },
         'host_path' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113]],
           'value' => undef
         },
         'iscsi' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114]],
           'value' => undef
         },
         'local' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115]],
           'value' => undef
         },
         'name' => {
@@ -11006,41 +8990,37 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'nfs' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116]],
           'value' => undef
         },
         'persistent_volume_claim' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117]],
           'value' => undef
         },
         'photon_persistent_disk' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118]],
           'value' => undef
         },
         'quobyte' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119]],
           'value' => undef
         },
         'rbd' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120]],
           'value' => undef
         },
         'secret' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122]],
           'value' => undef
         },
         'vsphere_volume' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_aws_elastic_block_store_1093_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11058,10 +9038,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_disk_1094_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'caching_mode' => String,
         'data_disk_uri' => String,
         'disk_name' => String,
@@ -11077,10 +9053,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_azure_file_1095_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'read_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -11091,10 +9063,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'monitors' => Array[String],
         'path' => {
           'type' => Optional[String],
@@ -11109,7 +9077,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097]],
           'value' => undef
         },
         'user' => {
@@ -11120,10 +9088,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_ceph_fs_1096_secret_ref_1097_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11132,10 +9096,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_cinder_1098_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11149,16 +9109,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100]],
           'value' => undef
         },
         'name' => {
@@ -11169,10 +9125,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_config_map_1099_items_1100_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -11189,44 +9141,32 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_ref' => Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103,
+        'field_ref' => Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103],
         'mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'path' => String,
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_field_ref_1103_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -11239,10 +9179,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_downward_api_1101_items_1102_resource_field_ref_1104_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => String,
         'quantity' => {
           'type' => Optional[String],
@@ -11253,10 +9189,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_empty_dir_1105_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'medium' => {
           'type' => Optional[String],
           'value' => undef
@@ -11265,10 +9197,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_fc_1106_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11283,10 +9211,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver' => String,
         'fs_type' => {
           'type' => Optional[String],
@@ -11301,17 +9225,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_flex_volume_1107_secret_ref_1108_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11320,10 +9240,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_flocker_1109_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11336,10 +9252,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_gce_persistent_disk_1110_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11357,10 +9269,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_git_repo_1111_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'directory' => {
           'type' => Optional[String],
           'value' => undef
@@ -11377,10 +9285,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_glusterfs_1112_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoints_name' => String,
         'path' => String,
         'read_only' => {
@@ -11391,10 +9295,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_host_path_1113_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -11403,10 +9303,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_iscsi_1114_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11429,10 +9325,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_local_1115_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -11441,10 +9333,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_nfs_1116_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String,
         'read_only' => {
           'type' => Optional[Boolean],
@@ -11455,10 +9343,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_persistent_volume_claim_1117_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'claim_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11471,10 +9355,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_photon_persistent_disk_1118_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11484,10 +9364,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_quobyte_1119_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -11506,10 +9382,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ceph_monitors' => Array[String],
         'fs_type' => {
           'type' => Optional[String],
@@ -11533,17 +9405,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121]],
           'value' => undef
         }
       }
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_rbd_1120_secret_ref_1121_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11552,16 +9420,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123],
+          'type' => Optional[Array[Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123]],
           'value' => undef
         },
         'optional' => {
@@ -11576,10 +9440,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_secret_1122_items_1123_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -11596,10 +9456,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124 => {
       attributes => {
-        'kubernetes_replication_controller_spec_893_template_894_volume_1092_vsphere_volume_1124_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11613,9 +9469,9 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_resource_quota_metadata_1125,
+        'metadata' => Array[Kubernetes_resource_quota_metadata_1125],
         'spec' => {
-          'type' => Optional[Kubernetes_resource_quota_spec_1126],
+          'type' => Optional[Array[Kubernetes_resource_quota_spec_1126]],
           'value' => undef
         }
       }
@@ -11633,10 +9489,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_resource_quota_metadata_1125 => {
       attributes => {
-        'kubernetes_resource_quota_metadata_1125_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -11677,10 +9529,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_resource_quota_spec_1126 => {
       attributes => {
-        'kubernetes_resource_quota_spec_1126_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'hard' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -11697,8 +9545,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_role_metadata_1127,
-        'rule' => Kubernetes_role_rule_1128
+        'metadata' => Array[Kubernetes_role_metadata_1127],
+        'rule' => Array[Kubernetes_role_rule_1128]
       }
     },
     Kubernetes_roleHandler => {
@@ -11718,9 +9566,9 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_role_binding_metadata_1129,
+        'metadata' => Array[Kubernetes_role_binding_metadata_1129],
         'role_ref' => Hash[String, String],
-        'subject' => Kubernetes_role_binding_subject_1130
+        'subject' => Array[Kubernetes_role_binding_subject_1130]
       }
     },
     Kubernetes_role_bindingHandler => {
@@ -11736,10 +9584,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_role_binding_metadata_1129 => {
       attributes => {
-        'kubernetes_role_binding_metadata_1129_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -11776,10 +9620,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_role_binding_subject_1130 => {
       attributes => {
-        'kubernetes_role_binding_subject_1130_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_group' => {
           'type' => Optional[String],
           'value' => undef
@@ -11794,10 +9634,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_role_metadata_1127 => {
       attributes => {
-        'kubernetes_role_metadata_1127_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -11838,10 +9674,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_role_rule_1128 => {
       attributes => {
-        'kubernetes_role_rule_1128_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_groups' => Array[String],
         'resource_names' => {
           'type' => Optional[Array[String]],
@@ -11861,7 +9693,7 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[Hash[String, String]],
           'value' => undef
         },
-        'metadata' => Kubernetes_secret_metadata_1131,
+        'metadata' => Array[Kubernetes_secret_metadata_1131],
         'type' => {
           'type' => Optional[String],
           'value' => undef
@@ -11881,10 +9713,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_secret_metadata_1131 => {
       attributes => {
-        'kubernetes_secret_metadata_1131_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -11930,11 +9758,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'load_balancer_ingress' => {
-          'type' => Optional[Kubernetes_service_load_balancer_ingress_1132],
+          'type' => Optional[Array[Kubernetes_service_load_balancer_ingress_1132]],
           'value' => undef
         },
-        'metadata' => Kubernetes_service_metadata_1133,
-        'spec' => Kubernetes_service_spec_1134
+        'metadata' => Array[Kubernetes_service_metadata_1133],
+        'spec' => Array[Kubernetes_service_spec_1134]
       }
     },
     Kubernetes_serviceHandler => {
@@ -11966,7 +9794,7 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[Kubernetes_service_account_image_pull_secret_1136],
           'value' => undef
         },
-        'metadata' => Kubernetes_service_account_metadata_1137,
+        'metadata' => Array[Kubernetes_service_account_metadata_1137],
         'secret' => {
           'type' => Optional[Kubernetes_service_account_secret_1138],
           'value' => undef
@@ -11986,10 +9814,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_account_image_pull_secret_1136 => {
       attributes => {
-        'kubernetes_service_account_image_pull_secret_1136_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -11998,10 +9822,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_account_metadata_1137 => {
       attributes => {
-        'kubernetes_service_account_metadata_1137_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -12042,10 +9862,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_account_secret_1138 => {
       attributes => {
-        'kubernetes_service_account_secret_1138_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -12054,10 +9870,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_load_balancer_ingress_1132 => {
       attributes => {
-        'kubernetes_service_load_balancer_ingress_1132_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'hostname' => {
           'type' => Optional[String],
           'value' => undef
@@ -12070,10 +9882,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_metadata_1133 => {
       attributes => {
-        'kubernetes_service_metadata_1133_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -12114,10 +9922,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_spec_1134 => {
       attributes => {
-        'kubernetes_service_spec_1134_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cluster_ip' => {
           'type' => Optional[String],
           'value' => undef
@@ -12139,7 +9943,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'port' => {
-          'type' => Optional[Kubernetes_service_spec_1134_port_1135],
+          'type' => Optional[Array[Kubernetes_service_spec_1134_port_1135]],
           'value' => undef
         },
         'selector' => {
@@ -12158,10 +9962,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_service_spec_1134_port_1135 => {
       attributes => {
-        'kubernetes_service_spec_1134_port_1135_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -12187,8 +9987,8 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_stateful_set_metadata_1139,
-        'spec' => Kubernetes_stateful_set_spec_1140
+        'metadata' => Array[Kubernetes_stateful_set_metadata_1139],
+        'spec' => Array[Kubernetes_stateful_set_spec_1140]
       }
     },
     Kubernetes_stateful_setHandler => {
@@ -12204,10 +10004,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_metadata_1139 => {
       attributes => {
-        'kubernetes_stateful_set_metadata_1139_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -12248,10 +10044,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'pod_management_policy' => {
           'type' => Optional[String],
           'value' => undef
@@ -12264,27 +10056,23 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[Integer],
           'value' => undef
         },
-        'selector' => Kubernetes_stateful_set_spec_1140_selector_1141,
+        'selector' => Array[Kubernetes_stateful_set_spec_1140_selector_1141],
         'service_name' => String,
-        'template' => Kubernetes_stateful_set_spec_1140_template_1143,
+        'template' => Array[Kubernetes_stateful_set_spec_1140_template_1143],
         'update_strategy' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_update_strategy_1260],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_update_strategy_1260]],
           'value' => undef
         },
         'volume_claim_template' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_selector_1141 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_selector_1141_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142]],
           'value' => undef
         },
         'match_labels' => {
@@ -12295,10 +10083,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_selector_1141_match_expressions_1142_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -12315,23 +10099,15 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'metadata' => Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144,
+        'metadata' => Array[Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144],
         'spec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_metadata_1144 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_metadata_1144_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -12368,16 +10144,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'active_deadline_seconds' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'container' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146]],
           'value' => undef
         },
         'dns_policy' => {
@@ -12401,11 +10173,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'image_pull_secrets' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185]],
           'value' => undef
         },
         'init_container' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186]],
           'value' => undef
         },
         'node_name' => {
@@ -12421,7 +10193,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225]],
           'value' => undef
         },
         'service_account_name' => {
@@ -12437,17 +10209,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -12457,11 +10225,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153]],
           'value' => undef
         },
         'image' => {
@@ -12473,28 +10241,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181]],
           'value' => undef
         },
         'stdin' => {
@@ -12514,7 +10282,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184]],
           'value' => undef
         },
         'working_dir' => {
@@ -12525,51 +10293,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_config_map_key_ref_1149_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -12582,10 +10338,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_field_ref_1150_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -12598,10 +10350,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_resource_field_ref_1151_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -12611,10 +10359,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_1147_value_from_1148_secret_key_ref_1152_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -12627,12 +10371,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154]],
           'value' => undef
         },
         'prefix' => {
@@ -12640,17 +10380,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_config_map_ref_1154_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -12660,10 +10396,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_env_from_1153_secret_ref_1155_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -12673,46 +10405,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_exec_1158_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -12721,16 +10441,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160]],
           'value' => undef
         },
         'path' => {
@@ -12749,10 +10465,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_http_get_1159_http_header_1160_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -12765,39 +10477,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_post_start_1157_tcp_socket_1161_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_exec_1163_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -12806,16 +10506,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165]],
           'value' => undef
         },
         'path' => {
@@ -12834,10 +10530,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_http_get_1164_http_header_1165_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -12850,21 +10542,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_lifecycle_1156_pre_stop_1162_tcp_socket_1166_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -12872,7 +10556,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -12888,7 +10572,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -12899,10 +10583,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_exec_1168_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -12911,16 +10591,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170]],
           'value' => undef
         },
         'path' => {
@@ -12939,10 +10615,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_http_get_1169_http_header_1170_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -12955,19 +10627,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_liveness_probe_1167_tcp_socket_1171_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_port_1172_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -12989,12 +10653,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -13002,7 +10662,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -13018,7 +10678,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -13029,10 +10689,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_exec_1174_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13041,16 +10697,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176]],
           'value' => undef
         },
         'path' => {
@@ -13069,10 +10721,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_http_get_1175_http_header_1176_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -13085,35 +10733,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_readiness_probe_1173_tcp_socket_1177_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_limits_1179_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -13126,10 +10762,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_resources_1178_requests_1180_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -13142,16 +10774,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182]],
           'value' => undef
         },
         'privileged' => {
@@ -13171,17 +10799,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_capabilities_1182_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13194,10 +10818,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_security_context_1181_se_linux_options_1183_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -13218,10 +10838,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_container_1146_volume_mount_1184_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -13236,19 +10852,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_image_pull_secrets_1185_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'args' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13258,11 +10866,11 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'env' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187]],
           'value' => undef
         },
         'env_from' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193]],
           'value' => undef
         },
         'image' => {
@@ -13274,28 +10882,28 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'lifecycle' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196]],
           'value' => undef
         },
         'liveness_probe' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207]],
           'value' => undef
         },
         'name' => String,
         'port' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212]],
           'value' => undef
         },
         'readiness_probe' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213]],
           'value' => undef
         },
         'resources' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218]],
           'value' => undef
         },
         'security_context' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221]],
           'value' => undef
         },
         'stdin' => {
@@ -13315,7 +10923,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'volume_mount' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224]],
           'value' => undef
         },
         'working_dir' => {
@@ -13326,51 +10934,39 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'value' => {
           'type' => Optional[String],
           'value' => undef
         },
         'value_from' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_key_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189]],
           'value' => undef
         },
         'field_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190]],
           'value' => undef
         },
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191]],
           'value' => undef
         },
         'secret_key_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_config_map_key_ref_1189_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -13383,10 +10979,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_field_ref_1190_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -13399,10 +10991,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_resource_field_ref_1191_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -13412,10 +11000,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_1187_value_from_1188_secret_key_ref_1192_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -13428,12 +11012,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'config_map_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194]],
           'value' => undef
         },
         'prefix' => {
@@ -13441,17 +11021,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_config_map_ref_1194_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -13461,10 +11037,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_env_from_1193_secret_ref_1195_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => String,
         'optional' => {
           'type' => Optional[Boolean],
@@ -13474,46 +11046,34 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'post_start' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197]],
           'value' => undef
         },
         'pre_stop' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_exec_1198_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13522,16 +11082,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200]],
           'value' => undef
         },
         'path' => {
@@ -13550,10 +11106,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_http_get_1199_http_header_1200_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -13566,39 +11118,27 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_post_start_1197_tcp_socket_1201_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203]],
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204]],
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_exec_1203_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13607,16 +11147,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205]],
           'value' => undef
         },
         'path' => {
@@ -13635,10 +11171,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_http_get_1204_http_header_1205_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -13651,21 +11183,13 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_lifecycle_1196_pre_stop_1202_tcp_socket_1206_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -13673,7 +11197,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -13689,7 +11213,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -13700,10 +11224,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_exec_1208_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13712,16 +11232,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210]],
           'value' => undef
         },
         'path' => {
@@ -13740,10 +11256,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_http_get_1209_http_header_1210_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -13756,19 +11268,11 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_liveness_probe_1207_tcp_socket_1211_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_port_1212_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_port' => Integer,
         'host_ip' => {
           'type' => Optional[String],
@@ -13790,12 +11294,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'exec' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214]],
           'value' => undef
         },
         'failure_threshold' => {
@@ -13803,7 +11303,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'http_get' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215]],
           'value' => undef
         },
         'initial_delay_seconds' => {
@@ -13819,7 +11319,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'tcp_socket' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217]],
           'value' => undef
         },
         'timeout_seconds' => {
@@ -13830,10 +11330,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_exec_1214_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'command' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13842,16 +11338,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'host' => {
           'type' => Optional[String],
           'value' => undef
         },
         'http_header' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216]],
           'value' => undef
         },
         'path' => {
@@ -13870,10 +11362,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_http_get_1215_http_header_1216_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -13886,35 +11374,23 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_readiness_probe_1213_tcp_socket_1217_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'port' => String
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219]],
           'value' => undef
         },
         'requests' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_limits_1219_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -13927,10 +11403,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_resources_1218_requests_1220_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'cpu' => {
           'type' => Optional[String],
           'value' => undef
@@ -13943,16 +11415,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'allow_privilege_escalation' => {
           'type' => Optional[Boolean],
           'value' => undef
         },
         'capabilities' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222]],
           'value' => undef
         },
         'privileged' => {
@@ -13972,17 +11440,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_capabilities_1222_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'add' => {
           'type' => Optional[Array[String]],
           'value' => undef
@@ -13995,10 +11459,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_security_context_1221_se_linux_options_1223_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -14019,10 +11479,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_init_container_1186_volume_mount_1224_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'mount_path' => String,
         'name' => String,
         'read_only' => {
@@ -14037,10 +11493,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_group' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -14054,7 +11506,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'se_linux_options' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226]],
           'value' => undef
         },
         'supplemental_groups' => {
@@ -14065,10 +11517,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_security_context_1225_se_linux_options_1226_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'level' => {
           'type' => Optional[String],
           'value' => undef
@@ -14089,76 +11537,72 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'aws_elastic_block_store' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228]],
           'value' => undef
         },
         'azure_disk' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229]],
           'value' => undef
         },
         'azure_file' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230]],
           'value' => undef
         },
         'ceph_fs' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231]],
           'value' => undef
         },
         'cinder' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233]],
           'value' => undef
         },
         'config_map' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234]],
           'value' => undef
         },
         'downward_api' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236]],
           'value' => undef
         },
         'empty_dir' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240]],
           'value' => undef
         },
         'fc' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241]],
           'value' => undef
         },
         'flex_volume' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242]],
           'value' => undef
         },
         'flocker' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244]],
           'value' => undef
         },
         'gce_persistent_disk' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245]],
           'value' => undef
         },
         'git_repo' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246]],
           'value' => undef
         },
         'glusterfs' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247]],
           'value' => undef
         },
         'host_path' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248]],
           'value' => undef
         },
         'iscsi' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249]],
           'value' => undef
         },
         'local' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250]],
           'value' => undef
         },
         'name' => {
@@ -14166,41 +11610,37 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'nfs' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251]],
           'value' => undef
         },
         'persistent_volume_claim' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252]],
           'value' => undef
         },
         'photon_persistent_disk' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253]],
           'value' => undef
         },
         'quobyte' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254]],
           'value' => undef
         },
         'rbd' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255]],
           'value' => undef
         },
         'secret' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257]],
           'value' => undef
         },
         'vsphere_volume' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_aws_elastic_block_store_1228_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14218,10 +11658,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_disk_1229_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'caching_mode' => String,
         'data_disk_uri' => String,
         'disk_name' => String,
@@ -14237,10 +11673,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_azure_file_1230_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'read_only' => {
           'type' => Optional[Boolean],
           'value' => undef
@@ -14251,10 +11683,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'monitors' => Array[String],
         'path' => {
           'type' => Optional[String],
@@ -14269,7 +11697,7 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232]],
           'value' => undef
         },
         'user' => {
@@ -14280,10 +11708,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_ceph_fs_1231_secret_ref_1232_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14292,10 +11716,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_cinder_1233_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14309,16 +11729,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235]],
           'value' => undef
         },
         'name' => {
@@ -14329,10 +11745,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_config_map_1234_items_1235_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -14349,44 +11761,32 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'field_ref' => Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238,
+        'field_ref' => Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238],
         'mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'path' => String,
         'resource_field_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_field_ref_1238_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'api_version' => {
           'type' => Optional[String],
           'value' => undef
@@ -14399,10 +11799,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_downward_api_1236_items_1237_resource_field_ref_1239_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'container_name' => String,
         'quantity' => {
           'type' => Optional[String],
@@ -14413,10 +11809,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_empty_dir_1240_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'medium' => {
           'type' => Optional[String],
           'value' => undef
@@ -14425,10 +11817,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_fc_1241_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14443,10 +11831,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'driver' => String,
         'fs_type' => {
           'type' => Optional[String],
@@ -14461,17 +11845,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flex_volume_1242_secret_ref_1243_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14480,10 +11860,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_flocker_1244_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'dataset_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14496,10 +11872,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_gce_persistent_disk_1245_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14517,10 +11889,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_git_repo_1246_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'directory' => {
           'type' => Optional[String],
           'value' => undef
@@ -14537,10 +11905,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_glusterfs_1247_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'endpoints_name' => String,
         'path' => String,
         'read_only' => {
@@ -14551,10 +11915,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_host_path_1248_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -14563,10 +11923,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_iscsi_1249_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14589,10 +11945,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_local_1250_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => {
           'type' => Optional[String],
           'value' => undef
@@ -14601,10 +11953,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_nfs_1251_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'path' => String,
         'read_only' => {
           'type' => Optional[Boolean],
@@ -14615,10 +11963,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_persistent_volume_claim_1252_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'claim_name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14631,10 +11975,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_photon_persistent_disk_1253_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14644,10 +11984,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_quobyte_1254_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'group' => {
           'type' => Optional[String],
           'value' => undef
@@ -14666,10 +12002,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'ceph_monitors' => Array[String],
         'fs_type' => {
           'type' => Optional[String],
@@ -14693,17 +12025,13 @@ type TerraformKubernetes = TypeSet[{
           'value' => undef
         },
         'secret_ref' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256]],
           'value' => undef
         }
       }
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_rbd_1255_secret_ref_1256_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'name' => {
           'type' => Optional[String],
           'value' => undef
@@ -14712,16 +12040,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'default_mode' => {
           'type' => Optional[Integer],
           'value' => undef
         },
         'items' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258]],
           'value' => undef
         },
         'optional' => {
@@ -14736,10 +12060,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_secret_1257_items_1258_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -14756,10 +12076,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_template_1143_spec_1145_volume_1227_vsphere_volume_1259_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'fs_type' => {
           'type' => Optional[String],
           'value' => undef
@@ -14769,12 +12085,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_update_strategy_1260 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_update_strategy_1260_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'rolling_update' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261]],
           'value' => undef
         },
         'type' => {
@@ -14785,10 +12097,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_update_strategy_1260_rolling_update_1261_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'partition' => {
           'type' => Optional[Integer],
           'value' => undef
@@ -14797,20 +12105,12 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_volume_claim_template_1262 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_volume_claim_template_1262_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
-        'metadata' => Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263,
-        'spec' => Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264
+        'metadata' => Array[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263],
+        'spec' => Array[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264]
       }
     },
     Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_volume_claim_template_1262_metadata_1263_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -14851,14 +12151,10 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'access_modes' => Array[String],
-        'resources' => Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265,
+        'resources' => Array[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265],
         'selector' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266]],
           'value' => undef
         },
         'storage_class_name' => {
@@ -14873,10 +12169,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_resources_1265_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'limits' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -14889,12 +12181,8 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'match_expressions' => {
-          'type' => Optional[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267],
+          'type' => Optional[Array[Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267]],
           'value' => undef
         },
         'match_labels' => {
@@ -14905,10 +12193,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267 => {
       attributes => {
-        'kubernetes_stateful_set_spec_1140_volume_claim_template_1262_spec_1264_selector_1266_match_expressions_1267_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'key' => {
           'type' => Optional[String],
           'value' => undef
@@ -14929,7 +12213,7 @@ type TerraformKubernetes = TypeSet[{
           'type' => Optional[String],
           'value' => undef
         },
-        'metadata' => Kubernetes_storage_class_metadata_1268,
+        'metadata' => Array[Kubernetes_storage_class_metadata_1268],
         'parameters' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef
@@ -14958,10 +12242,6 @@ type TerraformKubernetes = TypeSet[{
     },
     Kubernetes_storage_class_metadata_1268 => {
       attributes => {
-        'kubernetes_storage_class_metadata_1268_id' => {
-          'type' => Optional[String],
-          'value' => undef
-        },
         'annotations' => {
           'type' => Optional[Hash[String, String]],
           'value' => undef


### PR DESCRIPTION
Fixes to the bridge provider generator to support arrays of strings. Support for arrays of arbitrary types is not yet supported.

Remove unnecessary ID fields from nested generated types.