### PR TITLE
Switch to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 1
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 10m

--- a/cmd/lyra/cmd/root.go
+++ b/cmd/lyra/cmd/root.go
@@ -12,10 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defaultLogEncoding = "console"
-)
-
 var (
 	debug    bool
 	loglevel string
@@ -53,7 +49,10 @@ func NewRootCmd() *cobra.Command {
 }
 
 func runHelp(cmd *cobra.Command, args []string) {
-	cmd.Help()
+	err := cmd.Help()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func initialiseTool(cmd *cobra.Command, args []string) {

--- a/pkg/bridge/marshall.go
+++ b/pkg/bridge/marshall.go
@@ -204,9 +204,9 @@ func TerraformUnmarshal(m map[string]interface{}, s interface{}) {
 }
 
 func unmarshalStruct(name string, ptr reflect.Value, value interface{}) {
-	switch value.(type) {
+	switch value := value.(type) {
 	case map[string]interface{}:
-		TerraformUnmarshal(value.(map[string]interface{}), ptr.Interface())
+		TerraformUnmarshal(value, ptr.Interface())
 	default:
 		logger.Get().Error(fmt.Sprintf("TerraformUnmarshal: Skipping unsupported struct value type for field '%s': %T %v", name, value, spew.Sdump(value)))
 	}
@@ -228,20 +228,18 @@ func unmarshalValue(t reflect.Type, value interface{}) reflect.Value {
 		}
 		return reflect.ValueOf(castvalue)
 	case reflect.Bool:
-		var castvalue bool
-		var err error
-		switch value.(type) {
+		switch value := value.(type) {
 		case string:
-			castvalue, err = strconv.ParseBool(value.(string))
+			boolvalue, err := strconv.ParseBool(value)
 			if err != nil {
 				panic(fmt.Sprintf("TerraformUnmarshal: Bool conversion failed in unmarshalField: %v %v", value, err))
 			}
+			return reflect.ValueOf(boolvalue)
 		case bool:
-			castvalue = value.(bool)
+			return reflect.ValueOf(value)
 		default:
 			panic(fmt.Sprintf("TerraformUnmarshal: Unsupported bool conversion in unmarshalField: %v", value))
 		}
-		return reflect.ValueOf(castvalue)
 	case reflect.Float64:
 		castvalue, err := strconv.ParseFloat(value.(string), 64)
 		if err != nil {

--- a/pkg/bridge/marshall_test.go
+++ b/pkg/bridge/marshall_test.go
@@ -35,10 +35,6 @@ type Llama struct {
 	Location *string
 }
 
-type Item struct {
-	Name string
-}
-
 type Person struct {
 	PersonID   string `lyra:"ignore"`
 	FirstName  string

--- a/pkg/loader/fs.go
+++ b/pkg/loader/fs.go
@@ -1,80 +1,71 @@
 package loader
 
-import (
-	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
+// var (
+// 	// ToolDir is the home directory for the tool
+// 	ToolDir string
+// 	// DefaultPluginDir is where plugins are stored
+// 	DefaultPluginDir string
+// )
 
-	"github.com/lyraproj/lyra/pkg/logger"
-)
+// const (
+// 	// ToolDirEnvVar can be used to override the default user directory
+// 	ToolDirEnvVar = "LYRA_DIR"
+// 	// DefaultPluginDirEnvVar can be used to override the default plugin directory
+// 	DefaultPluginDirEnvVar = "LYRA_DEFAULT_PLUGINS_DIR"
+// )
 
-var (
-	// ToolDir is the home directory for the tool
-	ToolDir string
-	// DefaultPluginDir is where plugins are stored
-	DefaultPluginDir string
-)
+// // InitializeDirs ensures all directories have been created
+// func initializeDirs() error {
+// 	var err error
+// 	user, err := user.Current()
+// 	if err != nil {
+// 		return err
+// 	}
 
-const (
-	// ToolDirEnvVar can be used to override the default user directory
-	ToolDirEnvVar = "LYRA_DIR"
-	// DefaultPluginDirEnvVar can be used to override the default plugin directory
-	DefaultPluginDirEnvVar = "LYRA_DEFAULT_PLUGINS_DIR"
-)
+// 	if ToolDir, err = initialiseDir(ToolDirEnvVar, filepath.Join(user.HomeDir, ".lyra")); err != nil {
+// 		return err
+// 	}
+// 	if DefaultPluginDir, err = initialiseDir(DefaultPluginDirEnvVar, filepath.Join(ToolDir, "plugins")); err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
-// InitializeDirs ensures all directories have been created
-func initializeDirs() error {
-	var err error
-	user, err := user.Current()
-	if err != nil {
-		return err
-	}
+// func initialiseDir(envvar, defaultpath string) (string, error) {
+// 	path := defaultpath
+// 	if v, ok := os.LookupEnv(envvar); ok {
+// 		path = v
+// 	}
 
-	if ToolDir, err = initialiseDir(ToolDirEnvVar, filepath.Join(user.HomeDir, ".lyra")); err != nil {
-		return err
-	}
-	if DefaultPluginDir, err = initialiseDir(DefaultPluginDirEnvVar, filepath.Join(ToolDir, "plugins")); err != nil {
-		return err
-	}
-	return nil
-}
+// 	return path, ensureDir(path)
+// }
 
-func initialiseDir(envvar, defaultpath string) (string, error) {
-	path := defaultpath
-	if v, ok := os.LookupEnv(envvar); ok {
-		path = v
-	}
+// // Find returns paths to files matching the pattern relative to the
+// // supplied directory
+// func find(dir, pattern string) ([]string, error) {
+// 	stat, err := os.Stat(dir)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	if !stat.IsDir() {
+// 		return nil, fmt.Errorf("not a directory")
+// 	}
+// 	return filepath.Glob(filepath.Join(dir, pattern))
+// }
 
-	return path, ensureDir(path)
-}
+// func ensureDir(path string) error {
+// 	log := logger.Get()
+// 	log.Debug("ensure directory exists", "path", path)
+// 	info, err := os.Stat(path)
 
-// Find returns paths to files matching the pattern relative to the
-// supplied directory
-func find(dir, pattern string) ([]string, error) {
-	stat, err := os.Stat(dir)
-	if err != nil {
-		return nil, err
-	}
-	if !stat.IsDir() {
-		return nil, fmt.Errorf("not a directory")
-	}
-	return filepath.Glob(filepath.Join(dir, pattern))
-}
+// 	if os.IsNotExist(err) {
+// 		log.Debug("create directory", "path", path)
+// 		return os.MkdirAll(path, 0755)
+// 	}
 
-func ensureDir(path string) error {
-	log := logger.Get()
-	log.Debug("ensure directory exists", "path", path)
-	info, err := os.Stat(path)
+// 	if info.Mode().IsRegular() {
+// 		return fmt.Errorf("file exists at path")
+// 	}
 
-	if os.IsNotExist(err) {
-		log.Debug("create directory", "path", path)
-		return os.MkdirAll(path, 0755)
-	}
-
-	if info.Mode().IsRegular() {
-		return fmt.Errorf("file exists at path")
-	}
-
-	return nil
-}
+// 	return nil
+// }

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -77,7 +77,7 @@ func (l *Loader) LoadEntry(c eval.Context, name eval.TypedName) eval.LoaderEntry
 // LoadService will load the named service. The caller is responsible for unloading it.
 func (l *Loader) loadService(c eval.Context, serviceID eval.TypedName) serviceapi.Service {
 	cmd, foundCmd := l.serviceCmds[serviceID.MapKey()]
-	cmdArgs, _ := l.serviceCmdArgs[serviceID.MapKey()]
+	cmdArgs := l.serviceCmdArgs[serviceID.MapKey()]
 	if !foundCmd {
 		l.logger.Error("unknown service id", "serviceID", serviceID)
 		return nil


### PR DESCRIPTION
By default, we lint only pkg/... and cmd/lyra/... to keep memory consumption low enough to run on Travis.

Added a "make lint-all" target that runs on all packages.

The build breaks if lint is found and this commit also fixes the handful of lint errors found by default (but not those found by lint-all).
