### PR TITLE
Check for go modules as part of make lyra as well as make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ goplugin-example:
 	$(call build,goplugin-example,cmd/goplugin-example/main.go)
 
 PHONY+= lyra
-lyra:
+lyra: check-mods
 	$(call build,lyra,cmd/lyra/main.go)
 
 $(GOPATH)/bin/licenses:
@@ -145,7 +145,7 @@ check-mods:
 	@echo "🔘 Ensuring go version is 1.11.4 or later (`date '+%H:%M:%S'`)"
 	@if [ "$(HAS_REQUIRED_GO)" == "" ]; \
 	then \
-		echo "🔴 must be running Go version 1.11.4 or later"; \
+		echo "🔴 must be running Go version 1.11.4 or later.  Please upgrade and run go clean -modcache"; \
 		exit 1; \
 	fi	
 	@echo "✅ Go version is sufficient  (`date '+%H:%M:%S'`)"


### PR DESCRIPTION
Prior to this commit, `make` (all) would validate the go version is 11.4+and if not error with the message `must be running Go version 1.11.4 or later` (cref https://github.com/golang/go/issues/29278#issuecomment-447537558).  This commit adds that same validation to `make lyra` as this is commonly used instead of `make`.  As a result the check is done twice for `make` but this is very fast.