### PR TITLE
Add support for lyra link files

### DIFF
--- a/3RDPARTY_LICENSES.txt
+++ b/3RDPARTY_LICENSES.txt
@@ -28,9 +28,11 @@ github.com/lyraproj/lyra/vendor/github.com/golang/protobuf                      
 github.com/lyraproj/lyra/vendor/github.com/golang/snappy                                                 BSD 3-clause "New" or "Revised" License (96%)
 github.com/lyraproj/lyra/vendor/github.com/google/btree                                                  Apache License 2.0
 github.com/lyraproj/lyra/vendor/github.com/google/go-cmp/cmp/internal                                    BSD 3-clause "New" or "Revised" License (96%)
+github.com/lyraproj/lyra/vendor/github.com/google/go-github/github                                       BSD 3-clause "New" or "Revised" License (96%)
+github.com/lyraproj/lyra/vendor/github.com/google/go-querystring/query                                   BSD 3-clause "New" or "Revised" License (96%)
 github.com/lyraproj/lyra/vendor/github.com/google/gofuzz                                                 Apache License 2.0
 github.com/lyraproj/lyra/vendor/github.com/google/uuid                                                   BSD 3-clause "New" or "Revised" License (96%)
-github.com/lyraproj/lyra/vendor/github.com/googleapis/gax-go                                             BSD 3-clause "New" or "Revised" License (97%)
+github.com/lyraproj/lyra/vendor/github.com/googleapis/gax-go/v2                                          BSD 3-clause "New" or "Revised" License (97%)
 github.com/lyraproj/lyra/vendor/github.com/googleapis/gnostic                                            Apache License 2.0
 github.com/lyraproj/lyra/vendor/github.com/gophercloud/gophercloud                                       Apache License 2.0 (96%)
 github.com/lyraproj/lyra/vendor/github.com/gregjones/httpcache/diskcache                                 MIT License (98%)
@@ -40,7 +42,7 @@ github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-cleanhttp               
 github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-getter/helper/url                                Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-hclog                                            MIT License
 github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-multierror                                       Mozilla Public License 2.0
-github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-plugin/internal/proto                            Mozilla Public License 2.0
+github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-plugin/internal/plugin                           Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-safetemp                                         Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-uuid                                             Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/hashicorp/go-version                                          Mozilla Public License 2.0
@@ -99,6 +101,7 @@ github.com/lyraproj/lyra/vendor/github.com/spf13/pflag                          
 github.com/lyraproj/lyra/vendor/github.com/stoewer/go-strcase                                            MIT License
 github.com/lyraproj/lyra/vendor/github.com/terraform-providers/terraform-provider-aws/aws                Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/terraform-providers/terraform-provider-azurerm                Mozilla Public License 2.0
+github.com/lyraproj/lyra/vendor/github.com/terraform-providers/terraform-provider-github/github          Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/terraform-providers/terraform-provider-google                 Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes  Mozilla Public License 2.0
 github.com/lyraproj/lyra/vendor/github.com/toqueteos/trie                                                MIT License

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/lyraproj/puppet-evaluator v0.0.0-20190213111014-f445b297391c
 	github.com/lyraproj/puppet-workflow v0.0.0-20190215162224-286a7c080f50
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
-	github.com/lyraproj/servicesdk v0.0.0-20190215155324-03dc27163cc2
+	github.com/lyraproj/servicesdk v0.0.0-20190220105000-da78ac393e34
 	github.com/lyraproj/wfe v0.0.0-20190213141324-1ca88d9ec407
 	github.com/marstr/guid v1.1.0 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/lyraproj/servicesdk v0.0.0-20190213111125-9b344bb575d1 h1:f5fbA3fPFgQ
 github.com/lyraproj/servicesdk v0.0.0-20190213111125-9b344bb575d1/go.mod h1:TszLWROByVHvGy/7kMLJRCjXvDG0oCPu+2cjP6nF+YQ=
 github.com/lyraproj/servicesdk v0.0.0-20190215155324-03dc27163cc2 h1:Yb9hHXVPmUFDQU1cRSzarrw205SCYtEEtJBrCS7QytI=
 github.com/lyraproj/servicesdk v0.0.0-20190215155324-03dc27163cc2/go.mod h1:TszLWROByVHvGy/7kMLJRCjXvDG0oCPu+2cjP6nF+YQ=
+github.com/lyraproj/servicesdk v0.0.0-20190220105000-da78ac393e34 h1:gDqM85RjppOdunfj89nuqdp40LlSaLYMPt9YczRDbNc=
+github.com/lyraproj/servicesdk v0.0.0-20190220105000-da78ac393e34/go.mod h1:TszLWROByVHvGy/7kMLJRCjXvDG0oCPu+2cjP6nF+YQ=
 github.com/lyraproj/wfe v0.0.0-20190213141324-1ca88d9ec407 h1:fjJbMN7Ik10r2LcC/IEoMZboXttJLfEVDgKxkV3owok=
 github.com/lyraproj/wfe v0.0.0-20190213141324-1ca88d9ec407/go.mod h1:LdDYELaYRN0JFCboMQfIS+f6X8iWPPb65XsjaB7UuoE=
 github.com/marstr/guid v1.1.0 h1:/M4H/1G4avsieL6BbUwCOBzulmoeKVP5ux/3mQNnbyI=
@@ -311,6 +313,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/moovweb/rubex v0.0.1 h1:ly/bF6+2uxAciT7hvw+Uic5/s9l9SQW62sAJrJoa3f8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=

--- a/plugins/tsw-sample.ll
+++ b/plugins/tsw-sample.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: '$HOME/git/tsw-samples/dist/vpc_with_subnet.js'


### PR DESCRIPTION
Adds ability to express plugins as '.ll' (Lyra Link) files containing
a command and an argument or array of arguments expressed as yaml. Both
the command and the arguments are subjected to environment expansion.

At present, this should be viewed as a quick and dirty fix to enable
lyra to start a nodejs executable with a file.

Relates to #42.