### PR TITLE
Add TypeScript example.

### DIFF
--- a/examples/ts-samples/.clang-format
+++ b/examples/ts-samples/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     80

--- a/examples/ts-samples/.gitignore
+++ b/examples/ts-samples/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+node_modules/
+dist/

--- a/examples/ts-samples/package-lock.json
+++ b/examples/ts-samples/package-lock.json
@@ -1,0 +1,2325 @@
+{
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@types/google-protobuf": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.2.7.tgz",
+      "integrity": "sha512-Pb9wl5qDEwfnJeeu6Zpn5Y+waLrKETStqLZXHMGCTbkNuBBudPy4qOGN6veamyeoUBwTm2knOVeP/FlHHhhmzA=="
+    },
+    "@types/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+    },
+    "@types/node": {
+      "version": "10.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
+      "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg=="
+    },
+    "@types/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA=="
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "requires": {
+        "long": "~3"
+      }
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "glob": "^7.0.0",
+        "resolve": "^1.1.6"
+      }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
+    "google-protobuf": {
+      "version": "3.7.0-rc.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.7.0-rc.2.tgz",
+      "integrity": "sha512-mHl4c23RGm7PakQ7OODtWa0H3tpm78we9JE23GkcrTL8rbD/7jpX6p5977quPdr9bLa0yJSst4tDDyXl8wwW3Q=="
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "grpc": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.18.0.tgz",
+      "integrity": "sha512-M0K67Zhv2ZzCjrTbQvjWgYFPB929L+qAVnbNgXepbfO5kJxUYc30dP8m8vb+o8QdahLHAeYfIqRoIzZRcCB98Q==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.0.0",
+        "node-pre-gyp": "^0.12.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.12",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "protobufjs": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+          "requires": {
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
+        }
+      }
+    },
+    "grpc-boom": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/grpc-boom/-/grpc-boom-1.0.18.tgz",
+      "integrity": "sha512-4idUotyYiH2gMUYNywTwGMEeRvnKQS1+RSDS/ozV3hwRc91ERbP8nPBPl8MOmCm4BpnohvtGtL5c78ySBiyJuA=="
+    },
+    "grpc-ts-health-check": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/grpc-ts-health-check/-/grpc-ts-health-check-1.0.10.tgz",
+      "integrity": "sha512-4Tr0bEer/8jh3wnThHIsnEyE1ihGWvjmHLgusLhZGDiqjywVIHZFS1kuJ/MbKrp4JIzNJlcql9KqZDyoht4BiA==",
+      "requires": {
+        "grpc-boom": "~1.0.18"
+      }
+    },
+    "gts": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/gts/-/gts-0.9.0.tgz",
+      "integrity": "sha512-Id2Vmg0xNU1FODc0AwmaFA1h0+h6V9/zBqu4NfT8FucVOVEP7pyJ16btyHfSH/UdzTCXjV1fq+fNBEgx/50EaA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "clang-format": "1.2.3",
+        "diff": "^3.5.0",
+        "entities": "^1.1.1",
+        "inquirer": "^6.0.0",
+        "meow": "^5.0.0",
+        "pify": "^4.0.0",
+        "rimraf": "^2.6.2",
+        "tslint": "^5.9.1",
+        "update-notifier": "^2.5.0",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "^4.0.0"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "lyra-workflow": {
+      "version": "0.1.2-beta.1",
+      "resolved": "https://registry.npmjs.org/lyra-workflow/-/lyra-workflow-0.1.2-beta.1.tgz",
+      "integrity": "sha512-FGCSZkwVQ48d6PThT+4gdJ/5Nx1SA7tJdRJ8B1lhDRD6oF5ZFg89ng6U3ineVKiEfuak92I+zf4+fBO0zrNI4A==",
+      "requires": {
+        "@types/google-protobuf": "^3.2.7",
+        "@types/node": "^10.12.26",
+        "@types/sprintf-js": "^1.1.2",
+        "google-protobuf": "^3.7.0-rc.2",
+        "grpc": "^1.18.0",
+        "grpc-ts-health-check": "^1.0.10",
+        "net": "^1.0.2",
+        "protobufjs": "^6.8.8",
+        "require-from-string": "^2.0.2",
+        "source-map-resolve": "^0.5.2",
+        "typescript": "~3.1.0"
+      }
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
+    "meow": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+    },
+    "net": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
+      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        }
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
+      }
+    },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+      "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "typescript": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
+    }
+  }
+}

--- a/examples/ts-samples/package.json
+++ b/examples/ts-samples/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ts-samples",
+  "version": "0.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "check": "gts check",
+    "clean": "gts clean",
+    "compile": "tsc -p .",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.1.0"
+  },
+  "dependencies": {
+    "lyra-workflow": "^0.1.2-beta.1"
+  }
+}

--- a/examples/ts-samples/package.json
+++ b/examples/ts-samples/package.json
@@ -21,6 +21,6 @@
     "typescript": "~3.1.0"
   },
   "dependencies": {
-    "lyra-workflow": "^0.1.2-beta.1"
+    "lyra-workflow": "^0.1.2-beta.2"
   }
 }

--- a/examples/ts-samples/src/Aws.ts
+++ b/examples/ts-samples/src/Aws.ts
@@ -1,0 +1,1679 @@
+import {PcoreValue} from 'lyra-workflow/dist/pcore/Serializer';
+import {Value} from 'lyra-workflow/dist/pcore/Util';
+
+export class BlockDeviceMapping implements PcoreValue {
+  readonly deviceName: string;
+  readonly ebs: EbsBlockDevice|null;
+  readonly noDevice: string;
+  readonly virtualName: string;
+
+  constructor({deviceName = '', ebs = null, noDevice = '', virtualName = ''}: {
+    deviceName?: string,
+    ebs?: EbsBlockDevice|null,
+    noDevice?: string,
+    virtualName?: string
+  }) {
+    this.deviceName = deviceName;
+    this.ebs = ebs;
+    this.noDevice = noDevice;
+    this.virtualName = virtualName;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.deviceName !== '') {
+      ih['deviceName'] = this.deviceName;
+    }
+    if (this.ebs !== null) {
+      ih['ebs'] = this.ebs;
+    }
+    if (this.noDevice !== '') {
+      ih['noDevice'] = this.noDevice;
+    }
+    if (this.virtualName !== '') {
+      ih['virtualName'] = this.virtualName;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::BlockDeviceMapping';
+  }
+}
+
+export class CpuOptions implements PcoreValue {
+  readonly coreCount: number;
+  readonly threadsPerCore: number;
+
+  constructor({coreCount = 0, threadsPerCore = 0}:
+                  {coreCount?: number, threadsPerCore?: number}) {
+    this.coreCount = coreCount;
+    this.threadsPerCore = threadsPerCore;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.coreCount !== 0) {
+      ih['coreCount'] = this.coreCount;
+    }
+    if (this.threadsPerCore !== 0) {
+      ih['threadsPerCore'] = this.threadsPerCore;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::CpuOptions';
+  }
+}
+
+export class EbsBlockDevice implements PcoreValue {
+  readonly deleteOnTermination: boolean;
+  readonly encrypted: boolean;
+  readonly iops: number;
+  readonly kmsKeyId: string;
+  readonly snapshotId: string;
+  readonly volumeSize: number;
+  readonly volumeType: string;
+
+  constructor({
+    deleteOnTermination = false,
+    encrypted = false,
+    iops = 0,
+    kmsKeyId = '',
+    snapshotId = '',
+    volumeSize = 0,
+    volumeType = ''
+  }: {
+    deleteOnTermination?: boolean,
+    encrypted?: boolean,
+    iops?: number,
+    kmsKeyId?: string,
+    snapshotId?: string,
+    volumeSize?: number,
+    volumeType?: string
+  }) {
+    this.deleteOnTermination = deleteOnTermination;
+    this.encrypted = encrypted;
+    this.iops = iops;
+    this.kmsKeyId = kmsKeyId;
+    this.snapshotId = snapshotId;
+    this.volumeSize = volumeSize;
+    this.volumeType = volumeType;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.deleteOnTermination !== false) {
+      ih['deleteOnTermination'] = this.deleteOnTermination;
+    }
+    if (this.encrypted !== false) {
+      ih['encrypted'] = this.encrypted;
+    }
+    if (this.iops !== 0) {
+      ih['iops'] = this.iops;
+    }
+    if (this.kmsKeyId !== '') {
+      ih['kmsKeyId'] = this.kmsKeyId;
+    }
+    if (this.snapshotId !== '') {
+      ih['snapshotId'] = this.snapshotId;
+    }
+    if (this.volumeSize !== 0) {
+      ih['volumeSize'] = this.volumeSize;
+    }
+    if (this.volumeType !== '') {
+      ih['volumeType'] = this.volumeType;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::EbsBlockDevice';
+  }
+}
+
+export class GroupIdentifier implements PcoreValue {
+  readonly groupId: string;
+  readonly groupName: string;
+
+  constructor({groupId = '',
+               groupName = ''}: {groupId?: string, groupName?: string}) {
+    this.groupId = groupId;
+    this.groupName = groupName;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.groupId !== '') {
+      ih['groupId'] = this.groupId;
+    }
+    if (this.groupName !== '') {
+      ih['groupName'] = this.groupName;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::GroupIdentifier';
+  }
+}
+
+export class IamInstanceProfile implements PcoreValue {
+  readonly arn: string;
+  readonly name: string;
+  readonly id: string;
+
+  constructor({arn = '', name = '', id = ''}:
+                  {arn?: string, name?: string, id?: string}) {
+    this.arn = arn;
+    this.name = name;
+    this.id = id;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.arn !== '') {
+      ih['arn'] = this.arn;
+    }
+    if (this.name !== '') {
+      ih['name'] = this.name;
+    }
+    if (this.id !== '') {
+      ih['id'] = this.id;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::IamInstanceProfile';
+  }
+}
+
+export class IamRole implements PcoreValue {
+  readonly roleName: string;
+  readonly assumeRolePolicyDocument: string;
+  readonly tags: {[s: string]: string};
+  readonly description: string|null;
+  readonly path: string|null;
+
+  constructor({
+    roleName,
+    assumeRolePolicyDocument,
+    tags,
+    description = null,
+    path = null
+  }: {
+    roleName: string,
+    assumeRolePolicyDocument: string,
+    tags: {[s: string]: string},
+    description?: string|null,
+    path?: string|null
+  }) {
+    this.roleName = roleName;
+    this.assumeRolePolicyDocument = assumeRolePolicyDocument;
+    this.tags = tags;
+    this.description = description;
+    this.path = path;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['roleName'] = this.roleName;
+    ih['assumeRolePolicyDocument'] = this.assumeRolePolicyDocument;
+    ih['tags'] = this.tags;
+    if (this.description !== null) {
+      ih['description'] = this.description;
+    }
+    if (this.path !== null) {
+      ih['path'] = this.path;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::IamRole';
+  }
+}
+
+export class Instance implements PcoreValue {
+  readonly imageId: string;
+  readonly instanceType: string;
+  readonly maxCount: number;
+  readonly minCount: number;
+  readonly additionalInfo: string;
+  readonly blockDeviceMappings: BlockDeviceMapping[];
+  readonly clientToken: string;
+  readonly cpuOptions: CpuOptions|null;
+  readonly disableApiTermination: boolean;
+  readonly ebsOptimized: boolean;
+  readonly iamInstanceProfile: IamInstanceProfile|null;
+  readonly instanceInitiatedShutdownBehavior: string;
+  readonly ipv6AddressCount: number;
+  readonly ipv6Addresses: InstanceIpv6Address[];
+  readonly kernelId: string;
+  readonly keyName: string;
+  readonly launchTemplate: LaunchTemplateSpecification|null;
+  readonly monitoring: Monitoring|null;
+  readonly placement: Placement|null;
+  readonly privateIpAddress: string;
+  readonly ramdiskId: string;
+  readonly subnetId: string;
+  readonly userData: string;
+  readonly ownerId: string;
+  readonly requesterId: string;
+  readonly reservationId: string;
+  readonly amiLaunchIndex: number;
+  readonly architecture: string;
+  readonly enaSupport: boolean;
+  readonly hypervisor: string;
+  readonly instanceId: string;
+  readonly instanceLifecycle: string;
+  readonly platform: string;
+  readonly privateDnsName: string;
+  readonly productCodes: ProductCode[];
+  readonly publicDnsName: string;
+  readonly publicIpAddress: string;
+  readonly ramDiskId: string;
+  readonly rootDeviceName: string;
+  readonly rootDeviceType: string;
+  readonly securityGroups: GroupIdentifier[];
+  readonly sourceDestCheck: boolean;
+  readonly spotInstanceRequestId: string;
+  readonly sriovNetSupport: string;
+  readonly state: InstanceState|null;
+  readonly stateReason: StateReason|null;
+  readonly stateTransitionReason: string;
+  readonly tags: {[s: string]: string}|null;
+  readonly virtualizationType: string;
+  readonly vpcId: string;
+
+  constructor({
+    imageId,
+    instanceType,
+    maxCount,
+    minCount,
+    additionalInfo = '',
+    blockDeviceMappings = [],
+    clientToken = '',
+    cpuOptions = null,
+    disableApiTermination = false,
+    ebsOptimized = false,
+    iamInstanceProfile = null,
+    instanceInitiatedShutdownBehavior = '',
+    ipv6AddressCount = 0,
+    ipv6Addresses = [],
+    kernelId = '',
+    keyName = '',
+    launchTemplate = null,
+    monitoring = null,
+    placement = null,
+    privateIpAddress = '',
+    ramdiskId = '',
+    subnetId = '',
+    userData = '',
+    ownerId = '',
+    requesterId = '',
+    reservationId = '',
+    amiLaunchIndex = 0,
+    architecture = '',
+    enaSupport = false,
+    hypervisor = '',
+    instanceId = '',
+    instanceLifecycle = '',
+    platform = '',
+    privateDnsName = '',
+    productCodes = [],
+    publicDnsName = '',
+    publicIpAddress = '',
+    ramDiskId = '',
+    rootDeviceName = '',
+    rootDeviceType = '',
+    securityGroups = [],
+    sourceDestCheck = false,
+    spotInstanceRequestId = '',
+    sriovNetSupport = '',
+    state = null,
+    stateReason = null,
+    stateTransitionReason = '',
+    tags,
+    virtualizationType = '',
+    vpcId = ''
+  }: {
+    imageId: string,
+    instanceType: string,
+    maxCount: number,
+    minCount: number,
+    additionalInfo?: string,
+    blockDeviceMappings?: BlockDeviceMapping[],
+    clientToken?: string,
+    cpuOptions?: CpuOptions|null,
+    disableApiTermination?: boolean,
+    ebsOptimized?: boolean,
+    iamInstanceProfile?: IamInstanceProfile|null,
+    instanceInitiatedShutdownBehavior?: string,
+    ipv6AddressCount?: number,
+    ipv6Addresses?: InstanceIpv6Address[],
+    kernelId?: string,
+    keyName?: string,
+    launchTemplate?: LaunchTemplateSpecification|null,
+    monitoring?: Monitoring|null,
+    placement?: Placement|null,
+    privateIpAddress?: string,
+    ramdiskId?: string,
+    subnetId?: string,
+    userData?: string,
+    ownerId?: string,
+    requesterId?: string,
+    reservationId?: string,
+    amiLaunchIndex?: number,
+    architecture?: string,
+    enaSupport?: boolean,
+    hypervisor?: string,
+    instanceId?: string,
+    instanceLifecycle?: string,
+    platform?: string,
+    privateDnsName?: string,
+    productCodes?: ProductCode[],
+    publicDnsName?: string,
+    publicIpAddress?: string,
+    ramDiskId?: string,
+    rootDeviceName?: string,
+    rootDeviceType?: string,
+    securityGroups?: GroupIdentifier[],
+    sourceDestCheck?: boolean,
+    spotInstanceRequestId?: string,
+    sriovNetSupport?: string,
+    state?: InstanceState|null,
+    stateReason?: StateReason|null,
+    stateTransitionReason?: string, tags: {[s: string]: string}|null,
+    virtualizationType?: string,
+    vpcId?: string
+  }) {
+    this.imageId = imageId;
+    this.instanceType = instanceType;
+    this.maxCount = maxCount;
+    this.minCount = minCount;
+    this.additionalInfo = additionalInfo;
+    this.blockDeviceMappings = blockDeviceMappings;
+    this.clientToken = clientToken;
+    this.cpuOptions = cpuOptions;
+    this.disableApiTermination = disableApiTermination;
+    this.ebsOptimized = ebsOptimized;
+    this.iamInstanceProfile = iamInstanceProfile;
+    this.instanceInitiatedShutdownBehavior = instanceInitiatedShutdownBehavior;
+    this.ipv6AddressCount = ipv6AddressCount;
+    this.ipv6Addresses = ipv6Addresses;
+    this.kernelId = kernelId;
+    this.keyName = keyName;
+    this.launchTemplate = launchTemplate;
+    this.monitoring = monitoring;
+    this.placement = placement;
+    this.privateIpAddress = privateIpAddress;
+    this.ramdiskId = ramdiskId;
+    this.subnetId = subnetId;
+    this.userData = userData;
+    this.ownerId = ownerId;
+    this.requesterId = requesterId;
+    this.reservationId = reservationId;
+    this.amiLaunchIndex = amiLaunchIndex;
+    this.architecture = architecture;
+    this.enaSupport = enaSupport;
+    this.hypervisor = hypervisor;
+    this.instanceId = instanceId;
+    this.instanceLifecycle = instanceLifecycle;
+    this.platform = platform;
+    this.privateDnsName = privateDnsName;
+    this.productCodes = productCodes;
+    this.publicDnsName = publicDnsName;
+    this.publicIpAddress = publicIpAddress;
+    this.ramDiskId = ramDiskId;
+    this.rootDeviceName = rootDeviceName;
+    this.rootDeviceType = rootDeviceType;
+    this.securityGroups = securityGroups;
+    this.sourceDestCheck = sourceDestCheck;
+    this.spotInstanceRequestId = spotInstanceRequestId;
+    this.sriovNetSupport = sriovNetSupport;
+    this.state = state;
+    this.stateReason = stateReason;
+    this.stateTransitionReason = stateTransitionReason;
+    this.tags = tags;
+    this.virtualizationType = virtualizationType;
+    this.vpcId = vpcId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['imageId'] = this.imageId;
+    ih['instanceType'] = this.instanceType;
+    ih['maxCount'] = this.maxCount;
+    ih['minCount'] = this.minCount;
+    if (this.additionalInfo !== '') {
+      ih['additionalInfo'] = this.additionalInfo;
+    }
+    if (this.blockDeviceMappings !== []) {
+      ih['blockDeviceMappings'] = this.blockDeviceMappings;
+    }
+    if (this.clientToken !== '') {
+      ih['clientToken'] = this.clientToken;
+    }
+    if (this.cpuOptions !== null) {
+      ih['cpuOptions'] = this.cpuOptions;
+    }
+    if (this.disableApiTermination !== false) {
+      ih['disableApiTermination'] = this.disableApiTermination;
+    }
+    if (this.ebsOptimized !== false) {
+      ih['ebsOptimized'] = this.ebsOptimized;
+    }
+    if (this.iamInstanceProfile !== null) {
+      ih['iamInstanceProfile'] = this.iamInstanceProfile;
+    }
+    if (this.instanceInitiatedShutdownBehavior !== '') {
+      ih['instanceInitiatedShutdownBehavior'] =
+          this.instanceInitiatedShutdownBehavior;
+    }
+    if (this.ipv6AddressCount !== 0) {
+      ih['ipv6AddressCount'] = this.ipv6AddressCount;
+    }
+    if (this.ipv6Addresses !== []) {
+      ih['ipv6Addresses'] = this.ipv6Addresses;
+    }
+    if (this.kernelId !== '') {
+      ih['kernelId'] = this.kernelId;
+    }
+    if (this.keyName !== '') {
+      ih['keyName'] = this.keyName;
+    }
+    if (this.launchTemplate !== null) {
+      ih['launchTemplate'] = this.launchTemplate;
+    }
+    if (this.monitoring !== null) {
+      ih['monitoring'] = this.monitoring;
+    }
+    if (this.placement !== null) {
+      ih['placement'] = this.placement;
+    }
+    if (this.privateIpAddress !== '') {
+      ih['privateIpAddress'] = this.privateIpAddress;
+    }
+    if (this.ramdiskId !== '') {
+      ih['ramdiskId'] = this.ramdiskId;
+    }
+    if (this.subnetId !== '') {
+      ih['subnetId'] = this.subnetId;
+    }
+    if (this.userData !== '') {
+      ih['userData'] = this.userData;
+    }
+    if (this.ownerId !== '') {
+      ih['ownerId'] = this.ownerId;
+    }
+    if (this.requesterId !== '') {
+      ih['requesterId'] = this.requesterId;
+    }
+    if (this.reservationId !== '') {
+      ih['reservationId'] = this.reservationId;
+    }
+    if (this.amiLaunchIndex !== 0) {
+      ih['amiLaunchIndex'] = this.amiLaunchIndex;
+    }
+    if (this.architecture !== '') {
+      ih['architecture'] = this.architecture;
+    }
+    if (this.enaSupport !== false) {
+      ih['enaSupport'] = this.enaSupport;
+    }
+    if (this.hypervisor !== '') {
+      ih['hypervisor'] = this.hypervisor;
+    }
+    if (this.instanceId !== '') {
+      ih['instanceId'] = this.instanceId;
+    }
+    if (this.instanceLifecycle !== '') {
+      ih['instanceLifecycle'] = this.instanceLifecycle;
+    }
+    if (this.platform !== '') {
+      ih['platform'] = this.platform;
+    }
+    if (this.privateDnsName !== '') {
+      ih['privateDnsName'] = this.privateDnsName;
+    }
+    if (this.productCodes !== []) {
+      ih['productCodes'] = this.productCodes;
+    }
+    if (this.publicDnsName !== '') {
+      ih['publicDnsName'] = this.publicDnsName;
+    }
+    if (this.publicIpAddress !== '') {
+      ih['publicIpAddress'] = this.publicIpAddress;
+    }
+    if (this.ramDiskId !== '') {
+      ih['ramDiskId'] = this.ramDiskId;
+    }
+    if (this.rootDeviceName !== '') {
+      ih['rootDeviceName'] = this.rootDeviceName;
+    }
+    if (this.rootDeviceType !== '') {
+      ih['rootDeviceType'] = this.rootDeviceType;
+    }
+    if (this.securityGroups !== []) {
+      ih['securityGroups'] = this.securityGroups;
+    }
+    if (this.sourceDestCheck !== false) {
+      ih['sourceDestCheck'] = this.sourceDestCheck;
+    }
+    if (this.spotInstanceRequestId !== '') {
+      ih['spotInstanceRequestId'] = this.spotInstanceRequestId;
+    }
+    if (this.sriovNetSupport !== '') {
+      ih['sriovNetSupport'] = this.sriovNetSupport;
+    }
+    if (this.state !== null) {
+      ih['state'] = this.state;
+    }
+    if (this.stateReason !== null) {
+      ih['stateReason'] = this.stateReason;
+    }
+    if (this.stateTransitionReason !== '') {
+      ih['stateTransitionReason'] = this.stateTransitionReason;
+    }
+    ih['tags'] = this.tags;
+    if (this.virtualizationType !== '') {
+      ih['virtualizationType'] = this.virtualizationType;
+    }
+    if (this.vpcId !== '') {
+      ih['vpcId'] = this.vpcId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Instance';
+  }
+}
+
+export class InstanceHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::InstanceHandler';
+  }
+}
+
+export class InstanceIpv6Address implements PcoreValue {
+  readonly ipv6Address: string;
+
+  constructor({ipv6Address = ''}: {ipv6Address?: string}) {
+    this.ipv6Address = ipv6Address;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.ipv6Address !== '') {
+      ih['ipv6Address'] = this.ipv6Address;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::InstanceIpv6Address';
+  }
+}
+
+export class InstanceState implements PcoreValue {
+  readonly code: number;
+  readonly name: string;
+
+  constructor({code = 0, name = ''}: {code?: number, name?: string}) {
+    this.code = code;
+    this.name = name;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.code !== 0) {
+      ih['code'] = this.code;
+    }
+    if (this.name !== '') {
+      ih['name'] = this.name;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::InstanceState';
+  }
+}
+
+export class InternetGateway implements PcoreValue {
+  readonly tags: {[s: string]: string};
+  readonly internetGatewayId: string|null;
+  readonly attachments: InternetGatewayAttachment[];
+
+  constructor({tags, internetGatewayId = null, attachments = []}: {
+    tags: {[s: string]: string},
+    internetGatewayId?: string|null,
+    attachments?: InternetGatewayAttachment[]
+  }) {
+    this.tags = tags;
+    this.internetGatewayId = internetGatewayId;
+    this.attachments = attachments;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['tags'] = this.tags;
+    if (this.internetGatewayId !== null) {
+      ih['internetGatewayId'] = this.internetGatewayId;
+    }
+    if (this.attachments !== []) {
+      ih['attachments'] = this.attachments;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::InternetGateway';
+  }
+}
+
+export class InternetGatewayAttachment implements PcoreValue {
+  readonly state: string;
+  readonly vpcId: string;
+
+  constructor({state, vpcId}: {state: string, vpcId: string}) {
+    this.state = state;
+    this.vpcId = vpcId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['state'] = this.state;
+    ih['vpcId'] = this.vpcId;
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::InternetGatewayAttachment';
+  }
+}
+
+export class InternetGatewayHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::InternetGatewayHandler';
+  }
+}
+
+export class IpPermission implements PcoreValue {
+  readonly fromPort: number;
+  readonly ipProtocol: string;
+  readonly ipRanges: IpRange[];
+  readonly ipv6Ranges: Ipv6Range[];
+  readonly prefixListIds: PrefixListId[];
+  readonly toPort: number;
+  readonly userIdGroupPairs: UserIdGroupPair[];
+
+  constructor({
+    fromPort = 0,
+    ipProtocol = '',
+    ipRanges = [],
+    ipv6Ranges = [],
+    prefixListIds = [],
+    toPort = 0,
+    userIdGroupPairs = []
+  }: {
+    fromPort?: number,
+    ipProtocol?: string,
+    ipRanges?: IpRange[],
+    ipv6Ranges?: Ipv6Range[],
+    prefixListIds?: PrefixListId[],
+    toPort?: number,
+    userIdGroupPairs?: UserIdGroupPair[]
+  }) {
+    this.fromPort = fromPort;
+    this.ipProtocol = ipProtocol;
+    this.ipRanges = ipRanges;
+    this.ipv6Ranges = ipv6Ranges;
+    this.prefixListIds = prefixListIds;
+    this.toPort = toPort;
+    this.userIdGroupPairs = userIdGroupPairs;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.fromPort !== 0) {
+      ih['fromPort'] = this.fromPort;
+    }
+    if (this.ipProtocol !== '') {
+      ih['ipProtocol'] = this.ipProtocol;
+    }
+    if (this.ipRanges !== []) {
+      ih['ipRanges'] = this.ipRanges;
+    }
+    if (this.ipv6Ranges !== []) {
+      ih['ipv6Ranges'] = this.ipv6Ranges;
+    }
+    if (this.prefixListIds !== []) {
+      ih['prefixListIds'] = this.prefixListIds;
+    }
+    if (this.toPort !== 0) {
+      ih['toPort'] = this.toPort;
+    }
+    if (this.userIdGroupPairs !== []) {
+      ih['userIdGroupPairs'] = this.userIdGroupPairs;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::IpPermission';
+  }
+}
+
+export class IpRange implements PcoreValue {
+  readonly cidrIp: string;
+  readonly description: string;
+
+  constructor({cidrIp = '',
+               description = ''}: {cidrIp?: string, description?: string}) {
+    this.cidrIp = cidrIp;
+    this.description = description;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.cidrIp !== '') {
+      ih['cidrIp'] = this.cidrIp;
+    }
+    if (this.description !== '') {
+      ih['description'] = this.description;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::IpRange';
+  }
+}
+
+export class Ipv6Range implements PcoreValue {
+  readonly cidrIpv6: string;
+  readonly description: string;
+
+  constructor({cidrIpv6 = '',
+               description = ''}: {cidrIpv6?: string, description?: string}) {
+    this.cidrIpv6 = cidrIpv6;
+    this.description = description;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.cidrIpv6 !== '') {
+      ih['cidrIpv6'] = this.cidrIpv6;
+    }
+    if (this.description !== '') {
+      ih['description'] = this.description;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Ipv6Range';
+  }
+}
+
+export class KeyPair implements PcoreValue {
+  readonly publicKeyMaterial: string;
+  readonly keyName: string;
+  readonly keyFingerprint: string;
+
+  constructor({publicKeyMaterial, keyName, keyFingerprint = ''}: {
+    publicKeyMaterial: string,
+    keyName: string,
+    keyFingerprint?: string
+  }) {
+    this.publicKeyMaterial = publicKeyMaterial;
+    this.keyName = keyName;
+    this.keyFingerprint = keyFingerprint;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['publicKeyMaterial'] = this.publicKeyMaterial;
+    ih['keyName'] = this.keyName;
+    if (this.keyFingerprint !== '') {
+      ih['keyFingerprint'] = this.keyFingerprint;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::KeyPair';
+  }
+}
+
+export class KeyPairHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::KeyPairHandler';
+  }
+}
+
+export class LaunchTemplateSpecification implements PcoreValue {
+  readonly launchTemplateId: string;
+  readonly launchTemplateName: string;
+  readonly version: string;
+
+  constructor({launchTemplateId = '', launchTemplateName = '', version = ''}: {
+    launchTemplateId?: string,
+    launchTemplateName?: string,
+    version?: string
+  }) {
+    this.launchTemplateId = launchTemplateId;
+    this.launchTemplateName = launchTemplateName;
+    this.version = version;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.launchTemplateId !== '') {
+      ih['launchTemplateId'] = this.launchTemplateId;
+    }
+    if (this.launchTemplateName !== '') {
+      ih['launchTemplateName'] = this.launchTemplateName;
+    }
+    if (this.version !== '') {
+      ih['version'] = this.version;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::LaunchTemplateSpecification';
+  }
+}
+
+export class Monitoring implements PcoreValue {
+  readonly enabled: boolean;
+  readonly state: string;
+
+  constructor({enabled = false,
+               state = ''}: {enabled?: boolean, state?: string}) {
+    this.enabled = enabled;
+    this.state = state;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.enabled !== false) {
+      ih['enabled'] = this.enabled;
+    }
+    if (this.state !== '') {
+      ih['state'] = this.state;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Monitoring';
+  }
+}
+
+export class NativeInstanceHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::NativeInstanceHandler';
+  }
+}
+
+export class NativeInternetGatewayHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::NativeInternetGatewayHandler';
+  }
+}
+
+export class NativeRouteTableHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::NativeRouteTableHandler';
+  }
+}
+
+export class NativeSecurityGroupHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::NativeSecurityGroupHandler';
+  }
+}
+
+export class NativeSubnetHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::NativeSubnetHandler';
+  }
+}
+
+export class NativeVpcHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::NativeVpcHandler';
+  }
+}
+
+export class Placement implements PcoreValue {
+  readonly affinity: string;
+  readonly availabilityZone: string;
+  readonly groupName: string;
+  readonly hostId: string;
+  readonly spreadDomain: string;
+  readonly tenancy: string;
+
+  constructor({
+    affinity = '',
+    availabilityZone = '',
+    groupName = '',
+    hostId = '',
+    spreadDomain = '',
+    tenancy = ''
+  }: {
+    affinity?: string,
+    availabilityZone?: string,
+    groupName?: string,
+    hostId?: string,
+    spreadDomain?: string,
+    tenancy?: string
+  }) {
+    this.affinity = affinity;
+    this.availabilityZone = availabilityZone;
+    this.groupName = groupName;
+    this.hostId = hostId;
+    this.spreadDomain = spreadDomain;
+    this.tenancy = tenancy;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.affinity !== '') {
+      ih['affinity'] = this.affinity;
+    }
+    if (this.availabilityZone !== '') {
+      ih['availabilityZone'] = this.availabilityZone;
+    }
+    if (this.groupName !== '') {
+      ih['groupName'] = this.groupName;
+    }
+    if (this.hostId !== '') {
+      ih['hostId'] = this.hostId;
+    }
+    if (this.spreadDomain !== '') {
+      ih['spreadDomain'] = this.spreadDomain;
+    }
+    if (this.tenancy !== '') {
+      ih['tenancy'] = this.tenancy;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Placement';
+  }
+}
+
+export class PrefixListId implements PcoreValue {
+  readonly description: string;
+  readonly prefixListId: string;
+
+  constructor({description = '', prefixListId = ''}:
+                  {description?: string, prefixListId?: string}) {
+    this.description = description;
+    this.prefixListId = prefixListId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.description !== '') {
+      ih['description'] = this.description;
+    }
+    if (this.prefixListId !== '') {
+      ih['prefixListId'] = this.prefixListId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::PrefixListId';
+  }
+}
+
+export class ProductCode implements PcoreValue {
+  readonly productCodeId: string;
+  readonly productCodeType: string;
+
+  constructor({productCodeId = '', productCodeType = ''}:
+                  {productCodeId?: string, productCodeType?: string}) {
+    this.productCodeId = productCodeId;
+    this.productCodeType = productCodeType;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.productCodeId !== '') {
+      ih['productCodeId'] = this.productCodeId;
+    }
+    if (this.productCodeType !== '') {
+      ih['productCodeType'] = this.productCodeType;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::ProductCode';
+  }
+}
+
+export class PropagatingVgw implements PcoreValue {
+  readonly gatewayId: string;
+
+  constructor({gatewayId}: {gatewayId: string}) {
+    this.gatewayId = gatewayId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['gatewayId'] = this.gatewayId;
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::PropagatingVgw';
+  }
+}
+
+export class RoleHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::RoleHandler';
+  }
+}
+
+export class Route implements PcoreValue {
+  readonly tags: {[s: string]: string};
+  readonly destinationCidrBlock: string;
+  readonly destinationIpv6CidrBlock: string;
+  readonly destinationPrefixListId: string;
+  readonly egressOnlyInternetGatewayId: string;
+  readonly gatewayId: string;
+  readonly instanceId: string;
+  readonly instanceOwnerId: string;
+  readonly natGatewayId: string;
+  readonly networkInterfaceId: string;
+  readonly origin: string;
+  readonly state: string;
+  readonly vpcPeeringConnectionId: string;
+
+  constructor({
+    tags,
+    destinationCidrBlock = '',
+    destinationIpv6CidrBlock = '',
+    destinationPrefixListId = '',
+    egressOnlyInternetGatewayId = '',
+    gatewayId = '',
+    instanceId = '',
+    instanceOwnerId = '',
+    natGatewayId = '',
+    networkInterfaceId = '',
+    origin = '',
+    state = '',
+    vpcPeeringConnectionId = ''
+  }: {
+    tags: {[s: string]: string},
+    destinationCidrBlock?: string,
+    destinationIpv6CidrBlock?: string,
+    destinationPrefixListId?: string,
+    egressOnlyInternetGatewayId?: string,
+    gatewayId?: string,
+    instanceId?: string,
+    instanceOwnerId?: string,
+    natGatewayId?: string,
+    networkInterfaceId?: string,
+    origin?: string,
+    state?: string,
+    vpcPeeringConnectionId?: string
+  }) {
+    this.tags = tags;
+    this.destinationCidrBlock = destinationCidrBlock;
+    this.destinationIpv6CidrBlock = destinationIpv6CidrBlock;
+    this.destinationPrefixListId = destinationPrefixListId;
+    this.egressOnlyInternetGatewayId = egressOnlyInternetGatewayId;
+    this.gatewayId = gatewayId;
+    this.instanceId = instanceId;
+    this.instanceOwnerId = instanceOwnerId;
+    this.natGatewayId = natGatewayId;
+    this.networkInterfaceId = networkInterfaceId;
+    this.origin = origin;
+    this.state = state;
+    this.vpcPeeringConnectionId = vpcPeeringConnectionId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['tags'] = this.tags;
+    if (this.destinationCidrBlock !== '') {
+      ih['destinationCidrBlock'] = this.destinationCidrBlock;
+    }
+    if (this.destinationIpv6CidrBlock !== '') {
+      ih['destinationIpv6CidrBlock'] = this.destinationIpv6CidrBlock;
+    }
+    if (this.destinationPrefixListId !== '') {
+      ih['destinationPrefixListId'] = this.destinationPrefixListId;
+    }
+    if (this.egressOnlyInternetGatewayId !== '') {
+      ih['egressOnlyInternetGatewayId'] = this.egressOnlyInternetGatewayId;
+    }
+    if (this.gatewayId !== '') {
+      ih['gatewayId'] = this.gatewayId;
+    }
+    if (this.instanceId !== '') {
+      ih['instanceId'] = this.instanceId;
+    }
+    if (this.instanceOwnerId !== '') {
+      ih['instanceOwnerId'] = this.instanceOwnerId;
+    }
+    if (this.natGatewayId !== '') {
+      ih['natGatewayId'] = this.natGatewayId;
+    }
+    if (this.networkInterfaceId !== '') {
+      ih['networkInterfaceId'] = this.networkInterfaceId;
+    }
+    if (this.origin !== '') {
+      ih['origin'] = this.origin;
+    }
+    if (this.state !== '') {
+      ih['state'] = this.state;
+    }
+    if (this.vpcPeeringConnectionId !== '') {
+      ih['vpcPeeringConnectionId'] = this.vpcPeeringConnectionId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Route';
+  }
+}
+
+export class RouteTable implements PcoreValue {
+  readonly vpcId: string;
+  readonly tags: {[s: string]: string};
+  readonly routeTableId: string|null;
+  readonly subnetId: string|null;
+  readonly routes: Route[];
+  readonly associations: RouteTableAssociation[];
+  readonly propagatingVgws: PropagatingVgw[];
+
+  constructor({
+    vpcId,
+    tags,
+    routeTableId = null,
+    subnetId = null,
+    routes = [],
+    associations = [],
+    propagatingVgws = []
+  }: {
+    vpcId: string,
+    tags: {[s: string]: string},
+    routeTableId?: string|null,
+    subnetId?: string|null,
+    routes?: Route[],
+    associations?: RouteTableAssociation[],
+    propagatingVgws?: PropagatingVgw[]
+  }) {
+    this.vpcId = vpcId;
+    this.tags = tags;
+    this.routeTableId = routeTableId;
+    this.subnetId = subnetId;
+    this.routes = routes;
+    this.associations = associations;
+    this.propagatingVgws = propagatingVgws;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['vpcId'] = this.vpcId;
+    ih['tags'] = this.tags;
+    if (this.routeTableId !== null) {
+      ih['routeTableId'] = this.routeTableId;
+    }
+    if (this.subnetId !== null) {
+      ih['subnetId'] = this.subnetId;
+    }
+    if (this.routes !== []) {
+      ih['routes'] = this.routes;
+    }
+    if (this.associations !== []) {
+      ih['associations'] = this.associations;
+    }
+    if (this.propagatingVgws !== []) {
+      ih['propagatingVgws'] = this.propagatingVgws;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::RouteTable';
+  }
+}
+
+export class RouteTableAssociation implements PcoreValue {
+  readonly main: boolean;
+  readonly routeTableId: string;
+  readonly subnetId: string;
+  readonly routeTableAssociationId: string|null;
+
+  constructor({main, routeTableId, subnetId, routeTableAssociationId = null}: {
+    main: boolean,
+    routeTableId: string,
+    subnetId: string,
+    routeTableAssociationId?: string|null
+  }) {
+    this.main = main;
+    this.routeTableId = routeTableId;
+    this.subnetId = subnetId;
+    this.routeTableAssociationId = routeTableAssociationId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['main'] = this.main;
+    ih['routeTableId'] = this.routeTableId;
+    ih['subnetId'] = this.subnetId;
+    if (this.routeTableAssociationId !== null) {
+      ih['routeTableAssociationId'] = this.routeTableAssociationId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::RouteTableAssociation';
+  }
+}
+
+export class RouteTableHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::RouteTableHandler';
+  }
+}
+
+export class SecurityGroup implements PcoreValue {
+  readonly description: string;
+  readonly groupName: string;
+  readonly vpcId: string;
+  readonly groupId: string;
+  readonly ipPermissions: IpPermission[];
+  readonly ipPermissionsEgress: IpPermission[];
+  readonly ownerId: string;
+  readonly tags: {[s: string]: string}|null;
+
+  constructor({
+    description,
+    groupName,
+    vpcId = '',
+    groupId = '',
+    ipPermissions = [],
+    ipPermissionsEgress = [],
+    ownerId = '',
+    tags
+  }: {
+    description: string,
+    groupName: string,
+    vpcId?: string,
+    groupId?: string,
+    ipPermissions?: IpPermission[],
+    ipPermissionsEgress?: IpPermission[],
+    ownerId?: string, tags: {[s: string]: string}|null
+  }) {
+    this.description = description;
+    this.groupName = groupName;
+    this.vpcId = vpcId;
+    this.groupId = groupId;
+    this.ipPermissions = ipPermissions;
+    this.ipPermissionsEgress = ipPermissionsEgress;
+    this.ownerId = ownerId;
+    this.tags = tags;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['description'] = this.description;
+    ih['groupName'] = this.groupName;
+    if (this.vpcId !== '') {
+      ih['vpcId'] = this.vpcId;
+    }
+    if (this.groupId !== '') {
+      ih['groupId'] = this.groupId;
+    }
+    if (this.ipPermissions !== []) {
+      ih['ipPermissions'] = this.ipPermissions;
+    }
+    if (this.ipPermissionsEgress !== []) {
+      ih['ipPermissionsEgress'] = this.ipPermissionsEgress;
+    }
+    if (this.ownerId !== '') {
+      ih['ownerId'] = this.ownerId;
+    }
+    ih['tags'] = this.tags;
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::SecurityGroup';
+  }
+}
+
+export class SecurityGroupHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::SecurityGroupHandler';
+  }
+}
+
+export class StateReason implements PcoreValue {
+  readonly code: string;
+  readonly message: string;
+
+  constructor({code = '', message = ''}: {code?: string, message?: string}) {
+    this.code = code;
+    this.message = message;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.code !== '') {
+      ih['code'] = this.code;
+    }
+    if (this.message !== '') {
+      ih['message'] = this.message;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::StateReason';
+  }
+}
+
+export class Subnet implements PcoreValue {
+  readonly vpcId: string;
+  readonly cidrBlock: string;
+  readonly ipv6CidrBlock: string;
+  readonly tags: {[s: string]: string};
+  readonly assignIpv6AddressOnCreation: boolean;
+  readonly mapPublicIpOnLaunch: boolean;
+  readonly defaultForAz: boolean;
+  readonly state: string;
+  readonly availabilityZone: string|null;
+  readonly availableIpAddressCount: number|null;
+  readonly subnetId: string|null;
+
+  constructor({
+    vpcId,
+    cidrBlock,
+    ipv6CidrBlock,
+    tags,
+    assignIpv6AddressOnCreation,
+    mapPublicIpOnLaunch,
+    defaultForAz,
+    state,
+    availabilityZone = null,
+    availableIpAddressCount = null,
+    subnetId = null
+  }: {
+    vpcId: string,
+    cidrBlock: string,
+    ipv6CidrBlock: string,
+    tags: {[s: string]: string},
+    assignIpv6AddressOnCreation: boolean,
+    mapPublicIpOnLaunch: boolean,
+    defaultForAz: boolean,
+    state: string,
+    availabilityZone?: string|null,
+    availableIpAddressCount?: number|null,
+    subnetId?: string|null
+  }) {
+    this.vpcId = vpcId;
+    this.cidrBlock = cidrBlock;
+    this.ipv6CidrBlock = ipv6CidrBlock;
+    this.tags = tags;
+    this.assignIpv6AddressOnCreation = assignIpv6AddressOnCreation;
+    this.mapPublicIpOnLaunch = mapPublicIpOnLaunch;
+    this.defaultForAz = defaultForAz;
+    this.state = state;
+    this.availabilityZone = availabilityZone;
+    this.availableIpAddressCount = availableIpAddressCount;
+    this.subnetId = subnetId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['vpcId'] = this.vpcId;
+    ih['cidrBlock'] = this.cidrBlock;
+    ih['ipv6CidrBlock'] = this.ipv6CidrBlock;
+    ih['tags'] = this.tags;
+    ih['assignIpv6AddressOnCreation'] = this.assignIpv6AddressOnCreation;
+    ih['mapPublicIpOnLaunch'] = this.mapPublicIpOnLaunch;
+    ih['defaultForAz'] = this.defaultForAz;
+    ih['state'] = this.state;
+    if (this.availabilityZone !== null) {
+      ih['availabilityZone'] = this.availabilityZone;
+    }
+    if (this.availableIpAddressCount !== null) {
+      ih['availableIpAddressCount'] = this.availableIpAddressCount;
+    }
+    if (this.subnetId !== null) {
+      ih['subnetId'] = this.subnetId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Subnet';
+  }
+}
+
+export class SubnetHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::SubnetHandler';
+  }
+}
+
+export class UserIdGroupPair implements PcoreValue {
+  readonly description: string;
+  readonly groupId: string;
+  readonly groupName: string;
+  readonly peeringStatus: string;
+  readonly userId: string;
+  readonly vpcId: string;
+  readonly vpcPeeringConnectionId: string;
+
+  constructor({
+    description = '',
+    groupId = '',
+    groupName = '',
+    peeringStatus = '',
+    userId = '',
+    vpcId = '',
+    vpcPeeringConnectionId = ''
+  }: {
+    description?: string,
+    groupId?: string,
+    groupName?: string,
+    peeringStatus?: string,
+    userId?: string,
+    vpcId?: string,
+    vpcPeeringConnectionId?: string
+  }) {
+    this.description = description;
+    this.groupId = groupId;
+    this.groupName = groupName;
+    this.peeringStatus = peeringStatus;
+    this.userId = userId;
+    this.vpcId = vpcId;
+    this.vpcPeeringConnectionId = vpcPeeringConnectionId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    if (this.description !== '') {
+      ih['description'] = this.description;
+    }
+    if (this.groupId !== '') {
+      ih['groupId'] = this.groupId;
+    }
+    if (this.groupName !== '') {
+      ih['groupName'] = this.groupName;
+    }
+    if (this.peeringStatus !== '') {
+      ih['peeringStatus'] = this.peeringStatus;
+    }
+    if (this.userId !== '') {
+      ih['userId'] = this.userId;
+    }
+    if (this.vpcId !== '') {
+      ih['vpcId'] = this.vpcId;
+    }
+    if (this.vpcPeeringConnectionId !== '') {
+      ih['vpcPeeringConnectionId'] = this.vpcPeeringConnectionId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::UserIdGroupPair';
+  }
+}
+
+export class VPCHandler implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Aws::VPCHandler';
+  }
+}
+
+export class Vpc implements PcoreValue {
+  readonly amazonProvidedIpv6CidrBlock: boolean;
+  readonly cidrBlock: string;
+  readonly enableDnsHostnames: boolean;
+  readonly enableDnsSupport: boolean;
+  readonly tags: {[s: string]: string};
+  readonly isDefault: boolean;
+  readonly state: string;
+  readonly instanceTenancy: string|null;
+  readonly vpcId: string|null;
+  readonly dhcpOptionsId: string|null;
+
+  constructor({
+    amazonProvidedIpv6CidrBlock,
+    cidrBlock,
+    enableDnsHostnames,
+    enableDnsSupport,
+    tags,
+    isDefault,
+    state,
+    instanceTenancy = 'default',
+    vpcId = null,
+    dhcpOptionsId = null
+  }: {
+    amazonProvidedIpv6CidrBlock: boolean,
+    cidrBlock: string,
+    enableDnsHostnames: boolean,
+    enableDnsSupport: boolean,
+    tags: {[s: string]: string},
+    isDefault: boolean,
+    state: string,
+    instanceTenancy?: string|null,
+    vpcId?: string|null,
+    dhcpOptionsId?: string|null
+  }) {
+    this.amazonProvidedIpv6CidrBlock = amazonProvidedIpv6CidrBlock;
+    this.cidrBlock = cidrBlock;
+    this.enableDnsHostnames = enableDnsHostnames;
+    this.enableDnsSupport = enableDnsSupport;
+    this.tags = tags;
+    this.isDefault = isDefault;
+    this.state = state;
+    this.instanceTenancy = instanceTenancy;
+    this.vpcId = vpcId;
+    this.dhcpOptionsId = dhcpOptionsId;
+  }
+
+  __pvalue(): {[s: string]: Value} {
+    const ih: {[s: string]: Value} = {};
+    ih['amazonProvidedIpv6CidrBlock'] = this.amazonProvidedIpv6CidrBlock;
+    ih['cidrBlock'] = this.cidrBlock;
+    ih['enableDnsHostnames'] = this.enableDnsHostnames;
+    ih['enableDnsSupport'] = this.enableDnsSupport;
+    ih['tags'] = this.tags;
+    ih['isDefault'] = this.isDefault;
+    ih['state'] = this.state;
+    if (this.instanceTenancy !== 'default') {
+      ih['instanceTenancy'] = this.instanceTenancy;
+    }
+    if (this.vpcId !== null) {
+      ih['vpcId'] = this.vpcId;
+    }
+    if (this.dhcpOptionsId !== null) {
+      ih['dhcpOptionsId'] = this.dhcpOptionsId;
+    }
+    return ih;
+  }
+
+  __ptype(): string {
+    return 'Aws::Vpc';
+  }
+}

--- a/examples/ts-samples/src/vpc_with_subnet.ts
+++ b/examples/ts-samples/src/vpc_with_subnet.ts
@@ -1,0 +1,64 @@
+import {action, logger, PluginLogger, resource, ServiceBuilder} from 'lyra-workflow';
+import * as util from 'util';
+
+import * as Aws from './Aws';
+
+function makeRouteTable(
+    vpcId: string, tags: {[s: string]: string}): Aws.RouteTable {
+  return new Aws.RouteTable({vpcId, tags});
+}
+
+const wf = {
+  source: __filename,
+  input: {tags: {type: 'StringHash', lookup: 'aws.tags'}},
+
+  output: {vpcId: 'string', subnetId: 'string', routeTableId: 'string'},
+
+  activities: {
+    vpc: resource({
+      output: 'vpcId',
+      state: (tags: {[s: string]: string}): Aws.Vpc => new Aws.Vpc({
+        amazonProvidedIpv6CidrBlock: false,
+        cidrBlock: '192.168.0.0/16',
+        enableDnsHostnames: false,
+        enableDnsSupport: false,
+        isDefault: false,
+        state: 'available',
+        tags,
+      })
+    }),
+
+    vpcDone: action({
+      do: (vpcId: string): {vpcOk: boolean} => {
+        console.log(`created vpc with id ${vpcId}`);
+        return {vpcOk: true};
+      }
+    }),
+
+    subnet: resource({
+      output: 'subnetId',
+      state: (vpcId: string, tags: {[s: string]: string}) => new Aws.Subnet({
+        vpcId,
+        tags,
+        cidrBlock: '192.168.1.0/24',
+        ipv6CidrBlock: '',
+        assignIpv6AddressOnCreation: false,
+        mapPublicIpOnLaunch: false,
+        defaultForAz: false,
+        state: 'available'
+      })
+    }),
+
+    routetable: resource({
+      output: 'routeTableId',
+      state: (vpcId: string, tags: {[s: string]: string}) =>
+          makeRouteTable(vpcId, tags)
+    })
+  }
+};
+
+const sb = new ServiceBuilder('My::Service');
+sb.workflow(wf);
+const server = sb.build(global);
+logger.info('Starting the server', 'serverId', server.serviceId.toString());
+server.start();

--- a/examples/ts-samples/tsconfig.json
+++ b/examples/ts-samples/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "target": "es5",
+    "lib": [
+      "dom",
+      "es6"
+    ],
+    "noImplicitAny": true,
+     "experimentalDecorators": true,
+    "strictNullChecks": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/examples/ts-samples/tslint.json
+++ b/examples/ts-samples/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "gts/tslint.json"
+}

--- a/plugins/ts-samples.ll
+++ b/plugins/ts-samples.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: 'examples/ts-samples/dist/vpc_with_subnet.js'

--- a/plugins/tsw-sample.ll
+++ b/plugins/tsw-sample.ll
@@ -1,2 +1,0 @@
-executable: node
-arguments: '$HOME/git/tsw-samples/dist/vpc_with_subnet.js'


### PR DESCRIPTION
This commit adds a TypeScript example in the form of a NPM package. It
contains two TS files, the Aws.ts which is generated from a TypeSet and
vpc_with_subnet.ts which contains the actual workflow and also the
boiler plate code to start the plugin.

Relates to #42.