### PR TITLE
Fast default "make" target but thorough Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: go
 go:
-- stable
+  - stable
 env:
-- GO111MODULE=on
+  - GO111MODULE=on
 jobs:
   include:
-  - stage: Test and build
-    script:
-    - rm go.sum # Workaround for https://github.com/kubernetes/kubernetes/issues/69040
-    - make
-    before_deploy:
-    - sudo apt-get install -y upx
-    - make dist-release
+    - stage: Test and build
+      script:
+        - rm go.sum # Workaround for https://github.com/kubernetes/kubernetes/issues/69040
+        - make all
+      before_deploy:
+        - sudo apt-get install -y upx
+        - make dist-release
 deploy:
   provider: releases
   api_key:
@@ -27,8 +27,8 @@ notifications:
     secure: t03TPD1KQogKliNQ9yB1HGLIUcIiLIjsY/PVCkILBMXCXNuO28Yd9S+T4KkvNHds+HvzLTMVqN03/vdqubhtJb4HLmv5Wib18lRao3MOkeZEVbs3qGoEjgpWELJHIrF22bBxPm4tvGM8NDGHV2bgZuGszu7peEGRaJ8IhhpHlA1T3jgmfKCaJxvvxYxn0tPOLVGBdisDZT9JsfXEdf8CeiiyipwWq07w0M48BbqbqPUhfPlL325+SmDgkM+NY+FhMagqcme+F0JaosvAqvotLO/PzhyguCrm5q6hC7gnkIeJaYrPJeWLrIPABhtc62WR7fBkmTrrqSwppKcHSiwuiDsXbEBemxN5BsDE1r6L3DJvyCuhdwBVMjmT2ZZx0ABnf3TBBVmYEhuk4yORU1SS81SSv+PvouOaiHylIWV4Dw0tx7gMakcnZkGmLVt3pKXWuwwPMJG1LKPq4aNR0YgZ2xeBeaKBbxPlAeB3Awp9vJlkAz8egXk98IN6vMZaO26nIwUcMD81tRZe9WWSUk5f5epHG0A4w5BE9Jg2xFuvghNo2CY65cg3V3AsNgkzdNS7THGlgKZWvK4pyIbSQF8HBf3c4VHF0xB7F9Bm/zPTbu2u2uetjOJWI+06HQ48e00hgbfNc1YTo3lsb3mx3RDawGgwkZCR3ovaDjJNTbI59Xc=
 branches:
   except:
-  - /(ux.+|ux)/
+    - /(ux.+|ux)/
 cache:
   directories:
-  - $GOPATH/pkg/mod/
-  - $HOME/.cache/go-build/
+    - $GOPATH/pkg/mod/
+    - $HOME/.cache/go-build/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,3 @@
-PROTOC := $(shell command -v protoc 2> /dev/null)
-PROTOC_VERSION=3.5.1
-ifdef PROTOC
-	PROTOCBIN := protoc
-else
-	PROTOCBIN := tmp/bin/protoc
-endif
-
 OS_TYPE=$(shell echo `uname`| tr '[A-Z]' '[a-z]')
 ifeq ($(OS_TYPE),darwin)
 	OS := osx
@@ -13,40 +5,24 @@ else
 	OS := linux
 endif
 
-PHONY=
-
 HAS_REQUIRED_GO := $(shell go version | grep -E 'go[2-9]|go1.1[2-9]|go1.11.[4-9]')
 
 PACKAGE_NAME = github.com/lyraproj/lyra
 LDFLAGS += -X "$(PACKAGE_NAME)/pkg/version.BuildTime=$(shell date -u '+%Y-%m-%d %I:%M:%S %Z')"
 LDFLAGS += -X "$(PACKAGE_NAME)/pkg/version.BuildTag=$(shell git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///')"
 LDFLAGS += -X "$(PACKAGE_NAME)/pkg/version.BuildSHA=$(shell git rev-parse --short HEAD)"
-LDFLAGS += -s -w # Strip debug information
 
-LICENSE_TMPFILE = LICENSE_TMPFILE.txt
+PHONY+= default
+default: LINTFLAGS = --fast
+default: everything
 
 PHONY+= all
-all: check-mods clean test lyra plugins smoke-test
+all: LDFLAGS += -s -w # Strip debug information
+all: TESTFLAGS = --race
+all: everything
 
-PHONY+= protobuf
-protobuf: tmp/bin/protoc $(GOPATH)/bin/protoc-gen-go
-	@echo "🔘 Compiling protobuf definitions ($(shell $(PROTOCBIN) --version))"
-	find . -name "*.proto" -not -path "./tmp/*" -not -path "./vendor/*" -exec $(PROTOCBIN) --go_out=plugins=grpc:. {} \;
-
-tmp/bin/protoc:
-ifndef PROTOC
-	@echo "🔘 Installing protoc v$(PROTOC_VERSION) to tmp/bin/"
-	mkdir -p tmp/bin
-	curl -L -o tmp/protoc.zip https://github.com/google/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(OS)-x86_64.zip
-	unzip -d tmp/ tmp/protoc.zip
-	rm tmp/protoc.zip
-else
-	@echo "🔘 Using existing protoc ($(shell $(PROTOCBIN) --version))"
-endif
-
-$(GOPATH)/bin/protoc-gen-go:
-	@echo "🔘 Installing protoc-gen-go"
-	GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go
+PHONY+= everything
+everything: check-mods clean lint test lyra plugins smoke-test
 
 PHONY+= shrink
 shrink:
@@ -70,38 +46,10 @@ PHONY+= lyra
 lyra: check-mods
 	$(call build,lyra,cmd/lyra/main.go)
 
-$(GOPATH)/bin/licenses:
-	@echo "🔘 Installing github.com/pmezard/licenses"
-	GO111MODULE=off go get -u github.com/pmezard/licenses
-
-PHONY+= updatelicences
-updatelicences: $(GOPATH)/bin/licenses
-	PWD=$(shell pwd)
-	@if [ "$(PWD)" != "$(GOPATH)/src/$(PACKAGE_NAME)" ]; then echo "Cannot update licenses except from gopath (i.e. $(GOPATH)/src/$(PACKAGE_NAME))"; exit 1; fi
-	$(call generate_3rdparty_licence_file,3RDPARTY_LICENSES.txt)
-
-PHONY+= checklicences
-checklicences: $(GOPATH)/bin/licenses
-	@echo "🔘 Checking for new/changed licences"
-	PWD=$(shell pwd)
-	@if [ "$(PWD)" != "$(GOPATH)/src/$(PACKAGE_NAME)" ]; then echo "Cannot check licenses except from gopath (i.e. $(GOPATH)/src/$(PACKAGE_NAME))"; exit 1; fi
-	$(call generate_3rdparty_licence_file,$(LICENSE_TMPFILE))
-	@echo "🔘  comparing current licences with committed version"
-	@if !(diff 3RDPARTY_LICENSES.txt $(LICENSE_TMPFILE)); then\
-		echo "";\
-		echo "🔴 Change in dependencies detected, please update vendor and regenerate the";\
-		echo "  licence file with \`make updatelicences\`, committing if changes are OK.";\
-		rm $(LICENSE_TMPFILE);\
-		exit 1;\
-	else \
-		echo "✅ No change in licence file detected";\
-		rm $(LICENSE_TMPFILE);\
-	fi
-
 PHONY+= test
-test: vet lint
+test:
 	@echo "🔘 Running unit tests... (`date '+%H:%M:%S'`)"
-	go test -race github.com/lyraproj/lyra/...
+	go test $(TESTFLAGS) github.com/lyraproj/lyra/...
 
 PHONY+= clean
 clean:
@@ -112,32 +60,17 @@ clean:
 	@echo "🔘 Cleaning vendor..."
 	@rm -rf vendor
 
-$(GOPATH)/bin/golangci-lint:
-	@echo "🔘 Installing golangci-lint... (`date '+%H:%M:%S'`)"
-	@GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
-
 PHONY+= lint
 lint: $(GOPATH)/bin/golangci-lint
-	@echo "🔘 Linting... (`date '+%H:%M:%S'`)"
-	@lint=`golangci-lint run cmd/lyra/... pkg/...`; \
-	if [ "$$lint" != "" ]; \
-	then echo "🔴 Lint found"; echo "$$lint"; exit 1; \
-	else echo "✅ Lint-free (`date '+%H:%M:%S'`)"; \
-	fi
-
-PHONY+= lint-all
-lint-all: $(GOPATH)/bin/golangci-lint
-	@echo "🔘 Linting... (`date '+%H:%M:%S'`)"
-	@lint=`golangci-lint run`; \
-	if [ "$$lint" != "" ]; \
-	then echo "🔴 Lint found"; echo "$$lint"; \
-	else echo "✅ Lint-free (`date '+%H:%M:%S'`)"; \
-	fi
-
-PHONY+= vet
-vet:
-	@echo "🔘 Running go vet... (`date '+%H:%M:%S'`)"
-	@go vet ./...
+	$(call checklint,pkg/...)
+	$(call checklint,cmd/lyra/...)
+	$(call checklint,cmd/goplugin-aws/...)
+	$(call checklint,cmd/goplugin-example/...)
+	$(call checklint,cmd/goplugin-tf-aws/...)
+	$(call checklint,cmd/goplugin-tf-azurerm/...)
+	$(call checklint,cmd/goplugin-tf-github/...)
+	$(call checklint,cmd/goplugin-tf-google/...)
+	$(call checklint,cmd/goplugin-tf-kubernetes/...)
 
 PHONY+= dist-release
 dist-release:
@@ -180,15 +113,17 @@ define build
 	@echo "✅ build complete - $(1) (`date '+%H:%M:%S'`)"
 endef
 
-define generate_3rdparty_licence_file
-	@echo "🔘  generating vendor dir"
-	@rm -rf vendor
-	@GO111MODULE=on go mod vendor
-	@echo "🔘  generating 3rd party licence file - $(1)"
-	@GO111MODULE=off $(GOPATH)/bin/licenses $(PACKAGE_NAME)/cmd/lyra \
-	| grep github.com/lyraproj/lyra/vendor | grep -v lyra/puppet-evaluator | grep -v lyra/puppet-parser | grep -v lyra/issue | grep -v lyra/semver | grep -v golang.org/x/sys/unix > $(1)
-	@echo "🔘  cleaning vendor dir"
-	@rm -rf vendor
+define checklint
+	@echo "🔘 Linting $(1) (`date '+%H:%M:%S'`)"
+	@lint=`golangci-lint run $(LINTFLAGS) $(1)`; \
+	if [ "$$lint" != "" ]; \
+	then echo "🔴 Lint found"; echo "$$lint"; exit 1;\
+	else echo "✅ Lint-free (`date '+%H:%M:%S'`)"; \
+	fi
 endef
+
+$(GOPATH)/bin/golangci-lint:
+	@echo "🔘 Installing golangci-lint... (`date '+%H:%M:%S'`)"
+	@GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: $(PHONY)

--- a/go.sum
+++ b/go.sum
@@ -120,9 +120,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCy
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-github v16.0.0+incompatible h1:omSHCJqM3CNG6RFFfGmIqGVbdQS2U3QVQSqACgwV1PY=
 github.com/google/go-github v16.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=


### PR DESCRIPTION
This commit mostly updates the Makefile to create one fast and one thorough version of our build.

The default "make" target is now a fast variant of our existing lint/test/build approach. It runs the fast version of the linter, runs tests without race checks and builds binaries without stripping or compressing them. This gives a quick default build but with decent test/lint coverage. This is the experience that a new user who runs a simple "make" will see.

The "all" make target performs the same lint/test/build steps but more thoroughly and hence quite a bit more slowly (approx 5 mins vs 1 min). The full set of lint checks are performed, the tests are run with race detection and the binaries are shrunk/compressed.

Travis will now perform a "make all" to ensure thorough checks on PRs.

The Makefile is also pruned to remove proto and licence-relate things we don't use any more.