### PR TITLE
Enable stacktrace for issue.Reported when running with --debug

### DIFF
--- a/cmd/lyra/cmd/root.go
+++ b/cmd/lyra/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/lyraproj/issue/issue"
+
 	"github.com/leonelquinteros/gotext"
 	"github.com/lyraproj/lyra/cmd/lyra/ui"
 	"github.com/lyraproj/lyra/pkg/logger"
@@ -58,6 +60,7 @@ func runHelp(cmd *cobra.Command, args []string) {
 func initialiseTool(cmd *cobra.Command, args []string) {
 	if debug {
 		loglevel = "debug"
+		issue.IncludeStacktrace(true)
 	}
 	spec := logger.Spec{
 		Name:   "lyra",

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/leonelquinteros/gotext v1.4.0
 	github.com/lyraproj/hiera v0.0.0-20190313120414-23c940ce7383
 	github.com/lyraproj/identity v0.0.0-20190318120248-75df16c65ce7
-	github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560
+	github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0
 	github.com/lyraproj/lyra-operator v0.0.0-20190306102824-30ad4480dd58
-	github.com/lyraproj/pcore v0.0.0-20190317133239-e367a175e431
+	github.com/lyraproj/pcore v0.0.0-20190319132702-b24aeeee04ab
 	github.com/lyraproj/puppet-workflow v0.0.0-20190318122053-7c7712a6da54
 	github.com/lyraproj/servicesdk v0.0.0-20190317133540-499c41434691
 	github.com/lyraproj/wfe v0.0.0-20190317225657-57a806ded9d9

--- a/go.sum
+++ b/go.sum
@@ -232,11 +232,16 @@ github.com/lyraproj/identity v0.0.0-20190318120248-75df16c65ce7 h1:IQjaPFF4piDWF
 github.com/lyraproj/identity v0.0.0-20190318120248-75df16c65ce7/go.mod h1:XdV++v6+bWIITcy4pVV//UPFq9Xlh5a8MLd8M7c7HjU=
 github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560 h1:VVFwiMUrZe1a64kpEGzrPdeB6QzGEZTAVeo1OTOEWEk=
 github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
+github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0 h1:qjAIOHlkKCKyulOLovyl2ITvySGUYjJGg4oFTUAQslE=
+github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/lyra-operator v0.0.0-20190306102824-30ad4480dd58 h1:nq1tPUH3SxddUTr50P2v6u+6xVP54mUxqlthO/38w30=
 github.com/lyraproj/lyra-operator v0.0.0-20190306102824-30ad4480dd58/go.mod h1:Q2vRTVyCdN2dfhlJ0bfhFCaa/4hGDAGzDaEj0BlolW0=
 github.com/lyraproj/pcore v0.0.0-20190313112821-30e7bb7af627/go.mod h1:hKQkpsnpeamSKHIhhrKdhNAAViuZNfKYC3x0Drmra2w=
 github.com/lyraproj/pcore v0.0.0-20190317133239-e367a175e431 h1:y8tbegVN5uflsdpCqMfIRDGHLQWBy29VmKs4WGEG1mI=
 github.com/lyraproj/pcore v0.0.0-20190317133239-e367a175e431/go.mod h1:hKQkpsnpeamSKHIhhrKdhNAAViuZNfKYC3x0Drmra2w=
+github.com/lyraproj/pcore v0.0.0-20190319103451-ee0f09e38014 h1:EGU4xJ0O1RrG8gQsz2Yt/Y8usv3AIsm+aKXr2EOLBgQ=
+github.com/lyraproj/pcore v0.0.0-20190319132702-b24aeeee04ab h1:FDbBMcBOFsT52xRkLj+C6UAdDyPfB3084e7xd/TDag8=
+github.com/lyraproj/pcore v0.0.0-20190319132702-b24aeeee04ab/go.mod h1:4cACQR1J3k55a5wN5kZby31SVNT9k52tcJXlyQb+JuY=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190317134631-352f4890f050 h1:G05UPPTj7IiY3Gm7qj2JXO/jOpBo4gN8hltiBMVSoIM=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190317134631-352f4890f050/go.mod h1:wzDtO31x1Pdmma5inlrxXMw4usV6tDpYP7zcOUZ5RQg=
 github.com/lyraproj/puppet-parser v0.0.0-20190220160521-d5f541fd6c57 h1:z84TqgQCPiltNpKV5LEld5U0dQ//w/uk3+4HakwvNWM=


### PR DESCRIPTION
This commit leverages a new addition to the "issue" package. By
calling issue.IncludeStacktrace() with a "true" argument, all
issue.Reported errors will be created with a stacktrace from
the point they were created. As a result, almost all errors
generated by the framework will be displayed with a stacktrace.

Closes #184