### PR TITLE
Remove spurious registration of Aws.Vpc (and regenerate pp file) - is…

### DIFF
--- a/cmd/goplugin-aws/resource/register_types.go
+++ b/cmd/goplugin-aws/resource/register_types.go
@@ -104,11 +104,9 @@ func registerSDKTypes(sb *service.Builder) {
 
 func registerNonSDKTypes(sb *service.Builder) {
 	var evs []px.Type // nolint
-	evs = sb.RegisterTypes("Aws", Vpc{})
-	sb.RegisterTypes("Aws",
+	evs = sb.RegisterTypes("Aws",
 		sb.BuildResource(&Vpc{}, func(rtb service.ResourceTypeBuilder) {
-			rtb.ProvidedAttributes(`vpcId`, `dhcpOptionsId`)
-			rtb.ImmutableAttributes(`tags`)
+			rtb.ProvidedAttributes(`vpcId`, `dhcpOptionsId`, `instanceTenancy`)
 		}),
 	)
 	sb.RegisterHandler("Aws::VPCHandler", &VPCHandler{}, evs[0])

--- a/plugins/types/Aws.pp
+++ b/plugins/types/Aws.pp
@@ -2066,6 +2066,11 @@ type Aws = TypeSet[{
       }
     },
     Vpc => {
+      annotations => {
+        Lyra::Resource => {
+          'providedAttributes' => ['vpcId', 'dhcpOptionsId', 'instanceTenancy']
+        }
+      },
       attributes => {
         'amazonProvidedIpv6CidrBlock' => Boolean,
         'cidrBlock' => String,


### PR DESCRIPTION
…sue #171 

(second registration is a no-op and provided attributes are not added)