### PR TITLE
Add typesript example, k8s ts, and smoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ jobs:
     - stage: Test and build
       script:
         - rm go.sum # Workaround for https://github.com/kubernetes/kubernetes/issues/69040
+        - node --version
+        - nvm install 11
+        - nvm use 11
+        - node --version
         - make all
       before_deploy:
         - sudo apt-get install -y upx

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: TESTFLAGS = --race
 all: everything
 
 PHONY+= everything
-everything: check-mods clean lint test lyra plugins smoke-test
+everything: check-mods clean lint test lyra plugins smoke-test smoke-test-ts
 
 PHONY+= shrink
 shrink:
@@ -125,7 +125,14 @@ check-mods:
 PHONY+= smoke-test
 smoke-test: lyra plugins
 	@echo "🔘 Running a smoke test with sample workflow"
-	@build/lyra apply sample || (echo "Failed $$?"; exit 1)
+	@build/lyra apply sample || (echo "Failed applying sample $$?"; exit 1)
+
+smoke-test-ts: lyra plugins generate-ts
+	@build/lyra apply sample_ts || (echo "Failed apply typescript sample $$?"; exit 1)
+
+generate-ts: lyra plugins
+	@build/lyra generate typescript --target-directory examples/ts-samples/src/types
+	cd examples/ts-samples && npm install
 
 define build
 	echo "🔘 Building - $(1) (`date '+%H:%M:%S'`)"

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ smoke-test: lyra plugins
 	@build/lyra apply sample || (echo "Failed applying sample $$?"; exit 1)
 
 smoke-test-ts: lyra plugins generate-ts
-	@build/lyra apply sample_ts || (echo "Failed apply typescript sample $$?"; exit 1)
+	build/lyra apply sample_ts || (echo "Failed apply typescript sample $$?"; exit 1)
 
 generate-ts: lyra plugins
 	@build/lyra generate typescript --target-directory examples/ts-samples/src/types

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a more detailed view of how we think about Lyra, check out our introductory 
 ## Getting Started
 
 ### Build
-The project requires [Go](https://golang.org/doc/install) 1.11 or higher, and [go modules](https://github.com/golang/go/wiki/Modules) to be on.
+The project requires [Go](https://golang.org/doc/install) 1.11.4 or higher, and [go modules](https://github.com/golang/go/wiki/Modules) to be on.
 
 1. Clone the git repo: `$ git clone https://github.com/lyraproj/lyra`
 2. Build the binary: `$ cd lyra; make`
@@ -37,6 +37,8 @@ The project requires [Go](https://golang.org/doc/install) 1.11 or higher, and [g
 This workflow is an AWS Workflow called `aws_vpc_yaml` in `plugins\aws_vpc_yaml.yaml`.  Tag data (loaded [here](plugins/aws_vpc_yaml.yaml#L6) by a new golang implementation of [hiera](https://github.com/lyraproj/hiera)) is specified in the [the data.yaml file](data.yaml) file.  This workflow will use the default AWS credentials configured in your `~/.aws/credentials`.
 
 For the examples using Terraform providers (e.g. `typespace=>'TerraformAws'`), region is currently hard-coded to `eu-west-1`. For non-Terraform providers (e.g. `typespace=>'aws'`), Lyra will use the default region supplied in your `~/.aws/config`. 
+
+There are also examples of [workflows specified in TypeScript for various cloud providers](examples/ts-samples/src/).  All TypeScript examples require NodeJs version 9 or greater (`node --version`) - see [https://nodejs.org/en/download/]().  To run [a basic sample](examples/ts-samples/src/sample_ts.ts), run `make smoke-test-ts`.  This will run an npm install (`(cd examples/ts-samples && npm install)`) and then `build/lyra apply sample_ts --debug`.    
 
 ### Deploying Workflows with Kubernetes
 

--- a/examples/ts-samples/package-lock.json
+++ b/examples/ts-samples/package-lock.json
@@ -69,9 +69,9 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "10.12.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.27.tgz",
-      "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg=="
+      "version": "10.14.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
     },
     "@types/sprintf-js": {
       "version": "1.1.2",
@@ -622,9 +622,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.7.0-rc.3",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.7.0-rc.3.tgz",
-      "integrity": "sha512-NxMBVtkD2n3Ug+T/Rq/HgRTQdunfqOFSsi6zsIGqniXvMaOqSYi0Vec4B3bkOv4Pj/d1bxKCFtEeL8uI2gV4tA=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.7.1.tgz",
+      "integrity": "sha512-6fvlUey6cNKtWSEn1bt4CT4wc2EID1fVluHS1dOnqIlxyIu3cBid2BvWE8Rwl6wN+hRTgiAKhfyydAGV/weZYQ=="
     },
     "got": {
       "version": "6.7.1",
@@ -652,9 +652,9 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.18.0.tgz",
-      "integrity": "sha512-M0K67Zhv2ZzCjrTbQvjWgYFPB929L+qAVnbNgXepbfO5kJxUYc30dP8m8vb+o8QdahLHAeYfIqRoIzZRcCB98Q==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.19.0.tgz",
+      "integrity": "sha512-xX+jZ1M3YXjngsRj/gTxB4EwM0WoWUr54DmyNq9xTeg1oSuVaTPD/PK9wnZKOJWTt1pkeFspXqwJPhddZNxHOA==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
@@ -1420,9 +1420,9 @@
       }
     },
     "lyra-workflow": {
-      "version": "0.1.2-beta.4",
-      "resolved": "https://registry.npmjs.org/lyra-workflow/-/lyra-workflow-0.1.2-beta.4.tgz",
-      "integrity": "sha512-QwrCm2XgAeeTBGa0ibdaFBAQtF866WB78Ye9Mog+/ES5Eafk1fmdX4B83GAxJ5FiBuDO50+KZW+9Vrh0CqlgSA==",
+      "version": "0.1.2-beta.5",
+      "resolved": "https://registry.npmjs.org/lyra-workflow/-/lyra-workflow-0.1.2-beta.5.tgz",
+      "integrity": "sha512-DnS1kgrGrsaMLwB025JNnNkTR7hoU8RtTwA9/TYK2UF7pXTk36BwpL2CJyx2SSXdyQl/b52FgwbBJLFu5LiqfA==",
       "requires": {
         "@types/google-protobuf": "^3.2.7",
         "@types/node": "^10.12.26",
@@ -1515,9 +1515,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "net": {
       "version": "1.0.2",

--- a/examples/ts-samples/package.json
+++ b/examples/ts-samples/package.json
@@ -21,6 +21,6 @@
     "typescript": "~3.1.0"
   },
   "dependencies": {
-    "lyra-workflow": "^0.1.2-beta.4"
+    "lyra-workflow": "^0.1.2-beta.5"
   }
 }

--- a/examples/ts-samples/src/azure_virtual_machine_ts.ts
+++ b/examples/ts-samples/src/azure_virtual_machine_ts.ts
@@ -1,0 +1,164 @@
+import { action, logger, PluginLogger, resource, ServiceBuilder } from 'lyra-workflow';
+import * as util from 'util';
+
+import * as TerraformAzureRM from './types/TerraformAzureRM';
+
+const wf = {
+  source: __filename,
+
+  activities: {
+    azure_virtual_machine: resource({
+      output: {
+        "resourceGroupName": { alias: "name" }
+      },
+      state: (): TerraformAzureRM.Azurerm_resource_group => {
+        return new TerraformAzureRM.Azurerm_resource_group({
+          name: "lyra-ts",
+          location: "ukwest"
+        })
+      }
+    }),
+
+    rgDone: action({
+      do: (resourceGroupName: string): {rgOk: boolean} => {
+        logger.info('rg done', 'resourceGroupName', resourceGroupName);
+        return {rgOk: true};
+      }
+    }),
+
+    azurerm_virtual_network: resource({
+      output: {
+        "virtualNetworkName": { alias: "name" }
+      },
+      state: (resourceGroupName: string): TerraformAzureRM.Azurerm_virtual_network => {
+        return new TerraformAzureRM.Azurerm_virtual_network({
+          name: "lyraVnetTs",
+          address_space: ["10.0.0.0/16"],
+          location: "ukwest",
+          resource_group_name: resourceGroupName
+        })
+      }
+    }),
+
+    azurerm_subnet: resource({
+      output: {
+        "subnetId": { alias: "azurerm_subnet_id" }
+      },
+      state: (resourceGroupName: string, virtualNetworkName: string): TerraformAzureRM.Azurerm_subnet => {
+        return new TerraformAzureRM.Azurerm_subnet({
+          name: "lyraSubnetTs",
+          resource_group_name: resourceGroupName,
+          virtual_network_name: virtualNetworkName,
+          address_prefix: "10.0.1.0/24"
+        })
+      }
+    }),
+
+    azurerm_public_ip: resource({
+      output: {
+        "publicIpId": { alias: "azurerm_public_ip_id" }
+      },
+      state: (resourceGroupName: string): TerraformAzureRM.Azurerm_public_ip => {
+        return new TerraformAzureRM.Azurerm_public_ip({
+          name: "lyraSubnetTs",
+          location: "ukwest",
+          resource_group_name: resourceGroupName,
+          public_ip_address_allocation: "dynamic"
+        })
+      }
+    }),
+
+    azurerm_network_security_group: resource({
+      output: {
+        "nsgId": { alias: "azurerm_network_security_group_id" }
+      },
+      state: (resourceGroupName: string): TerraformAzureRM.Azurerm_network_security_group => {
+        return new TerraformAzureRM.Azurerm_network_security_group({
+          name: "lyraNetworkSecurityGroupTs",
+          location: "ukwest",
+          resource_group_name: resourceGroupName,
+          security_rule: [new TerraformAzureRM.Azurerm_network_security_group_security_rule_164({
+            name: "SSH",
+            priority: 1001,
+            direction: "Inbound",
+            access: "Allow",
+            protocol: "Tcp",
+            source_port_range: "*",
+            destination_port_range: "22",
+            source_address_prefix: "*",
+            destination_address_prefix: "*"
+          })]
+        })
+      }
+    }),
+
+    azurerm_network_interface: resource({
+      output: {
+        "nicId": { alias: "azurerm_network_interface_id" }
+      },
+      state: (resourceGroupName: string, subnetId: string, nsgId: string, publicIpId: string): TerraformAzureRM.Azurerm_network_interface => {
+        return new TerraformAzureRM.Azurerm_network_interface({
+          name: "lyraTsNIC",
+          location: "ukwest",
+          resource_group_name: resourceGroupName,
+          network_security_group_id: nsgId,
+          ip_configuration: [new TerraformAzureRM.Azurerm_network_interface_ip_configuration_163(
+            {
+              name: "lyraNicConfigurationTs",
+              subnet_id: subnetId,
+              private_ip_address_allocation: "dynamic",
+              public_ip_address_id: publicIpId
+            }
+          )]
+        })
+      }
+    }),
+
+    azurerm_virtual_machine: resource({
+      state: (resourceGroupName: string, nicId: string): TerraformAzureRM.Azurerm_virtual_machine => {
+        return new TerraformAzureRM.Azurerm_virtual_machine({
+          name: "lyraVirtualMachineTs",
+          location: "ukwest",
+          resource_group_name: resourceGroupName,
+          network_interface_ids: [nicId],
+          vm_size: "Standard_B1s",
+          storage_image_reference: [new TerraformAzureRM.Azurerm_virtual_machine_storage_image_reference_234(
+            {
+              publisher: "Canonical",
+              offer: "UbuntuServer",
+              sku: "18.04-LTS",
+              version: "latest"
+            }
+          )],
+          storage_os_disk: [new TerraformAzureRM.Azurerm_virtual_machine_storage_os_disk_235({
+
+            name: "lyraostsdisk1",
+            caching: "ReadWrite",
+            create_option: "FromImage",
+            managed_disk_type: "Standard_LRS",
+          })],
+          os_profile: [new TerraformAzureRM.Azurerm_virtual_machine_os_profile_224({
+
+            computer_name: "hostnameTs",
+            admin_username: "testadmints",
+            admin_password: "Password1234!",
+          })],
+          os_profile_linux_config: [new TerraformAzureRM.Azurerm_virtual_machine_os_profile_linux_config_225({
+            disable_password_authentication: false
+          })],
+          tags: {
+            "environment": "lyra-test-ts"
+          },
+          delete_os_disk_on_termination: true,
+          delete_data_disks_on_termination: true
+        })
+      }
+    }),
+  }
+};
+
+const sb = new ServiceBuilder('My::Service');
+sb.workflow(wf);
+const server = sb.build(global);
+logger.info('Starting the server', 'serverId', server.serviceId.toString());
+server.start();

--- a/examples/ts-samples/src/github_repository_ts.ts
+++ b/examples/ts-samples/src/github_repository_ts.ts
@@ -1,0 +1,29 @@
+import {action, logger, PluginLogger, resource, ServiceBuilder} from 'lyra-workflow';
+import * as util from 'util';
+
+import * as TerraformGitHub from './types/TerraformGitHub';
+
+// # You will need to set the following environment variables to authenticate with GitHub
+// # export GITHUB_ORGANIZATION=lyraproj
+// # export GITHUB_TOKEN=<token>
+
+const wf = {
+  source: __filename,
+
+  activities: {
+    github_repository: resource({
+      state: (): TerraformGitHub.Github_repository => {
+        return new TerraformGitHub.Github_repository({
+            name: "lyra-provider-test-ts",
+            description: "Created using Lyra"
+        })
+      }
+    })
+  }
+};
+
+const sb = new ServiceBuilder('My::Service');
+sb.workflow(wf);
+const server = sb.build(global);
+logger.info('Starting the server', 'serverId', server.serviceId.toString());
+server.start();

--- a/examples/ts-samples/src/google_compute_instance_ts.ts
+++ b/examples/ts-samples/src/google_compute_instance_ts.ts
@@ -1,0 +1,39 @@
+import { action, logger, PluginLogger, resource, ServiceBuilder } from 'lyra-workflow';
+import * as util from 'util';
+
+import * as TerraformGoogle from './types/TerraformGoogle';
+// # You will need to set the following environment variables to authenticate with GCP
+// # export GOOGLE_PROJECT=<some-project>
+// # export GOOGLE_APPLICATION_CREDENTIALS=<credentials-file.json>
+
+const wf = {
+  source: __filename,
+
+  activities: {
+    google_compute_instance_ts: resource({
+      state: (): TerraformGoogle.Google_compute_instance => {
+        return new TerraformGoogle.Google_compute_instance({
+          name: "lyra-test-ts",
+          zone: "us-central1-a",
+          machine_type: "f1-micro",
+          boot_disk: [new TerraformGoogle.Google_compute_instance_boot_disk_41({
+            initialize_params: [new TerraformGoogle.Google_compute_instance_boot_disk_41_initialize_params_42({
+              image: "debian-cloud/debian-9"
+            })],
+          })],
+          network_interface: [new TerraformGoogle.Google_compute_instance_network_interface_46({
+            network: "default",
+            // access_config: [new TerraformGoogle.Google_compute_instance_network_interface_46_access_config_47({})]
+            access_config: []
+          })]
+        })
+      }
+    })
+  }
+};
+
+const sb = new ServiceBuilder('My::Service');
+sb.workflow(wf);
+const server = sb.build(global);
+logger.info('Starting the server', 'serverId', server.serviceId.toString());
+server.start();

--- a/examples/ts-samples/src/k8s_namespace_service_ts.ts
+++ b/examples/ts-samples/src/k8s_namespace_service_ts.ts
@@ -1,0 +1,42 @@
+import {action, logger, PluginLogger, resource, ServiceBuilder} from 'lyra-workflow';
+import * as util from 'util';
+
+import * as TerraformKubernetes from './types/TerraformKubernetes';
+
+const wf = {
+  source: __filename,
+
+  activities: {
+    Kubernetes_namespace: resource({
+      output: 'kubernetes_namespace_id',
+      state: (): TerraformKubernetes.Kubernetes_namespace =>{
+        var m = new TerraformKubernetes.Kubernetes_namespace_metadata_133({name:"lyra-ts"})
+        return new TerraformKubernetes.Kubernetes_namespace({metadata:[m]})
+      }
+    }),
+    Kubernetes_service: resource({
+      output: 'kubernetes_service_id',
+      state: (): TerraformKubernetes.Kubernetes_service =>{
+        var m = new TerraformKubernetes.Kubernetes_service_metadata_545({name:"lyra-service-ts"})
+
+        var p = new TerraformKubernetes.Kubernetes_service_spec_546_port_547({port: 80, target_port: "80"})
+        var s = new TerraformKubernetes.Kubernetes_service_spec_546({
+          session_affinity: "ClientIP",
+          port: [p],
+          type: "LoadBalancer",
+          selector: {
+            "app": "lyra-test"
+          }
+        })
+        return new TerraformKubernetes.Kubernetes_service({metadata:[m], spec:[s] })
+      }
+    })
+
+  }
+};
+
+const sb = new ServiceBuilder('My::Service');
+sb.workflow(wf);
+const server = sb.build(global);
+logger.info('Starting the server', 'serverId', server.serviceId.toString());
+server.start();

--- a/examples/ts-samples/src/sample_ts.ts
+++ b/examples/ts-samples/src/sample_ts.ts
@@ -1,0 +1,27 @@
+import {action, logger, PluginLogger, resource, ServiceBuilder} from 'lyra-workflow';
+import * as util from 'util';
+
+import * as Example from './types/Example';
+
+const hash: {[s: string]: string} = {};
+
+const wf = {
+  source: __filename,
+  activities: {
+    person: resource({
+      state: (): Example.Person => {
+        return new Example.Person({
+          age: 77,
+          name: 'Bert',
+          human: false,
+        });
+      }
+    }),
+  }
+}
+
+const sb = new ServiceBuilder('My::Service');
+sb.workflow(wf);
+const server = sb.build(global);
+logger.info('Starting the server', 'serverId', server.serviceId.toString());
+server.start();

--- a/examples/ts-samples/src/types/Identity.ts
+++ b/examples/ts-samples/src/types/Identity.ts
@@ -1,0 +1,12 @@
+// this file is generated
+import {PcoreValue, Value} from 'lyra-workflow';
+
+export class Service implements PcoreValue {
+  __pvalue(): {[s: string]: Value} {
+    return {};
+  }
+
+  __ptype(): string {
+    return 'Identity::Service';
+  }
+}

--- a/examples/ts-samples/src/types/TerraformAzureRM.ts
+++ b/examples/ts-samples/src/types/TerraformAzureRM.ts
@@ -7,20 +7,20 @@ export class Azurerm_api_management implements PcoreValue {
   readonly publisher_email: string;
   readonly publisher_name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_api_management_sku_598[];
+  readonly sku: Azurerm_api_management_sku_10[];
   readonly azurerm_api_management_id: string|null;
-  readonly additional_location: Azurerm_api_management_additional_location_589[]|null;
-  readonly certificate: Azurerm_api_management_certificate_590[]|null;
+  readonly additional_location: Azurerm_api_management_additional_location_1[]|null;
+  readonly certificate: Azurerm_api_management_certificate_2[]|null;
   readonly gateway_regional_url: string|null;
   readonly gateway_url: string|null;
-  readonly hostname_configuration: Azurerm_api_management_hostname_configuration_591[]|null;
-  readonly identity: Azurerm_api_management_identity_596[]|null;
+  readonly hostname_configuration: Azurerm_api_management_hostname_configuration_3[]|null;
+  readonly identity: Azurerm_api_management_identity_8[]|null;
   readonly management_api_url: string|null;
   readonly notification_sender_email: string|null;
   readonly portal_url: string|null;
   readonly public_ip_addresses: string[]|null;
   readonly scm_url: string|null;
-  readonly security: Azurerm_api_management_security_597[]|null;
+  readonly security: Azurerm_api_management_security_9[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -50,20 +50,20 @@ export class Azurerm_api_management implements PcoreValue {
     publisher_email: string,
     publisher_name: string,
     resource_group_name: string,
-    sku: Azurerm_api_management_sku_598[],
+    sku: Azurerm_api_management_sku_10[],
     azurerm_api_management_id?: string|null,
-    additional_location?: Azurerm_api_management_additional_location_589[]|null,
-    certificate?: Azurerm_api_management_certificate_590[]|null,
+    additional_location?: Azurerm_api_management_additional_location_1[]|null,
+    certificate?: Azurerm_api_management_certificate_2[]|null,
     gateway_regional_url?: string|null,
     gateway_url?: string|null,
-    hostname_configuration?: Azurerm_api_management_hostname_configuration_591[]|null,
-    identity?: Azurerm_api_management_identity_596[]|null,
+    hostname_configuration?: Azurerm_api_management_hostname_configuration_3[]|null,
+    identity?: Azurerm_api_management_identity_8[]|null,
     management_api_url?: string|null,
     notification_sender_email?: string|null,
     portal_url?: string|null,
     public_ip_addresses?: string[]|null,
     scm_url?: string|null,
-    security?: Azurerm_api_management_security_597[]|null,
+    security?: Azurerm_api_management_security_9[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.location = location;
@@ -156,7 +156,7 @@ export class Azurerm_api_managementHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_api_management_additional_location_589 implements PcoreValue {
+export class Azurerm_api_management_additional_location_1 implements PcoreValue {
   readonly location: string;
   readonly gateway_regional_url: string|null;
   readonly public_ip_addresses: string[]|null;
@@ -188,11 +188,11 @@ export class Azurerm_api_management_additional_location_589 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_additional_location_589';
+    return 'TerraformAzureRM::Azurerm_api_management_additional_location_1';
   }
 }
 
-export class Azurerm_api_management_certificate_590 implements PcoreValue {
+export class Azurerm_api_management_certificate_2 implements PcoreValue {
   readonly certificate_password: string;
   readonly encoded_certificate: string;
   readonly store_name: string;
@@ -220,15 +220,15 @@ export class Azurerm_api_management_certificate_590 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_certificate_590';
+    return 'TerraformAzureRM::Azurerm_api_management_certificate_2';
   }
 }
 
-export class Azurerm_api_management_hostname_configuration_591 implements PcoreValue {
-  readonly management: Azurerm_api_management_hostname_configuration_591_management_592[]|null;
-  readonly portal: Azurerm_api_management_hostname_configuration_591_portal_593[]|null;
-  readonly proxy: Azurerm_api_management_hostname_configuration_591_proxy_594[]|null;
-  readonly scm: Azurerm_api_management_hostname_configuration_591_scm_595[]|null;
+export class Azurerm_api_management_hostname_configuration_3 implements PcoreValue {
+  readonly management: Azurerm_api_management_hostname_configuration_3_management_4[]|null;
+  readonly portal: Azurerm_api_management_hostname_configuration_3_portal_5[]|null;
+  readonly proxy: Azurerm_api_management_hostname_configuration_3_proxy_6[]|null;
+  readonly scm: Azurerm_api_management_hostname_configuration_3_scm_7[]|null;
 
   constructor({
     management = null,
@@ -236,10 +236,10 @@ export class Azurerm_api_management_hostname_configuration_591 implements PcoreV
     proxy = null,
     scm = null
   }: {
-    management?: Azurerm_api_management_hostname_configuration_591_management_592[]|null,
-    portal?: Azurerm_api_management_hostname_configuration_591_portal_593[]|null,
-    proxy?: Azurerm_api_management_hostname_configuration_591_proxy_594[]|null,
-    scm?: Azurerm_api_management_hostname_configuration_591_scm_595[]|null
+    management?: Azurerm_api_management_hostname_configuration_3_management_4[]|null,
+    portal?: Azurerm_api_management_hostname_configuration_3_portal_5[]|null,
+    proxy?: Azurerm_api_management_hostname_configuration_3_proxy_6[]|null,
+    scm?: Azurerm_api_management_hostname_configuration_3_scm_7[]|null
   }) {
     this.management = management;
     this.portal = portal;
@@ -265,11 +265,11 @@ export class Azurerm_api_management_hostname_configuration_591 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_591';
+    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_3';
   }
 }
 
-export class Azurerm_api_management_hostname_configuration_591_management_592 implements PcoreValue {
+export class Azurerm_api_management_hostname_configuration_3_management_4 implements PcoreValue {
   readonly host_name: string;
   readonly certificate: string|null;
   readonly certificate_password: string|null;
@@ -315,11 +315,11 @@ export class Azurerm_api_management_hostname_configuration_591_management_592 im
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_591_management_592';
+    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_3_management_4';
   }
 }
 
-export class Azurerm_api_management_hostname_configuration_591_portal_593 implements PcoreValue {
+export class Azurerm_api_management_hostname_configuration_3_portal_5 implements PcoreValue {
   readonly host_name: string;
   readonly certificate: string|null;
   readonly certificate_password: string|null;
@@ -365,11 +365,11 @@ export class Azurerm_api_management_hostname_configuration_591_portal_593 implem
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_591_portal_593';
+    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_3_portal_5';
   }
 }
 
-export class Azurerm_api_management_hostname_configuration_591_proxy_594 implements PcoreValue {
+export class Azurerm_api_management_hostname_configuration_3_proxy_6 implements PcoreValue {
   readonly host_name: string;
   readonly certificate: string|null;
   readonly certificate_password: string|null;
@@ -422,11 +422,11 @@ export class Azurerm_api_management_hostname_configuration_591_proxy_594 impleme
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_591_proxy_594';
+    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_3_proxy_6';
   }
 }
 
-export class Azurerm_api_management_hostname_configuration_591_scm_595 implements PcoreValue {
+export class Azurerm_api_management_hostname_configuration_3_scm_7 implements PcoreValue {
   readonly host_name: string;
   readonly certificate: string|null;
   readonly certificate_password: string|null;
@@ -472,11 +472,11 @@ export class Azurerm_api_management_hostname_configuration_591_scm_595 implement
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_591_scm_595';
+    return 'TerraformAzureRM::Azurerm_api_management_hostname_configuration_3_scm_7';
   }
 }
 
-export class Azurerm_api_management_identity_596 implements PcoreValue {
+export class Azurerm_api_management_identity_8 implements PcoreValue {
   readonly type: string;
   readonly principal_id: string|null;
   readonly tenant_id: string|null;
@@ -508,11 +508,11 @@ export class Azurerm_api_management_identity_596 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_identity_596';
+    return 'TerraformAzureRM::Azurerm_api_management_identity_8';
   }
 }
 
-export class Azurerm_api_management_security_597 implements PcoreValue {
+export class Azurerm_api_management_security_9 implements PcoreValue {
   readonly disable_backend_ssl30: boolean|null;
   readonly disable_backend_tls10: boolean|null;
   readonly disable_backend_tls11: boolean|null;
@@ -574,11 +574,11 @@ export class Azurerm_api_management_security_597 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_security_597';
+    return 'TerraformAzureRM::Azurerm_api_management_security_9';
   }
 }
 
-export class Azurerm_api_management_sku_598 implements PcoreValue {
+export class Azurerm_api_management_sku_10 implements PcoreValue {
   readonly capacity: number;
   readonly name: string;
 
@@ -601,7 +601,7 @@ export class Azurerm_api_management_sku_598 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_api_management_sku_598';
+    return 'TerraformAzureRM::Azurerm_api_management_sku_10';
   }
 }
 
@@ -613,16 +613,16 @@ export class Azurerm_app_service implements PcoreValue {
   readonly azurerm_app_service_id: string|null;
   readonly app_settings: {[s: string]: string}|null;
   readonly client_affinity_enabled: boolean|null;
-  readonly connection_string: Azurerm_app_service_connection_string_599[]|null;
+  readonly connection_string: Azurerm_app_service_connection_string_11[]|null;
   readonly default_site_hostname: string|null;
   readonly enabled: boolean|null;
   readonly https_only: boolean|null;
-  readonly identity: Azurerm_app_service_identity_600[]|null;
+  readonly identity: Azurerm_app_service_identity_12[]|null;
   readonly outbound_ip_addresses: string|null;
   readonly possible_outbound_ip_addresses: string|null;
-  readonly site_config: Azurerm_app_service_site_config_601[]|null;
-  readonly site_credential: Azurerm_app_service_site_credential_603[]|null;
-  readonly source_control: Azurerm_app_service_source_control_604[]|null;
+  readonly site_config: Azurerm_app_service_site_config_13[]|null;
+  readonly site_credential: Azurerm_app_service_site_credential_15[]|null;
+  readonly source_control: Azurerm_app_service_source_control_16[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -652,16 +652,16 @@ export class Azurerm_app_service implements PcoreValue {
     azurerm_app_service_id?: string|null,
     app_settings?: {[s: string]: string}|null,
     client_affinity_enabled?: boolean|null,
-    connection_string?: Azurerm_app_service_connection_string_599[]|null,
+    connection_string?: Azurerm_app_service_connection_string_11[]|null,
     default_site_hostname?: string|null,
     enabled?: boolean|null,
     https_only?: boolean|null,
-    identity?: Azurerm_app_service_identity_600[]|null,
+    identity?: Azurerm_app_service_identity_12[]|null,
     outbound_ip_addresses?: string|null,
     possible_outbound_ip_addresses?: string|null,
-    site_config?: Azurerm_app_service_site_config_601[]|null,
-    site_credential?: Azurerm_app_service_site_credential_603[]|null,
-    source_control?: Azurerm_app_service_source_control_604[]|null,
+    site_config?: Azurerm_app_service_site_config_13[]|null,
+    site_credential?: Azurerm_app_service_site_credential_15[]|null,
+    source_control?: Azurerm_app_service_source_control_16[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.app_service_plan_id = app_service_plan_id;
@@ -799,7 +799,7 @@ export class Azurerm_app_service_active_slotHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_app_service_connection_string_599 implements PcoreValue {
+export class Azurerm_app_service_connection_string_11 implements PcoreValue {
   readonly name: string;
   readonly type: string;
   readonly value: string;
@@ -827,7 +827,7 @@ export class Azurerm_app_service_connection_string_599 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_connection_string_599';
+    return 'TerraformAzureRM::Azurerm_app_service_connection_string_11';
   }
 }
 
@@ -880,7 +880,7 @@ export class Azurerm_app_service_custom_hostname_bindingHandler implements Pcore
   }
 }
 
-export class Azurerm_app_service_identity_600 implements PcoreValue {
+export class Azurerm_app_service_identity_12 implements PcoreValue {
   readonly type: string;
   readonly principal_id: string|null;
   readonly tenant_id: string|null;
@@ -912,7 +912,7 @@ export class Azurerm_app_service_identity_600 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_identity_600';
+    return 'TerraformAzureRM::Azurerm_app_service_identity_12';
   }
 }
 
@@ -920,13 +920,13 @@ export class Azurerm_app_service_plan implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_app_service_plan_sku_606[];
+  readonly sku: Azurerm_app_service_plan_sku_18[];
   readonly azurerm_app_service_plan_id: string|null;
   readonly app_service_environment_id: string|null;
   readonly kind: string|null;
   readonly maximum_number_of_workers: number|null;
   readonly per_site_scaling: boolean|null;
-  readonly properties: Azurerm_app_service_plan_properties_605[]|null;
+  readonly properties: Azurerm_app_service_plan_properties_17[]|null;
   readonly reserved: boolean|null;
   readonly tags: {[s: string]: string}|null;
 
@@ -947,13 +947,13 @@ export class Azurerm_app_service_plan implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_app_service_plan_sku_606[],
+    sku: Azurerm_app_service_plan_sku_18[],
     azurerm_app_service_plan_id?: string|null,
     app_service_environment_id?: string|null,
     kind?: string|null,
     maximum_number_of_workers?: number|null,
     per_site_scaling?: boolean|null,
-    properties?: Azurerm_app_service_plan_properties_605[]|null,
+    properties?: Azurerm_app_service_plan_properties_17[]|null,
     reserved?: boolean|null,
     tags?: {[s: string]: string}|null
   }) {
@@ -1019,7 +1019,7 @@ export class Azurerm_app_service_planHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_app_service_plan_properties_605 implements PcoreValue {
+export class Azurerm_app_service_plan_properties_17 implements PcoreValue {
   readonly app_service_environment_id: string|null;
   readonly per_site_scaling: boolean|null;
   readonly reserved: boolean|null;
@@ -1053,11 +1053,11 @@ export class Azurerm_app_service_plan_properties_605 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_plan_properties_605';
+    return 'TerraformAzureRM::Azurerm_app_service_plan_properties_17';
   }
 }
 
-export class Azurerm_app_service_plan_sku_606 implements PcoreValue {
+export class Azurerm_app_service_plan_sku_18 implements PcoreValue {
   readonly size: string;
   readonly tier: string;
   readonly capacity: number|null;
@@ -1087,18 +1087,18 @@ export class Azurerm_app_service_plan_sku_606 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_plan_sku_606';
+    return 'TerraformAzureRM::Azurerm_app_service_plan_sku_18';
   }
 }
 
-export class Azurerm_app_service_site_config_601 implements PcoreValue {
+export class Azurerm_app_service_site_config_13 implements PcoreValue {
   readonly always_on: boolean|null;
   readonly app_command_line: string|null;
   readonly default_documents: string[]|null;
   readonly dotnet_framework_version: string|null;
   readonly ftps_state: string|null;
   readonly http2_enabled: boolean|null;
-  readonly ip_restriction: Azurerm_app_service_site_config_601_ip_restriction_602[]|null;
+  readonly ip_restriction: Azurerm_app_service_site_config_13_ip_restriction_14[]|null;
   readonly java_container: string|null;
   readonly java_container_version: string|null;
   readonly java_version: string|null;
@@ -1145,7 +1145,7 @@ export class Azurerm_app_service_site_config_601 implements PcoreValue {
     dotnet_framework_version?: string|null,
     ftps_state?: string|null,
     http2_enabled?: boolean|null,
-    ip_restriction?: Azurerm_app_service_site_config_601_ip_restriction_602[]|null,
+    ip_restriction?: Azurerm_app_service_site_config_13_ip_restriction_14[]|null,
     java_container?: string|null,
     java_container_version?: string|null,
     java_version?: string|null,
@@ -1258,11 +1258,11 @@ export class Azurerm_app_service_site_config_601 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_site_config_601';
+    return 'TerraformAzureRM::Azurerm_app_service_site_config_13';
   }
 }
 
-export class Azurerm_app_service_site_config_601_ip_restriction_602 implements PcoreValue {
+export class Azurerm_app_service_site_config_13_ip_restriction_14 implements PcoreValue {
   readonly ip_address: string;
   readonly subnet_mask: string|null;
 
@@ -1287,11 +1287,11 @@ export class Azurerm_app_service_site_config_601_ip_restriction_602 implements P
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_site_config_601_ip_restriction_602';
+    return 'TerraformAzureRM::Azurerm_app_service_site_config_13_ip_restriction_14';
   }
 }
 
-export class Azurerm_app_service_site_credential_603 implements PcoreValue {
+export class Azurerm_app_service_site_credential_15 implements PcoreValue {
   readonly password: string|null;
   readonly username: string|null;
 
@@ -1318,7 +1318,7 @@ export class Azurerm_app_service_site_credential_603 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_site_credential_603';
+    return 'TerraformAzureRM::Azurerm_app_service_site_credential_15';
   }
 }
 
@@ -1331,12 +1331,12 @@ export class Azurerm_app_service_slot implements PcoreValue {
   readonly azurerm_app_service_slot_id: string|null;
   readonly app_settings: {[s: string]: string}|null;
   readonly client_affinity_enabled: boolean|null;
-  readonly connection_string: Azurerm_app_service_slot_connection_string_607[]|null;
+  readonly connection_string: Azurerm_app_service_slot_connection_string_19[]|null;
   readonly default_site_hostname: string|null;
   readonly enabled: boolean|null;
   readonly https_only: boolean|null;
-  readonly identity: Azurerm_app_service_slot_identity_608[]|null;
-  readonly site_config: Azurerm_app_service_slot_site_config_609[]|null;
+  readonly identity: Azurerm_app_service_slot_identity_20[]|null;
+  readonly site_config: Azurerm_app_service_slot_site_config_21[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -1364,12 +1364,12 @@ export class Azurerm_app_service_slot implements PcoreValue {
     azurerm_app_service_slot_id?: string|null,
     app_settings?: {[s: string]: string}|null,
     client_affinity_enabled?: boolean|null,
-    connection_string?: Azurerm_app_service_slot_connection_string_607[]|null,
+    connection_string?: Azurerm_app_service_slot_connection_string_19[]|null,
     default_site_hostname?: string|null,
     enabled?: boolean|null,
     https_only?: boolean|null,
-    identity?: Azurerm_app_service_slot_identity_608[]|null,
-    site_config?: Azurerm_app_service_slot_site_config_609[]|null,
+    identity?: Azurerm_app_service_slot_identity_20[]|null,
+    site_config?: Azurerm_app_service_slot_site_config_21[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.app_service_name = app_service_name;
@@ -1444,7 +1444,7 @@ export class Azurerm_app_service_slotHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_app_service_slot_connection_string_607 implements PcoreValue {
+export class Azurerm_app_service_slot_connection_string_19 implements PcoreValue {
   readonly name: string;
   readonly type: string;
   readonly value: string;
@@ -1472,11 +1472,11 @@ export class Azurerm_app_service_slot_connection_string_607 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_slot_connection_string_607';
+    return 'TerraformAzureRM::Azurerm_app_service_slot_connection_string_19';
   }
 }
 
-export class Azurerm_app_service_slot_identity_608 implements PcoreValue {
+export class Azurerm_app_service_slot_identity_20 implements PcoreValue {
   readonly type: string;
   readonly principal_id: string|null;
   readonly tenant_id: string|null;
@@ -1508,18 +1508,18 @@ export class Azurerm_app_service_slot_identity_608 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_slot_identity_608';
+    return 'TerraformAzureRM::Azurerm_app_service_slot_identity_20';
   }
 }
 
-export class Azurerm_app_service_slot_site_config_609 implements PcoreValue {
+export class Azurerm_app_service_slot_site_config_21 implements PcoreValue {
   readonly always_on: boolean|null;
   readonly app_command_line: string|null;
   readonly default_documents: string[]|null;
   readonly dotnet_framework_version: string|null;
   readonly ftps_state: string|null;
   readonly http2_enabled: boolean|null;
-  readonly ip_restriction: Azurerm_app_service_slot_site_config_609_ip_restriction_610[]|null;
+  readonly ip_restriction: Azurerm_app_service_slot_site_config_21_ip_restriction_22[]|null;
   readonly java_container: string|null;
   readonly java_container_version: string|null;
   readonly java_version: string|null;
@@ -1566,7 +1566,7 @@ export class Azurerm_app_service_slot_site_config_609 implements PcoreValue {
     dotnet_framework_version?: string|null,
     ftps_state?: string|null,
     http2_enabled?: boolean|null,
-    ip_restriction?: Azurerm_app_service_slot_site_config_609_ip_restriction_610[]|null,
+    ip_restriction?: Azurerm_app_service_slot_site_config_21_ip_restriction_22[]|null,
     java_container?: string|null,
     java_container_version?: string|null,
     java_version?: string|null,
@@ -1679,11 +1679,11 @@ export class Azurerm_app_service_slot_site_config_609 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_slot_site_config_609';
+    return 'TerraformAzureRM::Azurerm_app_service_slot_site_config_21';
   }
 }
 
-export class Azurerm_app_service_slot_site_config_609_ip_restriction_610 implements PcoreValue {
+export class Azurerm_app_service_slot_site_config_21_ip_restriction_22 implements PcoreValue {
   readonly ip_address: string;
   readonly subnet_mask: string|null;
 
@@ -1708,11 +1708,11 @@ export class Azurerm_app_service_slot_site_config_609_ip_restriction_610 impleme
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_slot_site_config_609_ip_restriction_610';
+    return 'TerraformAzureRM::Azurerm_app_service_slot_site_config_21_ip_restriction_22';
   }
 }
 
-export class Azurerm_app_service_source_control_604 implements PcoreValue {
+export class Azurerm_app_service_source_control_16 implements PcoreValue {
   readonly branch: string|null;
   readonly repo_url: string|null;
 
@@ -1739,30 +1739,30 @@ export class Azurerm_app_service_source_control_604 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_app_service_source_control_604';
+    return 'TerraformAzureRM::Azurerm_app_service_source_control_16';
   }
 }
 
 export class Azurerm_application_gateway implements PcoreValue {
-  readonly backend_address_pool: Azurerm_application_gateway_backend_address_pool_612[];
-  readonly backend_http_settings: Azurerm_application_gateway_backend_http_settings_613[];
-  readonly frontend_ip_configuration: Azurerm_application_gateway_frontend_ip_configuration_615[];
-  readonly frontend_port: Azurerm_application_gateway_frontend_port_616[];
-  readonly gateway_ip_configuration: Azurerm_application_gateway_gateway_ip_configuration_617[];
-  readonly http_listener: Azurerm_application_gateway_http_listener_618[];
+  readonly backend_address_pool: Azurerm_application_gateway_backend_address_pool_24[];
+  readonly backend_http_settings: Azurerm_application_gateway_backend_http_settings_25[];
+  readonly frontend_ip_configuration: Azurerm_application_gateway_frontend_ip_configuration_27[];
+  readonly frontend_port: Azurerm_application_gateway_frontend_port_28[];
+  readonly gateway_ip_configuration: Azurerm_application_gateway_gateway_ip_configuration_29[];
+  readonly http_listener: Azurerm_application_gateway_http_listener_30[];
   readonly location: string;
   readonly name: string;
-  readonly request_routing_rule: Azurerm_application_gateway_request_routing_rule_621[];
+  readonly request_routing_rule: Azurerm_application_gateway_request_routing_rule_33[];
   readonly resource_group_name: string;
-  readonly sku: Azurerm_application_gateway_sku_622[];
+  readonly sku: Azurerm_application_gateway_sku_34[];
   readonly azurerm_application_gateway_id: string|null;
-  readonly authentication_certificate: Azurerm_application_gateway_authentication_certificate_611[]|null;
+  readonly authentication_certificate: Azurerm_application_gateway_authentication_certificate_23[]|null;
   readonly disabled_ssl_protocols: string[]|null;
-  readonly probe: Azurerm_application_gateway_probe_619[]|null;
-  readonly ssl_certificate: Azurerm_application_gateway_ssl_certificate_623[]|null;
+  readonly probe: Azurerm_application_gateway_probe_31[]|null;
+  readonly ssl_certificate: Azurerm_application_gateway_ssl_certificate_35[]|null;
   readonly tags: {[s: string]: string}|null;
-  readonly url_path_map: Azurerm_application_gateway_url_path_map_624[]|null;
-  readonly waf_configuration: Azurerm_application_gateway_waf_configuration_626[]|null;
+  readonly url_path_map: Azurerm_application_gateway_url_path_map_36[]|null;
+  readonly waf_configuration: Azurerm_application_gateway_waf_configuration_38[]|null;
 
   constructor({
     backend_address_pool,
@@ -1785,25 +1785,25 @@ export class Azurerm_application_gateway implements PcoreValue {
     url_path_map = null,
     waf_configuration = null
   }: {
-    backend_address_pool: Azurerm_application_gateway_backend_address_pool_612[],
-    backend_http_settings: Azurerm_application_gateway_backend_http_settings_613[],
-    frontend_ip_configuration: Azurerm_application_gateway_frontend_ip_configuration_615[],
-    frontend_port: Azurerm_application_gateway_frontend_port_616[],
-    gateway_ip_configuration: Azurerm_application_gateway_gateway_ip_configuration_617[],
-    http_listener: Azurerm_application_gateway_http_listener_618[],
+    backend_address_pool: Azurerm_application_gateway_backend_address_pool_24[],
+    backend_http_settings: Azurerm_application_gateway_backend_http_settings_25[],
+    frontend_ip_configuration: Azurerm_application_gateway_frontend_ip_configuration_27[],
+    frontend_port: Azurerm_application_gateway_frontend_port_28[],
+    gateway_ip_configuration: Azurerm_application_gateway_gateway_ip_configuration_29[],
+    http_listener: Azurerm_application_gateway_http_listener_30[],
     location: string,
     name: string,
-    request_routing_rule: Azurerm_application_gateway_request_routing_rule_621[],
+    request_routing_rule: Azurerm_application_gateway_request_routing_rule_33[],
     resource_group_name: string,
-    sku: Azurerm_application_gateway_sku_622[],
+    sku: Azurerm_application_gateway_sku_34[],
     azurerm_application_gateway_id?: string|null,
-    authentication_certificate?: Azurerm_application_gateway_authentication_certificate_611[]|null,
+    authentication_certificate?: Azurerm_application_gateway_authentication_certificate_23[]|null,
     disabled_ssl_protocols?: string[]|null,
-    probe?: Azurerm_application_gateway_probe_619[]|null,
-    ssl_certificate?: Azurerm_application_gateway_ssl_certificate_623[]|null,
+    probe?: Azurerm_application_gateway_probe_31[]|null,
+    ssl_certificate?: Azurerm_application_gateway_ssl_certificate_35[]|null,
     tags?: {[s: string]: string}|null,
-    url_path_map?: Azurerm_application_gateway_url_path_map_624[]|null,
-    waf_configuration?: Azurerm_application_gateway_waf_configuration_626[]|null
+    url_path_map?: Azurerm_application_gateway_url_path_map_36[]|null,
+    waf_configuration?: Azurerm_application_gateway_waf_configuration_38[]|null
   }) {
     this.backend_address_pool = backend_address_pool;
     this.backend_http_settings = backend_http_settings;
@@ -1881,7 +1881,7 @@ export class Azurerm_application_gatewayHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_application_gateway_authentication_certificate_611 implements PcoreValue {
+export class Azurerm_application_gateway_authentication_certificate_23 implements PcoreValue {
   readonly data: string;
   readonly name: string;
   readonly id: string|null;
@@ -1911,11 +1911,11 @@ export class Azurerm_application_gateway_authentication_certificate_611 implemen
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_authentication_certificate_611';
+    return 'TerraformAzureRM::Azurerm_application_gateway_authentication_certificate_23';
   }
 }
 
-export class Azurerm_application_gateway_backend_address_pool_612 implements PcoreValue {
+export class Azurerm_application_gateway_backend_address_pool_24 implements PcoreValue {
   readonly name: string;
   readonly fqdn_list: string[]|null;
   readonly id: string|null;
@@ -1954,16 +1954,16 @@ export class Azurerm_application_gateway_backend_address_pool_612 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_backend_address_pool_612';
+    return 'TerraformAzureRM::Azurerm_application_gateway_backend_address_pool_24';
   }
 }
 
-export class Azurerm_application_gateway_backend_http_settings_613 implements PcoreValue {
+export class Azurerm_application_gateway_backend_http_settings_25 implements PcoreValue {
   readonly cookie_based_affinity: string;
   readonly name: string;
   readonly port: number;
   readonly protocol: string;
-  readonly authentication_certificate: Azurerm_application_gateway_backend_http_settings_613_authentication_certificate_614[]|null;
+  readonly authentication_certificate: Azurerm_application_gateway_backend_http_settings_25_authentication_certificate_26[]|null;
   readonly id: string|null;
   readonly probe_id: string|null;
   readonly probe_name: string|null;
@@ -1984,7 +1984,7 @@ export class Azurerm_application_gateway_backend_http_settings_613 implements Pc
     name: string,
     port: number,
     protocol: string,
-    authentication_certificate?: Azurerm_application_gateway_backend_http_settings_613_authentication_certificate_614[]|null,
+    authentication_certificate?: Azurerm_application_gateway_backend_http_settings_25_authentication_certificate_26[]|null,
     id?: string|null,
     probe_id?: string|null,
     probe_name?: string|null,
@@ -2026,11 +2026,11 @@ export class Azurerm_application_gateway_backend_http_settings_613 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_backend_http_settings_613';
+    return 'TerraformAzureRM::Azurerm_application_gateway_backend_http_settings_25';
   }
 }
 
-export class Azurerm_application_gateway_backend_http_settings_613_authentication_certificate_614 implements PcoreValue {
+export class Azurerm_application_gateway_backend_http_settings_25_authentication_certificate_26 implements PcoreValue {
   readonly name: string;
   readonly id: string|null;
 
@@ -2055,11 +2055,11 @@ export class Azurerm_application_gateway_backend_http_settings_613_authenticatio
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_backend_http_settings_613_authentication_certificate_614';
+    return 'TerraformAzureRM::Azurerm_application_gateway_backend_http_settings_25_authentication_certificate_26';
   }
 }
 
-export class Azurerm_application_gateway_frontend_ip_configuration_615 implements PcoreValue {
+export class Azurerm_application_gateway_frontend_ip_configuration_27 implements PcoreValue {
   readonly name: string;
   readonly id: string|null;
   readonly private_ip_address: string|null;
@@ -2112,11 +2112,11 @@ export class Azurerm_application_gateway_frontend_ip_configuration_615 implement
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_frontend_ip_configuration_615';
+    return 'TerraformAzureRM::Azurerm_application_gateway_frontend_ip_configuration_27';
   }
 }
 
-export class Azurerm_application_gateway_frontend_port_616 implements PcoreValue {
+export class Azurerm_application_gateway_frontend_port_28 implements PcoreValue {
   readonly name: string;
   readonly port: number;
   readonly id: string|null;
@@ -2146,11 +2146,11 @@ export class Azurerm_application_gateway_frontend_port_616 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_frontend_port_616';
+    return 'TerraformAzureRM::Azurerm_application_gateway_frontend_port_28';
   }
 }
 
-export class Azurerm_application_gateway_gateway_ip_configuration_617 implements PcoreValue {
+export class Azurerm_application_gateway_gateway_ip_configuration_29 implements PcoreValue {
   readonly name: string;
   readonly subnet_id: string;
   readonly id: string|null;
@@ -2180,11 +2180,11 @@ export class Azurerm_application_gateway_gateway_ip_configuration_617 implements
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_gateway_ip_configuration_617';
+    return 'TerraformAzureRM::Azurerm_application_gateway_gateway_ip_configuration_29';
   }
 }
 
-export class Azurerm_application_gateway_http_listener_618 implements PcoreValue {
+export class Azurerm_application_gateway_http_listener_30 implements PcoreValue {
   readonly frontend_ip_configuration_name: string;
   readonly frontend_port_name: string;
   readonly name: string;
@@ -2266,11 +2266,11 @@ export class Azurerm_application_gateway_http_listener_618 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_http_listener_618';
+    return 'TerraformAzureRM::Azurerm_application_gateway_http_listener_30';
   }
 }
 
-export class Azurerm_application_gateway_probe_619 implements PcoreValue {
+export class Azurerm_application_gateway_probe_31 implements PcoreValue {
   readonly host: string;
   readonly interval: number;
   readonly name: string;
@@ -2279,7 +2279,7 @@ export class Azurerm_application_gateway_probe_619 implements PcoreValue {
   readonly timeout: number;
   readonly unhealthy_threshold: number;
   readonly id: string|null;
-  readonly match: Azurerm_application_gateway_probe_619_match_620[]|null;
+  readonly match: Azurerm_application_gateway_probe_31_match_32[]|null;
   readonly minimum_servers: number|null;
 
   constructor({
@@ -2302,7 +2302,7 @@ export class Azurerm_application_gateway_probe_619 implements PcoreValue {
     timeout: number,
     unhealthy_threshold: number,
     id?: string|null,
-    match?: Azurerm_application_gateway_probe_619_match_620[]|null,
+    match?: Azurerm_application_gateway_probe_31_match_32[]|null,
     minimum_servers?: number|null
   }) {
     this.host = host;
@@ -2339,11 +2339,11 @@ export class Azurerm_application_gateway_probe_619 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_probe_619';
+    return 'TerraformAzureRM::Azurerm_application_gateway_probe_31';
   }
 }
 
-export class Azurerm_application_gateway_probe_619_match_620 implements PcoreValue {
+export class Azurerm_application_gateway_probe_31_match_32 implements PcoreValue {
   readonly body: string|null;
   readonly status_code: string[]|null;
 
@@ -2370,11 +2370,11 @@ export class Azurerm_application_gateway_probe_619_match_620 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_probe_619_match_620';
+    return 'TerraformAzureRM::Azurerm_application_gateway_probe_31_match_32';
   }
 }
 
-export class Azurerm_application_gateway_request_routing_rule_621 implements PcoreValue {
+export class Azurerm_application_gateway_request_routing_rule_33 implements PcoreValue {
   readonly http_listener_name: string;
   readonly name: string;
   readonly rule_type: string;
@@ -2458,11 +2458,11 @@ export class Azurerm_application_gateway_request_routing_rule_621 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_request_routing_rule_621';
+    return 'TerraformAzureRM::Azurerm_application_gateway_request_routing_rule_33';
   }
 }
 
-export class Azurerm_application_gateway_sku_622 implements PcoreValue {
+export class Azurerm_application_gateway_sku_34 implements PcoreValue {
   readonly capacity: number;
   readonly name: string;
   readonly tier: string;
@@ -2490,11 +2490,11 @@ export class Azurerm_application_gateway_sku_622 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_sku_622';
+    return 'TerraformAzureRM::Azurerm_application_gateway_sku_34';
   }
 }
 
-export class Azurerm_application_gateway_ssl_certificate_623 implements PcoreValue {
+export class Azurerm_application_gateway_ssl_certificate_35 implements PcoreValue {
   readonly data: string;
   readonly name: string;
   readonly password: string;
@@ -2536,15 +2536,15 @@ export class Azurerm_application_gateway_ssl_certificate_623 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_ssl_certificate_623';
+    return 'TerraformAzureRM::Azurerm_application_gateway_ssl_certificate_35';
   }
 }
 
-export class Azurerm_application_gateway_url_path_map_624 implements PcoreValue {
+export class Azurerm_application_gateway_url_path_map_36 implements PcoreValue {
   readonly default_backend_address_pool_name: string;
   readonly default_backend_http_settings_name: string;
   readonly name: string;
-  readonly path_rule: Azurerm_application_gateway_url_path_map_624_path_rule_625[];
+  readonly path_rule: Azurerm_application_gateway_url_path_map_36_path_rule_37[];
   readonly default_backend_address_pool_id: string|null;
   readonly default_backend_http_settings_id: string|null;
   readonly id: string|null;
@@ -2561,7 +2561,7 @@ export class Azurerm_application_gateway_url_path_map_624 implements PcoreValue 
     default_backend_address_pool_name: string,
     default_backend_http_settings_name: string,
     name: string,
-    path_rule: Azurerm_application_gateway_url_path_map_624_path_rule_625[],
+    path_rule: Azurerm_application_gateway_url_path_map_36_path_rule_37[],
     default_backend_address_pool_id?: string|null,
     default_backend_http_settings_id?: string|null,
     id?: string|null
@@ -2594,11 +2594,11 @@ export class Azurerm_application_gateway_url_path_map_624 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_url_path_map_624';
+    return 'TerraformAzureRM::Azurerm_application_gateway_url_path_map_36';
   }
 }
 
-export class Azurerm_application_gateway_url_path_map_624_path_rule_625 implements PcoreValue {
+export class Azurerm_application_gateway_url_path_map_36_path_rule_37 implements PcoreValue {
   readonly backend_address_pool_name: string;
   readonly backend_http_settings_name: string;
   readonly name: string;
@@ -2652,11 +2652,11 @@ export class Azurerm_application_gateway_url_path_map_624_path_rule_625 implemen
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_url_path_map_624_path_rule_625';
+    return 'TerraformAzureRM::Azurerm_application_gateway_url_path_map_36_path_rule_37';
   }
 }
 
-export class Azurerm_application_gateway_waf_configuration_626 implements PcoreValue {
+export class Azurerm_application_gateway_waf_configuration_38 implements PcoreValue {
   readonly enabled: boolean;
   readonly firewall_mode: string;
   readonly rule_set_version: string;
@@ -2691,7 +2691,7 @@ export class Azurerm_application_gateway_waf_configuration_626 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_application_gateway_waf_configuration_626';
+    return 'TerraformAzureRM::Azurerm_application_gateway_waf_configuration_38';
   }
 }
 
@@ -2895,7 +2895,7 @@ export class Azurerm_automation_account implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_automation_account_sku_627[];
+  readonly sku: Azurerm_automation_account_sku_39[];
   readonly azurerm_automation_account_id: string|null;
   readonly dsc_primary_access_key: string|null;
   readonly dsc_secondary_access_key: string|null;
@@ -2916,7 +2916,7 @@ export class Azurerm_automation_account implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_automation_account_sku_627[],
+    sku: Azurerm_automation_account_sku_39[],
     azurerm_automation_account_id?: string|null,
     dsc_primary_access_key?: string|null,
     dsc_secondary_access_key?: string|null,
@@ -2973,7 +2973,7 @@ export class Azurerm_automation_accountHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_automation_account_sku_627 implements PcoreValue {
+export class Azurerm_automation_account_sku_39 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -2993,7 +2993,7 @@ export class Azurerm_automation_account_sku_627 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_automation_account_sku_627';
+    return 'TerraformAzureRM::Azurerm_automation_account_sku_39';
   }
 }
 
@@ -3206,7 +3206,7 @@ export class Azurerm_automation_dsc_nodeconfigurationHandler implements PcoreVal
 
 export class Azurerm_automation_module implements PcoreValue {
   readonly automation_account_name: string;
-  readonly module_link: Azurerm_automation_module_module_link_628[];
+  readonly module_link: Azurerm_automation_module_module_link_40[];
   readonly name: string;
   readonly resource_group_name: string;
   readonly azurerm_automation_module_id: string|null;
@@ -3219,7 +3219,7 @@ export class Azurerm_automation_module implements PcoreValue {
     azurerm_automation_module_id = null
   }: {
     automation_account_name: string,
-    module_link: Azurerm_automation_module_module_link_628[],
+    module_link: Azurerm_automation_module_module_link_40[],
     name: string,
     resource_group_name: string,
     azurerm_automation_module_id?: string|null
@@ -3258,16 +3258,16 @@ export class Azurerm_automation_moduleHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_automation_module_module_link_628 implements PcoreValue {
+export class Azurerm_automation_module_module_link_40 implements PcoreValue {
   readonly uri: string;
-  readonly hash: Azurerm_automation_module_module_link_628_hash_629[]|null;
+  readonly hash: Azurerm_automation_module_module_link_40_hash_41[]|null;
 
   constructor({
     uri,
     hash = null
   }: {
     uri: string,
-    hash?: Azurerm_automation_module_module_link_628_hash_629[]|null
+    hash?: Azurerm_automation_module_module_link_40_hash_41[]|null
   }) {
     this.uri = uri;
     this.hash = hash;
@@ -3283,11 +3283,11 @@ export class Azurerm_automation_module_module_link_628 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_automation_module_module_link_628';
+    return 'TerraformAzureRM::Azurerm_automation_module_module_link_40';
   }
 }
 
-export class Azurerm_automation_module_module_link_628_hash_629 implements PcoreValue {
+export class Azurerm_automation_module_module_link_40_hash_41 implements PcoreValue {
   readonly algorithm: string;
   readonly value: string;
 
@@ -3310,7 +3310,7 @@ export class Azurerm_automation_module_module_link_628_hash_629 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_automation_module_module_link_628_hash_629';
+    return 'TerraformAzureRM::Azurerm_automation_module_module_link_40_hash_41';
   }
 }
 
@@ -3320,7 +3320,7 @@ export class Azurerm_automation_runbook implements PcoreValue {
   readonly log_progress: boolean;
   readonly log_verbose: boolean;
   readonly name: string;
-  readonly publish_content_link: Azurerm_automation_runbook_publish_content_link_630[];
+  readonly publish_content_link: Azurerm_automation_runbook_publish_content_link_42[];
   readonly resource_group_name: string;
   readonly runbook_type: string;
   readonly azurerm_automation_runbook_id: string|null;
@@ -3347,7 +3347,7 @@ export class Azurerm_automation_runbook implements PcoreValue {
     log_progress: boolean,
     log_verbose: boolean,
     name: string,
-    publish_content_link: Azurerm_automation_runbook_publish_content_link_630[],
+    publish_content_link: Azurerm_automation_runbook_publish_content_link_42[],
     resource_group_name: string,
     runbook_type: string,
     azurerm_automation_runbook_id?: string|null,
@@ -3409,9 +3409,9 @@ export class Azurerm_automation_runbookHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_automation_runbook_publish_content_link_630 implements PcoreValue {
+export class Azurerm_automation_runbook_publish_content_link_42 implements PcoreValue {
   readonly uri: string;
-  readonly hash: Azurerm_automation_runbook_publish_content_link_630_hash_631[]|null;
+  readonly hash: Azurerm_automation_runbook_publish_content_link_42_hash_43[]|null;
   readonly version: string|null;
 
   constructor({
@@ -3420,7 +3420,7 @@ export class Azurerm_automation_runbook_publish_content_link_630 implements Pcor
     version = null
   }: {
     uri: string,
-    hash?: Azurerm_automation_runbook_publish_content_link_630_hash_631[]|null,
+    hash?: Azurerm_automation_runbook_publish_content_link_42_hash_43[]|null,
     version?: string|null
   }) {
     this.uri = uri;
@@ -3441,11 +3441,11 @@ export class Azurerm_automation_runbook_publish_content_link_630 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_automation_runbook_publish_content_link_630';
+    return 'TerraformAzureRM::Azurerm_automation_runbook_publish_content_link_42';
   }
 }
 
-export class Azurerm_automation_runbook_publish_content_link_630_hash_631 implements PcoreValue {
+export class Azurerm_automation_runbook_publish_content_link_42_hash_43 implements PcoreValue {
   readonly algorithm: string;
   readonly value: string;
 
@@ -3468,7 +3468,7 @@ export class Azurerm_automation_runbook_publish_content_link_630_hash_631 implem
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_automation_runbook_publish_content_link_630_hash_631';
+    return 'TerraformAzureRM::Azurerm_automation_runbook_publish_content_link_42_hash_43';
   }
 }
 
@@ -3483,7 +3483,7 @@ export class Azurerm_automation_schedule implements PcoreValue {
   readonly expiry_time: string|null;
   readonly interval: number|null;
   readonly month_days: number[]|null;
-  readonly monthly_occurrence: Azurerm_automation_schedule_monthly_occurrence_632[]|null;
+  readonly monthly_occurrence: Azurerm_automation_schedule_monthly_occurrence_44[]|null;
   readonly start_time: string|null;
   readonly timezone: string|null;
   readonly week_days: string[]|null;
@@ -3514,7 +3514,7 @@ export class Azurerm_automation_schedule implements PcoreValue {
     expiry_time?: string|null,
     interval?: number|null,
     month_days?: number[]|null,
-    monthly_occurrence?: Azurerm_automation_schedule_monthly_occurrence_632[]|null,
+    monthly_occurrence?: Azurerm_automation_schedule_monthly_occurrence_44[]|null,
     start_time?: string|null,
     timezone?: string|null,
     week_days?: string[]|null
@@ -3591,7 +3591,7 @@ export class Azurerm_automation_scheduleHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_automation_schedule_monthly_occurrence_632 implements PcoreValue {
+export class Azurerm_automation_schedule_monthly_occurrence_44 implements PcoreValue {
   readonly day: string;
   readonly occurrence: number;
 
@@ -3614,19 +3614,19 @@ export class Azurerm_automation_schedule_monthly_occurrence_632 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_automation_schedule_monthly_occurrence_632';
+    return 'TerraformAzureRM::Azurerm_automation_schedule_monthly_occurrence_44';
   }
 }
 
 export class Azurerm_autoscale_setting implements PcoreValue {
   readonly location: string;
   readonly name: string;
-  readonly profile: Azurerm_autoscale_setting_profile_636[];
+  readonly profile: Azurerm_autoscale_setting_profile_48[];
   readonly resource_group_name: string;
   readonly target_resource_id: string;
   readonly azurerm_autoscale_setting_id: string|null;
   readonly enabled: boolean|null;
-  readonly notification: Azurerm_autoscale_setting_notification_633[]|null;
+  readonly notification: Azurerm_autoscale_setting_notification_45[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -3642,12 +3642,12 @@ export class Azurerm_autoscale_setting implements PcoreValue {
   }: {
     location: string,
     name: string,
-    profile: Azurerm_autoscale_setting_profile_636[],
+    profile: Azurerm_autoscale_setting_profile_48[],
     resource_group_name: string,
     target_resource_id: string,
     azurerm_autoscale_setting_id?: string|null,
     enabled?: boolean|null,
-    notification?: Azurerm_autoscale_setting_notification_633[]|null,
+    notification?: Azurerm_autoscale_setting_notification_45[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.location = location;
@@ -3698,16 +3698,16 @@ export class Azurerm_autoscale_settingHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_autoscale_setting_notification_633 implements PcoreValue {
-  readonly email: Azurerm_autoscale_setting_notification_633_email_634[]|null;
-  readonly webhook: Azurerm_autoscale_setting_notification_633_webhook_635[]|null;
+export class Azurerm_autoscale_setting_notification_45 implements PcoreValue {
+  readonly email: Azurerm_autoscale_setting_notification_45_email_46[]|null;
+  readonly webhook: Azurerm_autoscale_setting_notification_45_webhook_47[]|null;
 
   constructor({
     email = null,
     webhook = null
   }: {
-    email?: Azurerm_autoscale_setting_notification_633_email_634[]|null,
-    webhook?: Azurerm_autoscale_setting_notification_633_webhook_635[]|null
+    email?: Azurerm_autoscale_setting_notification_45_email_46[]|null,
+    webhook?: Azurerm_autoscale_setting_notification_45_webhook_47[]|null
   }) {
     this.email = email;
     this.webhook = webhook;
@@ -3725,11 +3725,11 @@ export class Azurerm_autoscale_setting_notification_633 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_notification_633';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_notification_45';
   }
 }
 
-export class Azurerm_autoscale_setting_notification_633_email_634 implements PcoreValue {
+export class Azurerm_autoscale_setting_notification_45_email_46 implements PcoreValue {
   readonly custom_emails: string[]|null;
   readonly send_to_subscription_administrator: boolean|null;
   readonly send_to_subscription_co_administrator: boolean|null;
@@ -3763,11 +3763,11 @@ export class Azurerm_autoscale_setting_notification_633_email_634 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_notification_633_email_634';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_notification_45_email_46';
   }
 }
 
-export class Azurerm_autoscale_setting_notification_633_webhook_635 implements PcoreValue {
+export class Azurerm_autoscale_setting_notification_45_webhook_47 implements PcoreValue {
   readonly service_uri: string;
   readonly properties: {[s: string]: string}|null;
 
@@ -3792,16 +3792,16 @@ export class Azurerm_autoscale_setting_notification_633_webhook_635 implements P
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_notification_633_webhook_635';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_notification_45_webhook_47';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636 implements PcoreValue {
-  readonly capacity: Azurerm_autoscale_setting_profile_636_capacity_637[];
+export class Azurerm_autoscale_setting_profile_48 implements PcoreValue {
+  readonly capacity: Azurerm_autoscale_setting_profile_48_capacity_49[];
   readonly name: string;
-  readonly fixed_date: Azurerm_autoscale_setting_profile_636_fixed_date_638[]|null;
-  readonly recurrence: Azurerm_autoscale_setting_profile_636_recurrence_639[]|null;
-  readonly rule: Azurerm_autoscale_setting_profile_636_rule_640[]|null;
+  readonly fixed_date: Azurerm_autoscale_setting_profile_48_fixed_date_50[]|null;
+  readonly recurrence: Azurerm_autoscale_setting_profile_48_recurrence_51[]|null;
+  readonly rule: Azurerm_autoscale_setting_profile_48_rule_52[]|null;
 
   constructor({
     capacity,
@@ -3810,11 +3810,11 @@ export class Azurerm_autoscale_setting_profile_636 implements PcoreValue {
     recurrence = null,
     rule = null
   }: {
-    capacity: Azurerm_autoscale_setting_profile_636_capacity_637[],
+    capacity: Azurerm_autoscale_setting_profile_48_capacity_49[],
     name: string,
-    fixed_date?: Azurerm_autoscale_setting_profile_636_fixed_date_638[]|null,
-    recurrence?: Azurerm_autoscale_setting_profile_636_recurrence_639[]|null,
-    rule?: Azurerm_autoscale_setting_profile_636_rule_640[]|null
+    fixed_date?: Azurerm_autoscale_setting_profile_48_fixed_date_50[]|null,
+    recurrence?: Azurerm_autoscale_setting_profile_48_recurrence_51[]|null,
+    rule?: Azurerm_autoscale_setting_profile_48_rule_52[]|null
   }) {
     this.capacity = capacity;
     this.name = name;
@@ -3840,11 +3840,11 @@ export class Azurerm_autoscale_setting_profile_636 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636_capacity_637 implements PcoreValue {
+export class Azurerm_autoscale_setting_profile_48_capacity_49 implements PcoreValue {
   readonly default_: number;
   readonly maximum: number;
   readonly minimum: number;
@@ -3872,11 +3872,11 @@ export class Azurerm_autoscale_setting_profile_636_capacity_637 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636_capacity_637';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48_capacity_49';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636_fixed_date_638 implements PcoreValue {
+export class Azurerm_autoscale_setting_profile_48_fixed_date_50 implements PcoreValue {
   readonly end: string;
   readonly start: string;
   readonly timezone: string|null;
@@ -3906,11 +3906,11 @@ export class Azurerm_autoscale_setting_profile_636_fixed_date_638 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636_fixed_date_638';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48_fixed_date_50';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636_recurrence_639 implements PcoreValue {
+export class Azurerm_autoscale_setting_profile_48_recurrence_51 implements PcoreValue {
   readonly days: string[];
   readonly hours: number[];
   readonly minutes: number[];
@@ -3945,20 +3945,20 @@ export class Azurerm_autoscale_setting_profile_636_recurrence_639 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636_recurrence_639';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48_recurrence_51';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636_rule_640 implements PcoreValue {
-  readonly metric_trigger: Azurerm_autoscale_setting_profile_636_rule_640_metric_trigger_641[];
-  readonly scale_action: Azurerm_autoscale_setting_profile_636_rule_640_scale_action_642[];
+export class Azurerm_autoscale_setting_profile_48_rule_52 implements PcoreValue {
+  readonly metric_trigger: Azurerm_autoscale_setting_profile_48_rule_52_metric_trigger_53[];
+  readonly scale_action: Azurerm_autoscale_setting_profile_48_rule_52_scale_action_54[];
 
   constructor({
     metric_trigger,
     scale_action
   }: {
-    metric_trigger: Azurerm_autoscale_setting_profile_636_rule_640_metric_trigger_641[],
-    scale_action: Azurerm_autoscale_setting_profile_636_rule_640_scale_action_642[]
+    metric_trigger: Azurerm_autoscale_setting_profile_48_rule_52_metric_trigger_53[],
+    scale_action: Azurerm_autoscale_setting_profile_48_rule_52_scale_action_54[]
   }) {
     this.metric_trigger = metric_trigger;
     this.scale_action = scale_action;
@@ -3972,11 +3972,11 @@ export class Azurerm_autoscale_setting_profile_636_rule_640 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636_rule_640';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48_rule_52';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636_rule_640_metric_trigger_641 implements PcoreValue {
+export class Azurerm_autoscale_setting_profile_48_rule_52_metric_trigger_53 implements PcoreValue {
   readonly metric_name: string;
   readonly metric_resource_id: string;
   readonly operator: string;
@@ -4029,11 +4029,11 @@ export class Azurerm_autoscale_setting_profile_636_rule_640_metric_trigger_641 i
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636_rule_640_metric_trigger_641';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48_rule_52_metric_trigger_53';
   }
 }
 
-export class Azurerm_autoscale_setting_profile_636_rule_640_scale_action_642 implements PcoreValue {
+export class Azurerm_autoscale_setting_profile_48_rule_52_scale_action_54 implements PcoreValue {
   readonly cooldown: string;
   readonly direction: string;
   readonly type: string;
@@ -4066,7 +4066,7 @@ export class Azurerm_autoscale_setting_profile_636_rule_640_scale_action_642 imp
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_636_rule_640_scale_action_642';
+    return 'TerraformAzureRM::Azurerm_autoscale_setting_profile_48_rule_52_scale_action_54';
   }
 }
 
@@ -4412,13 +4412,13 @@ export class Azurerm_batch_pool implements PcoreValue {
   readonly name: string;
   readonly node_agent_sku_id: string;
   readonly resource_group_name: string;
-  readonly storage_image_reference: Azurerm_batch_pool_storage_image_reference_648[];
+  readonly storage_image_reference: Azurerm_batch_pool_storage_image_reference_60[];
   readonly vm_size: string;
   readonly azurerm_batch_pool_id: string|null;
-  readonly auto_scale: Azurerm_batch_pool_auto_scale_643[]|null;
+  readonly auto_scale: Azurerm_batch_pool_auto_scale_55[]|null;
   readonly display_name: string|null;
-  readonly fixed_scale: Azurerm_batch_pool_fixed_scale_644[]|null;
-  readonly start_task: Azurerm_batch_pool_start_task_645[]|null;
+  readonly fixed_scale: Azurerm_batch_pool_fixed_scale_56[]|null;
+  readonly start_task: Azurerm_batch_pool_start_task_57[]|null;
   readonly stop_pending_resize_operation: boolean|null;
 
   constructor({
@@ -4439,13 +4439,13 @@ export class Azurerm_batch_pool implements PcoreValue {
     name: string,
     node_agent_sku_id: string,
     resource_group_name: string,
-    storage_image_reference: Azurerm_batch_pool_storage_image_reference_648[],
+    storage_image_reference: Azurerm_batch_pool_storage_image_reference_60[],
     vm_size: string,
     azurerm_batch_pool_id?: string|null,
-    auto_scale?: Azurerm_batch_pool_auto_scale_643[]|null,
+    auto_scale?: Azurerm_batch_pool_auto_scale_55[]|null,
     display_name?: string|null,
-    fixed_scale?: Azurerm_batch_pool_fixed_scale_644[]|null,
-    start_task?: Azurerm_batch_pool_start_task_645[]|null,
+    fixed_scale?: Azurerm_batch_pool_fixed_scale_56[]|null,
+    start_task?: Azurerm_batch_pool_start_task_57[]|null,
     stop_pending_resize_operation?: boolean|null
   }) {
     this.account_name = account_name;
@@ -4506,7 +4506,7 @@ export class Azurerm_batch_poolHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_batch_pool_auto_scale_643 implements PcoreValue {
+export class Azurerm_batch_pool_auto_scale_55 implements PcoreValue {
   readonly formula: string;
   readonly evaluation_interval: string|null;
 
@@ -4531,11 +4531,11 @@ export class Azurerm_batch_pool_auto_scale_643 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_batch_pool_auto_scale_643';
+    return 'TerraformAzureRM::Azurerm_batch_pool_auto_scale_55';
   }
 }
 
-export class Azurerm_batch_pool_fixed_scale_644 implements PcoreValue {
+export class Azurerm_batch_pool_fixed_scale_56 implements PcoreValue {
   readonly resize_timeout: string|null;
   readonly target_dedicated_nodes: number|null;
   readonly target_low_priority_nodes: number|null;
@@ -4569,13 +4569,13 @@ export class Azurerm_batch_pool_fixed_scale_644 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_batch_pool_fixed_scale_644';
+    return 'TerraformAzureRM::Azurerm_batch_pool_fixed_scale_56';
   }
 }
 
-export class Azurerm_batch_pool_start_task_645 implements PcoreValue {
+export class Azurerm_batch_pool_start_task_57 implements PcoreValue {
   readonly command_line: string;
-  readonly user_identity: Azurerm_batch_pool_start_task_645_user_identity_646[];
+  readonly user_identity: Azurerm_batch_pool_start_task_57_user_identity_58[];
   readonly environment: {[s: string]: string}|null;
   readonly max_task_retry_count: number|null;
   readonly wait_for_success: boolean|null;
@@ -4588,7 +4588,7 @@ export class Azurerm_batch_pool_start_task_645 implements PcoreValue {
     wait_for_success = null
   }: {
     command_line: string,
-    user_identity: Azurerm_batch_pool_start_task_645_user_identity_646[],
+    user_identity: Azurerm_batch_pool_start_task_57_user_identity_58[],
     environment?: {[s: string]: string}|null,
     max_task_retry_count?: number|null,
     wait_for_success?: boolean|null
@@ -4617,19 +4617,19 @@ export class Azurerm_batch_pool_start_task_645 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_batch_pool_start_task_645';
+    return 'TerraformAzureRM::Azurerm_batch_pool_start_task_57';
   }
 }
 
-export class Azurerm_batch_pool_start_task_645_user_identity_646 implements PcoreValue {
-  readonly auto_user: Azurerm_batch_pool_start_task_645_user_identity_646_auto_user_647[]|null;
+export class Azurerm_batch_pool_start_task_57_user_identity_58 implements PcoreValue {
+  readonly auto_user: Azurerm_batch_pool_start_task_57_user_identity_58_auto_user_59[]|null;
   readonly user_name: string|null;
 
   constructor({
     auto_user = null,
     user_name = null
   }: {
-    auto_user?: Azurerm_batch_pool_start_task_645_user_identity_646_auto_user_647[]|null,
+    auto_user?: Azurerm_batch_pool_start_task_57_user_identity_58_auto_user_59[]|null,
     user_name?: string|null
   }) {
     this.auto_user = auto_user;
@@ -4648,11 +4648,11 @@ export class Azurerm_batch_pool_start_task_645_user_identity_646 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_batch_pool_start_task_645_user_identity_646';
+    return 'TerraformAzureRM::Azurerm_batch_pool_start_task_57_user_identity_58';
   }
 }
 
-export class Azurerm_batch_pool_start_task_645_user_identity_646_auto_user_647 implements PcoreValue {
+export class Azurerm_batch_pool_start_task_57_user_identity_58_auto_user_59 implements PcoreValue {
   readonly elevation_level: string|null;
   readonly scope: string|null;
 
@@ -4679,11 +4679,11 @@ export class Azurerm_batch_pool_start_task_645_user_identity_646_auto_user_647 i
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_batch_pool_start_task_645_user_identity_646_auto_user_647';
+    return 'TerraformAzureRM::Azurerm_batch_pool_start_task_57_user_identity_58_auto_user_59';
   }
 }
 
-export class Azurerm_batch_pool_storage_image_reference_648 implements PcoreValue {
+export class Azurerm_batch_pool_storage_image_reference_60 implements PcoreValue {
   readonly offer: string;
   readonly publisher: string;
   readonly sku: string;
@@ -4723,19 +4723,19 @@ export class Azurerm_batch_pool_storage_image_reference_648 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_batch_pool_storage_image_reference_648';
+    return 'TerraformAzureRM::Azurerm_batch_pool_storage_image_reference_60';
   }
 }
 
 export class Azurerm_cdn_endpoint implements PcoreValue {
   readonly location: string;
   readonly name: string;
-  readonly origin: Azurerm_cdn_endpoint_origin_650[];
+  readonly origin: Azurerm_cdn_endpoint_origin_62[];
   readonly profile_name: string;
   readonly resource_group_name: string;
   readonly azurerm_cdn_endpoint_id: string|null;
   readonly content_types_to_compress: string[]|null;
-  readonly geo_filter: Azurerm_cdn_endpoint_geo_filter_649[]|null;
+  readonly geo_filter: Azurerm_cdn_endpoint_geo_filter_61[]|null;
   readonly host_name: string|null;
   readonly is_compression_enabled: boolean|null;
   readonly is_http_allowed: boolean|null;
@@ -4769,12 +4769,12 @@ export class Azurerm_cdn_endpoint implements PcoreValue {
   }: {
     location: string,
     name: string,
-    origin: Azurerm_cdn_endpoint_origin_650[],
+    origin: Azurerm_cdn_endpoint_origin_62[],
     profile_name: string,
     resource_group_name: string,
     azurerm_cdn_endpoint_id?: string|null,
     content_types_to_compress?: string[]|null,
-    geo_filter?: Azurerm_cdn_endpoint_geo_filter_649[]|null,
+    geo_filter?: Azurerm_cdn_endpoint_geo_filter_61[]|null,
     host_name?: string|null,
     is_compression_enabled?: boolean|null,
     is_http_allowed?: boolean|null,
@@ -4870,7 +4870,7 @@ export class Azurerm_cdn_endpointHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_cdn_endpoint_geo_filter_649 implements PcoreValue {
+export class Azurerm_cdn_endpoint_geo_filter_61 implements PcoreValue {
   readonly action: string;
   readonly country_codes: string[];
   readonly relative_path: string;
@@ -4898,11 +4898,11 @@ export class Azurerm_cdn_endpoint_geo_filter_649 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cdn_endpoint_geo_filter_649';
+    return 'TerraformAzureRM::Azurerm_cdn_endpoint_geo_filter_61';
   }
 }
 
-export class Azurerm_cdn_endpoint_origin_650 implements PcoreValue {
+export class Azurerm_cdn_endpoint_origin_62 implements PcoreValue {
   readonly host_name: string;
   readonly name: string;
   readonly http_port: number|null;
@@ -4939,7 +4939,7 @@ export class Azurerm_cdn_endpoint_origin_650 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cdn_endpoint_origin_650';
+    return 'TerraformAzureRM::Azurerm_cdn_endpoint_origin_62';
   }
 }
 
@@ -5009,7 +5009,7 @@ export class Azurerm_cognitive_account implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_cognitive_account_sku_651[];
+  readonly sku: Azurerm_cognitive_account_sku_63[];
   readonly azurerm_cognitive_account_id: string|null;
   readonly endpoint: string|null;
   readonly tags: {[s: string]: string}|null;
@@ -5028,7 +5028,7 @@ export class Azurerm_cognitive_account implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_cognitive_account_sku_651[],
+    sku: Azurerm_cognitive_account_sku_63[],
     azurerm_cognitive_account_id?: string|null,
     endpoint?: string|null,
     tags?: {[s: string]: string}|null
@@ -5077,7 +5077,7 @@ export class Azurerm_cognitive_accountHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_cognitive_account_sku_651 implements PcoreValue {
+export class Azurerm_cognitive_account_sku_63 implements PcoreValue {
   readonly name: string;
   readonly tier: string;
 
@@ -5100,12 +5100,12 @@ export class Azurerm_cognitive_account_sku_651 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cognitive_account_sku_651';
+    return 'TerraformAzureRM::Azurerm_cognitive_account_sku_63';
   }
 }
 
 export class Azurerm_container_group implements PcoreValue {
-  readonly container: Azurerm_container_group_container_652[];
+  readonly container: Azurerm_container_group_container_64[];
   readonly location: string;
   readonly name: string;
   readonly os_type: string;
@@ -5113,7 +5113,7 @@ export class Azurerm_container_group implements PcoreValue {
   readonly azurerm_container_group_id: string|null;
   readonly dns_name_label: string|null;
   readonly fqdn: string|null;
-  readonly image_registry_credential: Azurerm_container_group_image_registry_credential_655[]|null;
+  readonly image_registry_credential: Azurerm_container_group_image_registry_credential_67[]|null;
   readonly ip_address: string|null;
   readonly ip_address_type: string|null;
   readonly restart_policy: string|null;
@@ -5134,7 +5134,7 @@ export class Azurerm_container_group implements PcoreValue {
     restart_policy = null,
     tags = null
   }: {
-    container: Azurerm_container_group_container_652[],
+    container: Azurerm_container_group_container_64[],
     location: string,
     name: string,
     os_type: string,
@@ -5142,7 +5142,7 @@ export class Azurerm_container_group implements PcoreValue {
     azurerm_container_group_id?: string|null,
     dns_name_label?: string|null,
     fqdn?: string|null,
-    image_registry_credential?: Azurerm_container_group_image_registry_credential_655[]|null,
+    image_registry_credential?: Azurerm_container_group_image_registry_credential_67[]|null,
     ip_address?: string|null,
     ip_address_type?: string|null,
     restart_policy?: string|null,
@@ -5212,7 +5212,7 @@ export class Azurerm_container_groupHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_container_group_container_652 implements PcoreValue {
+export class Azurerm_container_group_container_64 implements PcoreValue {
   readonly cpu: number;
   readonly image: string;
   readonly memory: number;
@@ -5221,10 +5221,10 @@ export class Azurerm_container_group_container_652 implements PcoreValue {
   readonly commands: string[]|null;
   readonly environment_variables: {[s: string]: string}|null;
   readonly port: number|null;
-  readonly ports: Azurerm_container_group_container_652_ports_653[]|null;
+  readonly ports: Azurerm_container_group_container_64_ports_65[]|null;
   readonly protocol: string|null;
   readonly secure_environment_variables: {[s: string]: string}|null;
-  readonly volume: Azurerm_container_group_container_652_volume_654[]|null;
+  readonly volume: Azurerm_container_group_container_64_volume_66[]|null;
 
   constructor({
     cpu,
@@ -5248,10 +5248,10 @@ export class Azurerm_container_group_container_652 implements PcoreValue {
     commands?: string[]|null,
     environment_variables?: {[s: string]: string}|null,
     port?: number|null,
-    ports?: Azurerm_container_group_container_652_ports_653[]|null,
+    ports?: Azurerm_container_group_container_64_ports_65[]|null,
     protocol?: string|null,
     secure_environment_variables?: {[s: string]: string}|null,
-    volume?: Azurerm_container_group_container_652_volume_654[]|null
+    volume?: Azurerm_container_group_container_64_volume_66[]|null
   }) {
     this.cpu = cpu;
     this.image = image;
@@ -5301,11 +5301,11 @@ export class Azurerm_container_group_container_652 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_group_container_652';
+    return 'TerraformAzureRM::Azurerm_container_group_container_64';
   }
 }
 
-export class Azurerm_container_group_container_652_ports_653 implements PcoreValue {
+export class Azurerm_container_group_container_64_ports_65 implements PcoreValue {
   readonly port: number|null;
   readonly protocol: string|null;
 
@@ -5332,11 +5332,11 @@ export class Azurerm_container_group_container_652_ports_653 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_group_container_652_ports_653';
+    return 'TerraformAzureRM::Azurerm_container_group_container_64_ports_65';
   }
 }
 
-export class Azurerm_container_group_container_652_volume_654 implements PcoreValue {
+export class Azurerm_container_group_container_64_volume_66 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly share_name: string;
@@ -5381,11 +5381,11 @@ export class Azurerm_container_group_container_652_volume_654 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_group_container_652_volume_654';
+    return 'TerraformAzureRM::Azurerm_container_group_container_64_volume_66';
   }
 }
 
-export class Azurerm_container_group_image_registry_credential_655 implements PcoreValue {
+export class Azurerm_container_group_image_registry_credential_67 implements PcoreValue {
   readonly password: string;
   readonly server: string;
   readonly username: string;
@@ -5413,7 +5413,7 @@ export class Azurerm_container_group_image_registry_credential_655 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_group_image_registry_credential_655';
+    return 'TerraformAzureRM::Azurerm_container_group_image_registry_credential_67';
   }
 }
 
@@ -5428,7 +5428,7 @@ export class Azurerm_container_registry implements PcoreValue {
   readonly georeplication_locations: string[]|null;
   readonly login_server: string|null;
   readonly sku: string|null;
-  readonly storage_account: Azurerm_container_registry_storage_account_656[]|null;
+  readonly storage_account: Azurerm_container_registry_storage_account_68[]|null;
   readonly storage_account_id: string|null;
   readonly tags: {[s: string]: string}|null;
 
@@ -5457,7 +5457,7 @@ export class Azurerm_container_registry implements PcoreValue {
     georeplication_locations?: string[]|null,
     login_server?: string|null,
     sku?: string|null,
-    storage_account?: Azurerm_container_registry_storage_account_656[]|null,
+    storage_account?: Azurerm_container_registry_storage_account_68[]|null,
     storage_account_id?: string|null,
     tags?: {[s: string]: string}|null
   }) {
@@ -5529,7 +5529,7 @@ export class Azurerm_container_registryHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_container_registry_storage_account_656 implements PcoreValue {
+export class Azurerm_container_registry_storage_account_68 implements PcoreValue {
   readonly access_key: string;
   readonly name: string;
 
@@ -5552,21 +5552,21 @@ export class Azurerm_container_registry_storage_account_656 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_registry_storage_account_656';
+    return 'TerraformAzureRM::Azurerm_container_registry_storage_account_68';
   }
 }
 
 export class Azurerm_container_service implements PcoreValue {
-  readonly agent_pool_profile: Azurerm_container_service_agent_pool_profile_657[];
-  readonly diagnostics_profile: Azurerm_container_service_diagnostics_profile_658[];
-  readonly linux_profile: Azurerm_container_service_linux_profile_659[];
+  readonly agent_pool_profile: Azurerm_container_service_agent_pool_profile_69[];
+  readonly diagnostics_profile: Azurerm_container_service_diagnostics_profile_70[];
+  readonly linux_profile: Azurerm_container_service_linux_profile_71[];
   readonly location: string;
-  readonly master_profile: Azurerm_container_service_master_profile_661[];
+  readonly master_profile: Azurerm_container_service_master_profile_73[];
   readonly name: string;
   readonly orchestration_platform: string;
   readonly resource_group_name: string;
   readonly azurerm_container_service_id: string|null;
-  readonly service_principal: Azurerm_container_service_service_principal_662[]|null;
+  readonly service_principal: Azurerm_container_service_service_principal_74[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -5582,16 +5582,16 @@ export class Azurerm_container_service implements PcoreValue {
     service_principal = null,
     tags = null
   }: {
-    agent_pool_profile: Azurerm_container_service_agent_pool_profile_657[],
-    diagnostics_profile: Azurerm_container_service_diagnostics_profile_658[],
-    linux_profile: Azurerm_container_service_linux_profile_659[],
+    agent_pool_profile: Azurerm_container_service_agent_pool_profile_69[],
+    diagnostics_profile: Azurerm_container_service_diagnostics_profile_70[],
+    linux_profile: Azurerm_container_service_linux_profile_71[],
     location: string,
-    master_profile: Azurerm_container_service_master_profile_661[],
+    master_profile: Azurerm_container_service_master_profile_73[],
     name: string,
     orchestration_platform: string,
     resource_group_name: string,
     azurerm_container_service_id?: string|null,
-    service_principal?: Azurerm_container_service_service_principal_662[]|null,
+    service_principal?: Azurerm_container_service_service_principal_74[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.agent_pool_profile = agent_pool_profile;
@@ -5644,7 +5644,7 @@ export class Azurerm_container_serviceHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_container_service_agent_pool_profile_657 implements PcoreValue {
+export class Azurerm_container_service_agent_pool_profile_69 implements PcoreValue {
   readonly dns_prefix: string;
   readonly name: string;
   readonly vm_size: string;
@@ -5686,11 +5686,11 @@ export class Azurerm_container_service_agent_pool_profile_657 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_service_agent_pool_profile_657';
+    return 'TerraformAzureRM::Azurerm_container_service_agent_pool_profile_69';
   }
 }
 
-export class Azurerm_container_service_diagnostics_profile_658 implements PcoreValue {
+export class Azurerm_container_service_diagnostics_profile_70 implements PcoreValue {
   readonly enabled: boolean;
   readonly storage_uri: string|null;
 
@@ -5715,20 +5715,20 @@ export class Azurerm_container_service_diagnostics_profile_658 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_service_diagnostics_profile_658';
+    return 'TerraformAzureRM::Azurerm_container_service_diagnostics_profile_70';
   }
 }
 
-export class Azurerm_container_service_linux_profile_659 implements PcoreValue {
+export class Azurerm_container_service_linux_profile_71 implements PcoreValue {
   readonly admin_username: string;
-  readonly ssh_key: Azurerm_container_service_linux_profile_659_ssh_key_660[];
+  readonly ssh_key: Azurerm_container_service_linux_profile_71_ssh_key_72[];
 
   constructor({
     admin_username,
     ssh_key
   }: {
     admin_username: string,
-    ssh_key: Azurerm_container_service_linux_profile_659_ssh_key_660[]
+    ssh_key: Azurerm_container_service_linux_profile_71_ssh_key_72[]
   }) {
     this.admin_username = admin_username;
     this.ssh_key = ssh_key;
@@ -5742,11 +5742,11 @@ export class Azurerm_container_service_linux_profile_659 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_service_linux_profile_659';
+    return 'TerraformAzureRM::Azurerm_container_service_linux_profile_71';
   }
 }
 
-export class Azurerm_container_service_linux_profile_659_ssh_key_660 implements PcoreValue {
+export class Azurerm_container_service_linux_profile_71_ssh_key_72 implements PcoreValue {
   readonly key_data: string;
 
   constructor({
@@ -5764,11 +5764,11 @@ export class Azurerm_container_service_linux_profile_659_ssh_key_660 implements 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_service_linux_profile_659_ssh_key_660';
+    return 'TerraformAzureRM::Azurerm_container_service_linux_profile_71_ssh_key_72';
   }
 }
 
-export class Azurerm_container_service_master_profile_661 implements PcoreValue {
+export class Azurerm_container_service_master_profile_73 implements PcoreValue {
   readonly dns_prefix: string;
   readonly count: number|null;
   readonly fqdn: string|null;
@@ -5800,11 +5800,11 @@ export class Azurerm_container_service_master_profile_661 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_service_master_profile_661';
+    return 'TerraformAzureRM::Azurerm_container_service_master_profile_73';
   }
 }
 
-export class Azurerm_container_service_service_principal_662 implements PcoreValue {
+export class Azurerm_container_service_service_principal_74 implements PcoreValue {
   readonly client_id: string;
   readonly client_secret: string;
 
@@ -5827,24 +5827,24 @@ export class Azurerm_container_service_service_principal_662 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_container_service_service_principal_662';
+    return 'TerraformAzureRM::Azurerm_container_service_service_principal_74';
   }
 }
 
 export class Azurerm_cosmosdb_account implements PcoreValue {
-  readonly consistency_policy: Azurerm_cosmosdb_account_consistency_policy_664[];
+  readonly consistency_policy: Azurerm_cosmosdb_account_consistency_policy_76[];
   readonly location: string;
   readonly name: string;
   readonly offer_type: string;
   readonly resource_group_name: string;
   readonly azurerm_cosmosdb_account_id: string|null;
-  readonly capabilities: Azurerm_cosmosdb_account_capabilities_663[]|null;
+  readonly capabilities: Azurerm_cosmosdb_account_capabilities_75[]|null;
   readonly connection_strings: string[]|null;
   readonly enable_automatic_failover: boolean|null;
   readonly enable_multiple_write_locations: boolean|null;
   readonly endpoint: string|null;
-  readonly failover_policy: Azurerm_cosmosdb_account_failover_policy_665[]|null;
-  readonly geo_location: Azurerm_cosmosdb_account_geo_location_666[]|null;
+  readonly failover_policy: Azurerm_cosmosdb_account_failover_policy_77[]|null;
+  readonly geo_location: Azurerm_cosmosdb_account_geo_location_78[]|null;
   readonly ip_range_filter: string|null;
   readonly is_virtual_network_filter_enabled: boolean|null;
   readonly kind: string|null;
@@ -5854,7 +5854,7 @@ export class Azurerm_cosmosdb_account implements PcoreValue {
   readonly secondary_master_key: string|null;
   readonly secondary_readonly_master_key: string|null;
   readonly tags: {[s: string]: string}|null;
-  readonly virtual_network_rule: Azurerm_cosmosdb_account_virtual_network_rule_667[]|null;
+  readonly virtual_network_rule: Azurerm_cosmosdb_account_virtual_network_rule_79[]|null;
   readonly write_endpoints: string[]|null;
 
   constructor({
@@ -5883,19 +5883,19 @@ export class Azurerm_cosmosdb_account implements PcoreValue {
     virtual_network_rule = null,
     write_endpoints = null
   }: {
-    consistency_policy: Azurerm_cosmosdb_account_consistency_policy_664[],
+    consistency_policy: Azurerm_cosmosdb_account_consistency_policy_76[],
     location: string,
     name: string,
     offer_type: string,
     resource_group_name: string,
     azurerm_cosmosdb_account_id?: string|null,
-    capabilities?: Azurerm_cosmosdb_account_capabilities_663[]|null,
+    capabilities?: Azurerm_cosmosdb_account_capabilities_75[]|null,
     connection_strings?: string[]|null,
     enable_automatic_failover?: boolean|null,
     enable_multiple_write_locations?: boolean|null,
     endpoint?: string|null,
-    failover_policy?: Azurerm_cosmosdb_account_failover_policy_665[]|null,
-    geo_location?: Azurerm_cosmosdb_account_geo_location_666[]|null,
+    failover_policy?: Azurerm_cosmosdb_account_failover_policy_77[]|null,
+    geo_location?: Azurerm_cosmosdb_account_geo_location_78[]|null,
     ip_range_filter?: string|null,
     is_virtual_network_filter_enabled?: boolean|null,
     kind?: string|null,
@@ -5905,7 +5905,7 @@ export class Azurerm_cosmosdb_account implements PcoreValue {
     secondary_master_key?: string|null,
     secondary_readonly_master_key?: string|null,
     tags?: {[s: string]: string}|null,
-    virtual_network_rule?: Azurerm_cosmosdb_account_virtual_network_rule_667[]|null,
+    virtual_network_rule?: Azurerm_cosmosdb_account_virtual_network_rule_79[]|null,
     write_endpoints?: string[]|null
   }) {
     this.consistency_policy = consistency_policy;
@@ -6016,7 +6016,7 @@ export class Azurerm_cosmosdb_accountHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_cosmosdb_account_capabilities_663 implements PcoreValue {
+export class Azurerm_cosmosdb_account_capabilities_75 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -6034,11 +6034,11 @@ export class Azurerm_cosmosdb_account_capabilities_663 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cosmosdb_account_capabilities_663';
+    return 'TerraformAzureRM::Azurerm_cosmosdb_account_capabilities_75';
   }
 }
 
-export class Azurerm_cosmosdb_account_consistency_policy_664 implements PcoreValue {
+export class Azurerm_cosmosdb_account_consistency_policy_76 implements PcoreValue {
   readonly consistency_level: string;
   readonly max_interval_in_seconds: number|null;
   readonly max_staleness_prefix: number|null;
@@ -6070,11 +6070,11 @@ export class Azurerm_cosmosdb_account_consistency_policy_664 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cosmosdb_account_consistency_policy_664';
+    return 'TerraformAzureRM::Azurerm_cosmosdb_account_consistency_policy_76';
   }
 }
 
-export class Azurerm_cosmosdb_account_failover_policy_665 implements PcoreValue {
+export class Azurerm_cosmosdb_account_failover_policy_77 implements PcoreValue {
   readonly location: string;
   readonly priority: number;
   readonly id: string|null;
@@ -6104,11 +6104,11 @@ export class Azurerm_cosmosdb_account_failover_policy_665 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cosmosdb_account_failover_policy_665';
+    return 'TerraformAzureRM::Azurerm_cosmosdb_account_failover_policy_77';
   }
 }
 
-export class Azurerm_cosmosdb_account_geo_location_666 implements PcoreValue {
+export class Azurerm_cosmosdb_account_geo_location_78 implements PcoreValue {
   readonly failover_priority: number;
   readonly location: string;
   readonly id: string|null;
@@ -6145,11 +6145,11 @@ export class Azurerm_cosmosdb_account_geo_location_666 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cosmosdb_account_geo_location_666';
+    return 'TerraformAzureRM::Azurerm_cosmosdb_account_geo_location_78';
   }
 }
 
-export class Azurerm_cosmosdb_account_virtual_network_rule_667 implements PcoreValue {
+export class Azurerm_cosmosdb_account_virtual_network_rule_79 implements PcoreValue {
   readonly id: string;
 
   constructor({
@@ -6167,7 +6167,7 @@ export class Azurerm_cosmosdb_account_virtual_network_rule_667 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_cosmosdb_account_virtual_network_rule_667';
+    return 'TerraformAzureRM::Azurerm_cosmosdb_account_virtual_network_rule_79';
   }
 }
 
@@ -6685,7 +6685,7 @@ export class Azurerm_dev_test_labHandler implements PcoreValue {
 }
 
 export class Azurerm_dev_test_linux_virtual_machine implements PcoreValue {
-  readonly gallery_image_reference: Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_668[];
+  readonly gallery_image_reference: Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_80[];
   readonly lab_name: string;
   readonly lab_subnet_name: string;
   readonly lab_virtual_network_id: string;
@@ -6699,7 +6699,7 @@ export class Azurerm_dev_test_linux_virtual_machine implements PcoreValue {
   readonly allow_claim: boolean|null;
   readonly disallow_public_ip_address: boolean|null;
   readonly fqdn: string|null;
-  readonly inbound_nat_rule: Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_669[]|null;
+  readonly inbound_nat_rule: Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_81[]|null;
   readonly notes: string|null;
   readonly password: string|null;
   readonly ssh_key: string|null;
@@ -6728,7 +6728,7 @@ export class Azurerm_dev_test_linux_virtual_machine implements PcoreValue {
     tags = null,
     unique_identifier = null
   }: {
-    gallery_image_reference: Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_668[],
+    gallery_image_reference: Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_80[],
     lab_name: string,
     lab_subnet_name: string,
     lab_virtual_network_id: string,
@@ -6742,7 +6742,7 @@ export class Azurerm_dev_test_linux_virtual_machine implements PcoreValue {
     allow_claim?: boolean|null,
     disallow_public_ip_address?: boolean|null,
     fqdn?: string|null,
-    inbound_nat_rule?: Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_669[]|null,
+    inbound_nat_rule?: Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_81[]|null,
     notes?: string|null,
     password?: string|null,
     ssh_key?: string|null,
@@ -6831,7 +6831,7 @@ export class Azurerm_dev_test_linux_virtual_machineHandler implements PcoreValue
   }
 }
 
-export class Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_668 implements PcoreValue {
+export class Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_80 implements PcoreValue {
   readonly offer: string;
   readonly publisher: string;
   readonly sku: string;
@@ -6864,11 +6864,11 @@ export class Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_668 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_668';
+    return 'TerraformAzureRM::Azurerm_dev_test_linux_virtual_machine_gallery_image_reference_80';
   }
 }
 
-export class Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_669 implements PcoreValue {
+export class Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_81 implements PcoreValue {
   readonly backend_port: number;
   readonly protocol: string;
   readonly frontend_port: number|null;
@@ -6898,7 +6898,7 @@ export class Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_669 impleme
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_669';
+    return 'TerraformAzureRM::Azurerm_dev_test_linux_virtual_machine_inbound_nat_rule_81';
   }
 }
 
@@ -6993,7 +6993,7 @@ export class Azurerm_dev_test_virtual_network implements PcoreValue {
   readonly resource_group_name: string;
   readonly azurerm_dev_test_virtual_network_id: string|null;
   readonly description: string|null;
-  readonly subnet: Azurerm_dev_test_virtual_network_subnet_670[]|null;
+  readonly subnet: Azurerm_dev_test_virtual_network_subnet_82[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly unique_identifier: string|null;
 
@@ -7012,7 +7012,7 @@ export class Azurerm_dev_test_virtual_network implements PcoreValue {
     resource_group_name: string,
     azurerm_dev_test_virtual_network_id?: string|null,
     description?: string|null,
-    subnet?: Azurerm_dev_test_virtual_network_subnet_670[]|null,
+    subnet?: Azurerm_dev_test_virtual_network_subnet_82[]|null,
     tags?: {[s: string]: string}|null,
     unique_identifier?: string|null
   }) {
@@ -7064,7 +7064,7 @@ export class Azurerm_dev_test_virtual_networkHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_dev_test_virtual_network_subnet_670 implements PcoreValue {
+export class Azurerm_dev_test_virtual_network_subnet_82 implements PcoreValue {
   readonly name: string|null;
   readonly use_in_virtual_machine_creation: string|null;
   readonly use_public_ip_address: string|null;
@@ -7098,12 +7098,12 @@ export class Azurerm_dev_test_virtual_network_subnet_670 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dev_test_virtual_network_subnet_670';
+    return 'TerraformAzureRM::Azurerm_dev_test_virtual_network_subnet_82';
   }
 }
 
 export class Azurerm_dev_test_windows_virtual_machine implements PcoreValue {
-  readonly gallery_image_reference: Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_671[];
+  readonly gallery_image_reference: Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_83[];
   readonly lab_name: string;
   readonly lab_subnet_name: string;
   readonly lab_virtual_network_id: string;
@@ -7118,7 +7118,7 @@ export class Azurerm_dev_test_windows_virtual_machine implements PcoreValue {
   readonly allow_claim: boolean|null;
   readonly disallow_public_ip_address: boolean|null;
   readonly fqdn: string|null;
-  readonly inbound_nat_rule: Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_672[]|null;
+  readonly inbound_nat_rule: Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_84[]|null;
   readonly notes: string|null;
   readonly tags: {[s: string]: string}|null;
   readonly unique_identifier: string|null;
@@ -7144,7 +7144,7 @@ export class Azurerm_dev_test_windows_virtual_machine implements PcoreValue {
     tags = null,
     unique_identifier = null
   }: {
-    gallery_image_reference: Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_671[],
+    gallery_image_reference: Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_83[],
     lab_name: string,
     lab_subnet_name: string,
     lab_virtual_network_id: string,
@@ -7159,7 +7159,7 @@ export class Azurerm_dev_test_windows_virtual_machine implements PcoreValue {
     allow_claim?: boolean|null,
     disallow_public_ip_address?: boolean|null,
     fqdn?: string|null,
-    inbound_nat_rule?: Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_672[]|null,
+    inbound_nat_rule?: Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_84[]|null,
     notes?: string|null,
     tags?: {[s: string]: string}|null,
     unique_identifier?: string|null
@@ -7240,7 +7240,7 @@ export class Azurerm_dev_test_windows_virtual_machineHandler implements PcoreVal
   }
 }
 
-export class Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_671 implements PcoreValue {
+export class Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_83 implements PcoreValue {
   readonly offer: string;
   readonly publisher: string;
   readonly sku: string;
@@ -7273,11 +7273,11 @@ export class Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_67
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_671';
+    return 'TerraformAzureRM::Azurerm_dev_test_windows_virtual_machine_gallery_image_reference_83';
   }
 }
 
-export class Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_672 implements PcoreValue {
+export class Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_84 implements PcoreValue {
   readonly backend_port: number;
   readonly protocol: string;
   readonly frontend_port: number|null;
@@ -7307,7 +7307,7 @@ export class Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_672 imple
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_672';
+    return 'TerraformAzureRM::Azurerm_dev_test_windows_virtual_machine_inbound_nat_rule_84';
   }
 }
 
@@ -7316,7 +7316,7 @@ export class Azurerm_devspace_controller implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_devspace_controller_sku_673[];
+  readonly sku: Azurerm_devspace_controller_sku_85[];
   readonly target_container_host_credentials_base64: string;
   readonly target_container_host_resource_id: string;
   readonly azurerm_devspace_controller_id: string|null;
@@ -7339,7 +7339,7 @@ export class Azurerm_devspace_controller implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_devspace_controller_sku_673[],
+    sku: Azurerm_devspace_controller_sku_85[],
     target_container_host_credentials_base64: string,
     target_container_host_resource_id: string,
     azurerm_devspace_controller_id?: string|null,
@@ -7394,7 +7394,7 @@ export class Azurerm_devspace_controllerHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_devspace_controller_sku_673 implements PcoreValue {
+export class Azurerm_devspace_controller_sku_85 implements PcoreValue {
   readonly name: string;
   readonly tier: string;
 
@@ -7417,7 +7417,7 @@ export class Azurerm_devspace_controller_sku_673 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_devspace_controller_sku_673';
+    return 'TerraformAzureRM::Azurerm_devspace_controller_sku_85';
   }
 }
 
@@ -7555,7 +7555,7 @@ export class Azurerm_dns_aaaa_recordHandler implements PcoreValue {
 
 export class Azurerm_dns_caa_record implements PcoreValue {
   readonly name: string;
-  readonly record: Azurerm_dns_caa_record_record_674[];
+  readonly record: Azurerm_dns_caa_record_record_86[];
   readonly resource_group_name: string;
   readonly ttl: number;
   readonly zone_name: string;
@@ -7572,7 +7572,7 @@ export class Azurerm_dns_caa_record implements PcoreValue {
     tags = null
   }: {
     name: string,
-    record: Azurerm_dns_caa_record_record_674[],
+    record: Azurerm_dns_caa_record_record_86[],
     resource_group_name: string,
     ttl: number,
     zone_name: string,
@@ -7619,7 +7619,7 @@ export class Azurerm_dns_caa_recordHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_dns_caa_record_record_674 implements PcoreValue {
+export class Azurerm_dns_caa_record_record_86 implements PcoreValue {
   readonly flags: number;
   readonly tag: string;
   readonly value: string;
@@ -7647,7 +7647,7 @@ export class Azurerm_dns_caa_record_record_674 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dns_caa_record_record_674';
+    return 'TerraformAzureRM::Azurerm_dns_caa_record_record_86';
   }
 }
 
@@ -7726,7 +7726,7 @@ export class Azurerm_dns_cname_recordHandler implements PcoreValue {
 
 export class Azurerm_dns_mx_record implements PcoreValue {
   readonly name: string;
-  readonly record: Azurerm_dns_mx_record_record_675[];
+  readonly record: Azurerm_dns_mx_record_record_87[];
   readonly resource_group_name: string;
   readonly ttl: number;
   readonly zone_name: string;
@@ -7743,7 +7743,7 @@ export class Azurerm_dns_mx_record implements PcoreValue {
     tags = null
   }: {
     name: string,
-    record: Azurerm_dns_mx_record_record_675[],
+    record: Azurerm_dns_mx_record_record_87[],
     resource_group_name: string,
     ttl: number,
     zone_name: string,
@@ -7790,7 +7790,7 @@ export class Azurerm_dns_mx_recordHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_dns_mx_record_record_675 implements PcoreValue {
+export class Azurerm_dns_mx_record_record_87 implements PcoreValue {
   readonly exchange: string;
   readonly preference: string;
 
@@ -7813,7 +7813,7 @@ export class Azurerm_dns_mx_record_record_675 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dns_mx_record_record_675';
+    return 'TerraformAzureRM::Azurerm_dns_mx_record_record_87';
   }
 }
 
@@ -7823,7 +7823,7 @@ export class Azurerm_dns_ns_record implements PcoreValue {
   readonly ttl: number;
   readonly zone_name: string;
   readonly azurerm_dns_ns_record_id: string|null;
-  readonly record: Azurerm_dns_ns_record_record_676[]|null;
+  readonly record: Azurerm_dns_ns_record_record_88[]|null;
   readonly records: string[]|null;
   readonly tags: {[s: string]: string}|null;
 
@@ -7842,7 +7842,7 @@ export class Azurerm_dns_ns_record implements PcoreValue {
     ttl: number,
     zone_name: string,
     azurerm_dns_ns_record_id?: string|null,
-    record?: Azurerm_dns_ns_record_record_676[]|null,
+    record?: Azurerm_dns_ns_record_record_88[]|null,
     records?: string[]|null,
     tags?: {[s: string]: string}|null
   }) {
@@ -7892,7 +7892,7 @@ export class Azurerm_dns_ns_recordHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_dns_ns_record_record_676 implements PcoreValue {
+export class Azurerm_dns_ns_record_record_88 implements PcoreValue {
   readonly nsdname: string;
 
   constructor({
@@ -7910,7 +7910,7 @@ export class Azurerm_dns_ns_record_record_676 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dns_ns_record_record_676';
+    return 'TerraformAzureRM::Azurerm_dns_ns_record_record_88';
   }
 }
 
@@ -7982,7 +7982,7 @@ export class Azurerm_dns_ptr_recordHandler implements PcoreValue {
 
 export class Azurerm_dns_srv_record implements PcoreValue {
   readonly name: string;
-  readonly record: Azurerm_dns_srv_record_record_677[];
+  readonly record: Azurerm_dns_srv_record_record_89[];
   readonly resource_group_name: string;
   readonly ttl: number;
   readonly zone_name: string;
@@ -7999,7 +7999,7 @@ export class Azurerm_dns_srv_record implements PcoreValue {
     tags = null
   }: {
     name: string,
-    record: Azurerm_dns_srv_record_record_677[],
+    record: Azurerm_dns_srv_record_record_89[],
     resource_group_name: string,
     ttl: number,
     zone_name: string,
@@ -8046,7 +8046,7 @@ export class Azurerm_dns_srv_recordHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_dns_srv_record_record_677 implements PcoreValue {
+export class Azurerm_dns_srv_record_record_89 implements PcoreValue {
   readonly port: number;
   readonly priority: number;
   readonly target: string;
@@ -8079,13 +8079,13 @@ export class Azurerm_dns_srv_record_record_677 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dns_srv_record_record_677';
+    return 'TerraformAzureRM::Azurerm_dns_srv_record_record_89';
   }
 }
 
 export class Azurerm_dns_txt_record implements PcoreValue {
   readonly name: string;
-  readonly record: Azurerm_dns_txt_record_record_678[];
+  readonly record: Azurerm_dns_txt_record_record_90[];
   readonly resource_group_name: string;
   readonly ttl: number;
   readonly zone_name: string;
@@ -8102,7 +8102,7 @@ export class Azurerm_dns_txt_record implements PcoreValue {
     tags = null
   }: {
     name: string,
-    record: Azurerm_dns_txt_record_record_678[],
+    record: Azurerm_dns_txt_record_record_90[],
     resource_group_name: string,
     ttl: number,
     zone_name: string,
@@ -8149,7 +8149,7 @@ export class Azurerm_dns_txt_recordHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_dns_txt_record_record_678 implements PcoreValue {
+export class Azurerm_dns_txt_record_record_90 implements PcoreValue {
   readonly value: string;
 
   constructor({
@@ -8167,7 +8167,7 @@ export class Azurerm_dns_txt_record_record_678 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_dns_txt_record_record_678';
+    return 'TerraformAzureRM::Azurerm_dns_txt_record_record_90';
   }
 }
 
@@ -8348,7 +8348,7 @@ export class Azurerm_eventhub implements PcoreValue {
   readonly partition_count: number;
   readonly resource_group_name: string;
   readonly azurerm_eventhub_id: string|null;
-  readonly capture_description: Azurerm_eventhub_capture_description_679[]|null;
+  readonly capture_description: Azurerm_eventhub_capture_description_91[]|null;
   readonly location: string|null;
   readonly partition_ids: string[]|null;
 
@@ -8369,7 +8369,7 @@ export class Azurerm_eventhub implements PcoreValue {
     partition_count: number,
     resource_group_name: string,
     azurerm_eventhub_id?: string|null,
-    capture_description?: Azurerm_eventhub_capture_description_679[]|null,
+    capture_description?: Azurerm_eventhub_capture_description_91[]|null,
     location?: string|null,
     partition_ids?: string[]|null
   }) {
@@ -8531,8 +8531,8 @@ export class Azurerm_eventhub_authorization_ruleHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_eventhub_capture_description_679 implements PcoreValue {
-  readonly destination: Azurerm_eventhub_capture_description_679_destination_680[];
+export class Azurerm_eventhub_capture_description_91 implements PcoreValue {
+  readonly destination: Azurerm_eventhub_capture_description_91_destination_92[];
   readonly enabled: boolean;
   readonly encoding: string;
   readonly interval_in_seconds: number|null;
@@ -8545,7 +8545,7 @@ export class Azurerm_eventhub_capture_description_679 implements PcoreValue {
     interval_in_seconds = null,
     size_limit_in_bytes = null
   }: {
-    destination: Azurerm_eventhub_capture_description_679_destination_680[],
+    destination: Azurerm_eventhub_capture_description_91_destination_92[],
     enabled: boolean,
     encoding: string,
     interval_in_seconds?: number|null,
@@ -8573,11 +8573,11 @@ export class Azurerm_eventhub_capture_description_679 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_eventhub_capture_description_679';
+    return 'TerraformAzureRM::Azurerm_eventhub_capture_description_91';
   }
 }
 
-export class Azurerm_eventhub_capture_description_679_destination_680 implements PcoreValue {
+export class Azurerm_eventhub_capture_description_91_destination_92 implements PcoreValue {
   readonly archive_name_format: string;
   readonly blob_container_name: string;
   readonly name: string;
@@ -8610,7 +8610,7 @@ export class Azurerm_eventhub_capture_description_679_destination_680 implements
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_eventhub_capture_description_679_destination_680';
+    return 'TerraformAzureRM::Azurerm_eventhub_capture_description_91_destination_92';
   }
 }
 
@@ -8911,7 +8911,7 @@ export class Azurerm_express_route_circuit implements PcoreValue {
   readonly peering_location: string;
   readonly resource_group_name: string;
   readonly service_provider_name: string;
-  readonly sku: Azurerm_express_route_circuit_sku_681[];
+  readonly sku: Azurerm_express_route_circuit_sku_93[];
   readonly azurerm_express_route_circuit_id: string|null;
   readonly allow_classic_operations: boolean|null;
   readonly service_key: string|null;
@@ -8938,7 +8938,7 @@ export class Azurerm_express_route_circuit implements PcoreValue {
     peering_location: string,
     resource_group_name: string,
     service_provider_name: string,
-    sku: Azurerm_express_route_circuit_sku_681[],
+    sku: Azurerm_express_route_circuit_sku_93[],
     azurerm_express_route_circuit_id?: string|null,
     allow_classic_operations?: boolean|null,
     service_key?: string|null,
@@ -9073,7 +9073,7 @@ export class Azurerm_express_route_circuit_peering implements PcoreValue {
   readonly vlan_id: number;
   readonly azurerm_express_route_circuit_peering_id: string|null;
   readonly azure_asn: number|null;
-  readonly microsoft_peering_config: Azurerm_express_route_circuit_peering_microsoft_peering_config_682[]|null;
+  readonly microsoft_peering_config: Azurerm_express_route_circuit_peering_microsoft_peering_config_94[]|null;
   readonly peer_asn: number|null;
   readonly primary_azure_port: string|null;
   readonly secondary_azure_port: string|null;
@@ -9102,7 +9102,7 @@ export class Azurerm_express_route_circuit_peering implements PcoreValue {
     vlan_id: number,
     azurerm_express_route_circuit_peering_id?: string|null,
     azure_asn?: number|null,
-    microsoft_peering_config?: Azurerm_express_route_circuit_peering_microsoft_peering_config_682[]|null,
+    microsoft_peering_config?: Azurerm_express_route_circuit_peering_microsoft_peering_config_94[]|null,
     peer_asn?: number|null,
     primary_azure_port?: string|null,
     secondary_azure_port?: string|null,
@@ -9170,7 +9170,7 @@ export class Azurerm_express_route_circuit_peeringHandler implements PcoreValue 
   }
 }
 
-export class Azurerm_express_route_circuit_peering_microsoft_peering_config_682 implements PcoreValue {
+export class Azurerm_express_route_circuit_peering_microsoft_peering_config_94 implements PcoreValue {
   readonly advertised_public_prefixes: string[];
 
   constructor({
@@ -9188,11 +9188,11 @@ export class Azurerm_express_route_circuit_peering_microsoft_peering_config_682 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_express_route_circuit_peering_microsoft_peering_config_682';
+    return 'TerraformAzureRM::Azurerm_express_route_circuit_peering_microsoft_peering_config_94';
   }
 }
 
-export class Azurerm_express_route_circuit_sku_681 implements PcoreValue {
+export class Azurerm_express_route_circuit_sku_93 implements PcoreValue {
   readonly family: string;
   readonly tier: string;
 
@@ -9215,12 +9215,12 @@ export class Azurerm_express_route_circuit_sku_681 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_express_route_circuit_sku_681';
+    return 'TerraformAzureRM::Azurerm_express_route_circuit_sku_93';
   }
 }
 
 export class Azurerm_firewall implements PcoreValue {
-  readonly ip_configuration: Azurerm_firewall_ip_configuration_683[];
+  readonly ip_configuration: Azurerm_firewall_ip_configuration_95[];
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
@@ -9235,7 +9235,7 @@ export class Azurerm_firewall implements PcoreValue {
     azurerm_firewall_id = null,
     tags = null
   }: {
-    ip_configuration: Azurerm_firewall_ip_configuration_683[],
+    ip_configuration: Azurerm_firewall_ip_configuration_95[],
     location: string,
     name: string,
     resource_group_name: string,
@@ -9286,7 +9286,7 @@ export class Azurerm_firewall_application_rule_collection implements PcoreValue 
   readonly name: string;
   readonly priority: number;
   readonly resource_group_name: string;
-  readonly rule: Azurerm_firewall_application_rule_collection_rule_684[];
+  readonly rule: Azurerm_firewall_application_rule_collection_rule_96[];
   readonly azurerm_firewall_application_rule_collection_id: string|null;
 
   constructor({
@@ -9303,7 +9303,7 @@ export class Azurerm_firewall_application_rule_collection implements PcoreValue 
     name: string,
     priority: number,
     resource_group_name: string,
-    rule: Azurerm_firewall_application_rule_collection_rule_684[],
+    rule: Azurerm_firewall_application_rule_collection_rule_96[],
     azurerm_firewall_application_rule_collection_id?: string|null
   }) {
     this.action = action;
@@ -9344,12 +9344,12 @@ export class Azurerm_firewall_application_rule_collectionHandler implements Pcor
   }
 }
 
-export class Azurerm_firewall_application_rule_collection_rule_684 implements PcoreValue {
+export class Azurerm_firewall_application_rule_collection_rule_96 implements PcoreValue {
   readonly name: string;
   readonly source_addresses: string[];
   readonly description: string|null;
   readonly fqdn_tags: string[]|null;
-  readonly protocol: Azurerm_firewall_application_rule_collection_rule_684_protocol_685[]|null;
+  readonly protocol: Azurerm_firewall_application_rule_collection_rule_96_protocol_97[]|null;
   readonly target_fqdns: string[]|null;
 
   constructor({
@@ -9364,7 +9364,7 @@ export class Azurerm_firewall_application_rule_collection_rule_684 implements Pc
     source_addresses: string[],
     description?: string|null,
     fqdn_tags?: string[]|null,
-    protocol?: Azurerm_firewall_application_rule_collection_rule_684_protocol_685[]|null,
+    protocol?: Azurerm_firewall_application_rule_collection_rule_96_protocol_97[]|null,
     target_fqdns?: string[]|null
   }) {
     this.name = name;
@@ -9395,11 +9395,11 @@ export class Azurerm_firewall_application_rule_collection_rule_684 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_firewall_application_rule_collection_rule_684';
+    return 'TerraformAzureRM::Azurerm_firewall_application_rule_collection_rule_96';
   }
 }
 
-export class Azurerm_firewall_application_rule_collection_rule_684_protocol_685 implements PcoreValue {
+export class Azurerm_firewall_application_rule_collection_rule_96_protocol_97 implements PcoreValue {
   readonly type: string;
   readonly port: number|null;
 
@@ -9424,11 +9424,11 @@ export class Azurerm_firewall_application_rule_collection_rule_684_protocol_685 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_firewall_application_rule_collection_rule_684_protocol_685';
+    return 'TerraformAzureRM::Azurerm_firewall_application_rule_collection_rule_96_protocol_97';
   }
 }
 
-export class Azurerm_firewall_ip_configuration_683 implements PcoreValue {
+export class Azurerm_firewall_ip_configuration_95 implements PcoreValue {
   readonly name: string;
   readonly subnet_id: string;
   readonly internal_public_ip_address_id: string|null;
@@ -9472,7 +9472,7 @@ export class Azurerm_firewall_ip_configuration_683 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_firewall_ip_configuration_683';
+    return 'TerraformAzureRM::Azurerm_firewall_ip_configuration_95';
   }
 }
 
@@ -9482,7 +9482,7 @@ export class Azurerm_firewall_network_rule_collection implements PcoreValue {
   readonly name: string;
   readonly priority: number;
   readonly resource_group_name: string;
-  readonly rule: Azurerm_firewall_network_rule_collection_rule_686[];
+  readonly rule: Azurerm_firewall_network_rule_collection_rule_98[];
   readonly azurerm_firewall_network_rule_collection_id: string|null;
 
   constructor({
@@ -9499,7 +9499,7 @@ export class Azurerm_firewall_network_rule_collection implements PcoreValue {
     name: string,
     priority: number,
     resource_group_name: string,
-    rule: Azurerm_firewall_network_rule_collection_rule_686[],
+    rule: Azurerm_firewall_network_rule_collection_rule_98[],
     azurerm_firewall_network_rule_collection_id?: string|null
   }) {
     this.action = action;
@@ -9540,7 +9540,7 @@ export class Azurerm_firewall_network_rule_collectionHandler implements PcoreVal
   }
 }
 
-export class Azurerm_firewall_network_rule_collection_rule_686 implements PcoreValue {
+export class Azurerm_firewall_network_rule_collection_rule_98 implements PcoreValue {
   readonly destination_addresses: string[];
   readonly destination_ports: string[];
   readonly name: string;
@@ -9585,7 +9585,7 @@ export class Azurerm_firewall_network_rule_collection_rule_686 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_firewall_network_rule_collection_rule_686';
+    return 'TerraformAzureRM::Azurerm_firewall_network_rule_collection_rule_98';
   }
 }
 
@@ -9598,15 +9598,15 @@ export class Azurerm_function_app implements PcoreValue {
   readonly azurerm_function_app_id: string|null;
   readonly app_settings: {[s: string]: string}|null;
   readonly client_affinity_enabled: boolean|null;
-  readonly connection_string: Azurerm_function_app_connection_string_687[]|null;
+  readonly connection_string: Azurerm_function_app_connection_string_99[]|null;
   readonly default_hostname: string|null;
   readonly enable_builtin_logging: boolean|null;
   readonly enabled: boolean|null;
   readonly https_only: boolean|null;
-  readonly identity: Azurerm_function_app_identity_688[]|null;
+  readonly identity: Azurerm_function_app_identity_100[]|null;
   readonly outbound_ip_addresses: string|null;
-  readonly site_config: Azurerm_function_app_site_config_689[]|null;
-  readonly site_credential: Azurerm_function_app_site_credential_690[]|null;
+  readonly site_config: Azurerm_function_app_site_config_101[]|null;
+  readonly site_credential: Azurerm_function_app_site_credential_102[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly version: string|null;
 
@@ -9639,15 +9639,15 @@ export class Azurerm_function_app implements PcoreValue {
     azurerm_function_app_id?: string|null,
     app_settings?: {[s: string]: string}|null,
     client_affinity_enabled?: boolean|null,
-    connection_string?: Azurerm_function_app_connection_string_687[]|null,
+    connection_string?: Azurerm_function_app_connection_string_99[]|null,
     default_hostname?: string|null,
     enable_builtin_logging?: boolean|null,
     enabled?: boolean|null,
     https_only?: boolean|null,
-    identity?: Azurerm_function_app_identity_688[]|null,
+    identity?: Azurerm_function_app_identity_100[]|null,
     outbound_ip_addresses?: string|null,
-    site_config?: Azurerm_function_app_site_config_689[]|null,
-    site_credential?: Azurerm_function_app_site_credential_690[]|null,
+    site_config?: Azurerm_function_app_site_config_101[]|null,
+    site_credential?: Azurerm_function_app_site_credential_102[]|null,
     tags?: {[s: string]: string}|null,
     version?: string|null
   }) {
@@ -9739,7 +9739,7 @@ export class Azurerm_function_appHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_function_app_connection_string_687 implements PcoreValue {
+export class Azurerm_function_app_connection_string_99 implements PcoreValue {
   readonly name: string;
   readonly type: string;
   readonly value: string;
@@ -9767,11 +9767,11 @@ export class Azurerm_function_app_connection_string_687 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_function_app_connection_string_687';
+    return 'TerraformAzureRM::Azurerm_function_app_connection_string_99';
   }
 }
 
-export class Azurerm_function_app_identity_688 implements PcoreValue {
+export class Azurerm_function_app_identity_100 implements PcoreValue {
   readonly type: string;
   readonly principal_id: string|null;
   readonly tenant_id: string|null;
@@ -9803,11 +9803,11 @@ export class Azurerm_function_app_identity_688 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_function_app_identity_688';
+    return 'TerraformAzureRM::Azurerm_function_app_identity_100';
   }
 }
 
-export class Azurerm_function_app_site_config_689 implements PcoreValue {
+export class Azurerm_function_app_site_config_101 implements PcoreValue {
   readonly always_on: boolean|null;
   readonly use_32_bit_worker_process: boolean|null;
   readonly websockets_enabled: boolean|null;
@@ -9841,11 +9841,11 @@ export class Azurerm_function_app_site_config_689 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_function_app_site_config_689';
+    return 'TerraformAzureRM::Azurerm_function_app_site_config_101';
   }
 }
 
-export class Azurerm_function_app_site_credential_690 implements PcoreValue {
+export class Azurerm_function_app_site_credential_102 implements PcoreValue {
   readonly password: string|null;
   readonly username: string|null;
 
@@ -9872,7 +9872,7 @@ export class Azurerm_function_app_site_credential_690 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_function_app_site_credential_690';
+    return 'TerraformAzureRM::Azurerm_function_app_site_credential_102';
   }
 }
 
@@ -9881,8 +9881,8 @@ export class Azurerm_image implements PcoreValue {
   readonly name: string;
   readonly resource_group_name: string;
   readonly azurerm_image_id: string|null;
-  readonly data_disk: Azurerm_image_data_disk_691[]|null;
-  readonly os_disk: Azurerm_image_os_disk_692[]|null;
+  readonly data_disk: Azurerm_image_data_disk_103[]|null;
+  readonly os_disk: Azurerm_image_os_disk_104[]|null;
   readonly source_virtual_machine_id: string|null;
   readonly tags: {[s: string]: string}|null;
 
@@ -9900,8 +9900,8 @@ export class Azurerm_image implements PcoreValue {
     name: string,
     resource_group_name: string,
     azurerm_image_id?: string|null,
-    data_disk?: Azurerm_image_data_disk_691[]|null,
-    os_disk?: Azurerm_image_os_disk_692[]|null,
+    data_disk?: Azurerm_image_data_disk_103[]|null,
+    os_disk?: Azurerm_image_os_disk_104[]|null,
     source_virtual_machine_id?: string|null,
     tags?: {[s: string]: string}|null
   }) {
@@ -9953,7 +9953,7 @@ export class Azurerm_imageHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_image_data_disk_691 implements PcoreValue {
+export class Azurerm_image_data_disk_103 implements PcoreValue {
   readonly blob_uri: string|null;
   readonly caching: string|null;
   readonly lun: number|null;
@@ -10001,11 +10001,11 @@ export class Azurerm_image_data_disk_691 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_image_data_disk_691';
+    return 'TerraformAzureRM::Azurerm_image_data_disk_103';
   }
 }
 
-export class Azurerm_image_os_disk_692 implements PcoreValue {
+export class Azurerm_image_os_disk_104 implements PcoreValue {
   readonly blob_uri: string|null;
   readonly caching: string|null;
   readonly managed_disk_id: string|null;
@@ -10060,7 +10060,7 @@ export class Azurerm_image_os_disk_692 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_image_os_disk_692';
+    return 'TerraformAzureRM::Azurerm_image_os_disk_104';
   }
 }
 
@@ -10068,16 +10068,16 @@ export class Azurerm_iothub implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_iothub_sku_696[];
+  readonly sku: Azurerm_iothub_sku_108[];
   readonly azurerm_iothub_id: string|null;
-  readonly endpoint: Azurerm_iothub_endpoint_693[]|null;
+  readonly endpoint: Azurerm_iothub_endpoint_105[]|null;
   readonly event_hub_events_endpoint: string|null;
   readonly event_hub_events_path: string|null;
   readonly event_hub_operations_endpoint: string|null;
   readonly event_hub_operations_path: string|null;
   readonly hostname: string|null;
-  readonly route: Azurerm_iothub_route_694[]|null;
-  readonly shared_access_policy: Azurerm_iothub_shared_access_policy_695[]|null;
+  readonly route: Azurerm_iothub_route_106[]|null;
+  readonly shared_access_policy: Azurerm_iothub_shared_access_policy_107[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly type: string|null;
 
@@ -10101,16 +10101,16 @@ export class Azurerm_iothub implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_iothub_sku_696[],
+    sku: Azurerm_iothub_sku_108[],
     azurerm_iothub_id?: string|null,
-    endpoint?: Azurerm_iothub_endpoint_693[]|null,
+    endpoint?: Azurerm_iothub_endpoint_105[]|null,
     event_hub_events_endpoint?: string|null,
     event_hub_events_path?: string|null,
     event_hub_operations_endpoint?: string|null,
     event_hub_operations_path?: string|null,
     hostname?: string|null,
-    route?: Azurerm_iothub_route_694[]|null,
-    shared_access_policy?: Azurerm_iothub_shared_access_policy_695[]|null,
+    route?: Azurerm_iothub_route_106[]|null,
+    shared_access_policy?: Azurerm_iothub_shared_access_policy_107[]|null,
     tags?: {[s: string]: string}|null,
     type?: string|null
   }) {
@@ -10242,7 +10242,7 @@ export class Azurerm_iothub_consumer_groupHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_iothub_endpoint_693 implements PcoreValue {
+export class Azurerm_iothub_endpoint_105 implements PcoreValue {
   readonly connection_string: string;
   readonly name: string;
   readonly type: string;
@@ -10305,11 +10305,11 @@ export class Azurerm_iothub_endpoint_693 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_iothub_endpoint_693';
+    return 'TerraformAzureRM::Azurerm_iothub_endpoint_105';
   }
 }
 
-export class Azurerm_iothub_route_694 implements PcoreValue {
+export class Azurerm_iothub_route_106 implements PcoreValue {
   readonly enabled: boolean;
   readonly endpoint_names: string[];
   readonly name: string;
@@ -10349,11 +10349,11 @@ export class Azurerm_iothub_route_694 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_iothub_route_694';
+    return 'TerraformAzureRM::Azurerm_iothub_route_106';
   }
 }
 
-export class Azurerm_iothub_shared_access_policy_695 implements PcoreValue {
+export class Azurerm_iothub_shared_access_policy_107 implements PcoreValue {
   readonly key_name: string|null;
   readonly permissions: string|null;
   readonly primary_key: string|null;
@@ -10394,11 +10394,11 @@ export class Azurerm_iothub_shared_access_policy_695 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_iothub_shared_access_policy_695';
+    return 'TerraformAzureRM::Azurerm_iothub_shared_access_policy_107';
   }
 }
 
-export class Azurerm_iothub_sku_696 implements PcoreValue {
+export class Azurerm_iothub_sku_108 implements PcoreValue {
   readonly capacity: number;
   readonly name: string;
   readonly tier: string;
@@ -10426,7 +10426,7 @@ export class Azurerm_iothub_sku_696 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_iothub_sku_696';
+    return 'TerraformAzureRM::Azurerm_iothub_sku_108';
   }
 }
 
@@ -10434,14 +10434,14 @@ export class Azurerm_key_vault implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_key_vault_sku_699[];
+  readonly sku: Azurerm_key_vault_sku_111[];
   readonly tenant_id: string;
   readonly azurerm_key_vault_id: string|null;
-  readonly access_policy: Azurerm_key_vault_access_policy_697[]|null;
+  readonly access_policy: Azurerm_key_vault_access_policy_109[]|null;
   readonly enabled_for_deployment: boolean|null;
   readonly enabled_for_disk_encryption: boolean|null;
   readonly enabled_for_template_deployment: boolean|null;
-  readonly network_acls: Azurerm_key_vault_network_acls_698[]|null;
+  readonly network_acls: Azurerm_key_vault_network_acls_110[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly vault_uri: string|null;
 
@@ -10463,14 +10463,14 @@ export class Azurerm_key_vault implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_key_vault_sku_699[],
+    sku: Azurerm_key_vault_sku_111[],
     tenant_id: string,
     azurerm_key_vault_id?: string|null,
-    access_policy?: Azurerm_key_vault_access_policy_697[]|null,
+    access_policy?: Azurerm_key_vault_access_policy_109[]|null,
     enabled_for_deployment?: boolean|null,
     enabled_for_disk_encryption?: boolean|null,
     enabled_for_template_deployment?: boolean|null,
-    network_acls?: Azurerm_key_vault_network_acls_698[]|null,
+    network_acls?: Azurerm_key_vault_network_acls_110[]|null,
     tags?: {[s: string]: string}|null,
     vault_uri?: string|null
   }) {
@@ -10620,7 +10620,7 @@ export class Azurerm_key_vault_access_policyHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_key_vault_access_policy_697 implements PcoreValue {
+export class Azurerm_key_vault_access_policy_109 implements PcoreValue {
   readonly object_id: string;
   readonly tenant_id: string;
   readonly application_id: string|null;
@@ -10671,16 +10671,16 @@ export class Azurerm_key_vault_access_policy_697 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_access_policy_697';
+    return 'TerraformAzureRM::Azurerm_key_vault_access_policy_109';
   }
 }
 
 export class Azurerm_key_vault_certificate implements PcoreValue {
-  readonly certificate_policy: Azurerm_key_vault_certificate_certificate_policy_701[];
+  readonly certificate_policy: Azurerm_key_vault_certificate_certificate_policy_113[];
   readonly name: string;
   readonly vault_uri: string;
   readonly azurerm_key_vault_certificate_id: string|null;
-  readonly certificate: Azurerm_key_vault_certificate_certificate_700[]|null;
+  readonly certificate: Azurerm_key_vault_certificate_certificate_112[]|null;
   readonly certificate_data: string|null;
   readonly secret_id: string|null;
   readonly tags: {[s: string]: string}|null;
@@ -10699,11 +10699,11 @@ export class Azurerm_key_vault_certificate implements PcoreValue {
     thumbprint = null,
     version = null
   }: {
-    certificate_policy: Azurerm_key_vault_certificate_certificate_policy_701[],
+    certificate_policy: Azurerm_key_vault_certificate_certificate_policy_113[],
     name: string,
     vault_uri: string,
     azurerm_key_vault_certificate_id?: string|null,
-    certificate?: Azurerm_key_vault_certificate_certificate_700[]|null,
+    certificate?: Azurerm_key_vault_certificate_certificate_112[]|null,
     certificate_data?: string|null,
     secret_id?: string|null,
     tags?: {[s: string]: string}|null,
@@ -10766,7 +10766,7 @@ export class Azurerm_key_vault_certificateHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_700 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_112 implements PcoreValue {
   readonly contents: string;
   readonly password: string|null;
 
@@ -10791,16 +10791,16 @@ export class Azurerm_key_vault_certificate_certificate_700 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_700';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_112';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701 implements PcoreValue {
-  readonly issuer_parameters: Azurerm_key_vault_certificate_certificate_policy_701_issuer_parameters_702[];
-  readonly key_properties: Azurerm_key_vault_certificate_certificate_policy_701_key_properties_703[];
-  readonly secret_properties: Azurerm_key_vault_certificate_certificate_policy_701_secret_properties_707[];
-  readonly lifetime_action: Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704[]|null;
-  readonly x509_certificate_properties: Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708[]|null;
+export class Azurerm_key_vault_certificate_certificate_policy_113 implements PcoreValue {
+  readonly issuer_parameters: Azurerm_key_vault_certificate_certificate_policy_113_issuer_parameters_114[];
+  readonly key_properties: Azurerm_key_vault_certificate_certificate_policy_113_key_properties_115[];
+  readonly secret_properties: Azurerm_key_vault_certificate_certificate_policy_113_secret_properties_119[];
+  readonly lifetime_action: Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116[]|null;
+  readonly x509_certificate_properties: Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120[]|null;
 
   constructor({
     issuer_parameters,
@@ -10809,11 +10809,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701 implements Pco
     lifetime_action = null,
     x509_certificate_properties = null
   }: {
-    issuer_parameters: Azurerm_key_vault_certificate_certificate_policy_701_issuer_parameters_702[],
-    key_properties: Azurerm_key_vault_certificate_certificate_policy_701_key_properties_703[],
-    secret_properties: Azurerm_key_vault_certificate_certificate_policy_701_secret_properties_707[],
-    lifetime_action?: Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704[]|null,
-    x509_certificate_properties?: Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708[]|null
+    issuer_parameters: Azurerm_key_vault_certificate_certificate_policy_113_issuer_parameters_114[],
+    key_properties: Azurerm_key_vault_certificate_certificate_policy_113_key_properties_115[],
+    secret_properties: Azurerm_key_vault_certificate_certificate_policy_113_secret_properties_119[],
+    lifetime_action?: Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116[]|null,
+    x509_certificate_properties?: Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120[]|null
   }) {
     this.issuer_parameters = issuer_parameters;
     this.key_properties = key_properties;
@@ -10837,11 +10837,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_issuer_parameters_702 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_issuer_parameters_114 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -10859,11 +10859,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_issuer_paramet
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_issuer_parameters_702';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_issuer_parameters_114';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_key_properties_703 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_key_properties_115 implements PcoreValue {
   readonly exportable: boolean;
   readonly key_size: number;
   readonly key_type: string;
@@ -10896,20 +10896,20 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_key_properties
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_key_properties_703';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_key_properties_115';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704 implements PcoreValue {
-  readonly action: Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_action_705[];
-  readonly trigger: Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_trigger_706[];
+export class Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116 implements PcoreValue {
+  readonly action: Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_action_117[];
+  readonly trigger: Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_trigger_118[];
 
   constructor({
     action,
     trigger
   }: {
-    action: Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_action_705[],
-    trigger: Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_trigger_706[]
+    action: Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_action_117[],
+    trigger: Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_trigger_118[]
   }) {
     this.action = action;
     this.trigger = trigger;
@@ -10923,11 +10923,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_lifetime_actio
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_action_705 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_action_117 implements PcoreValue {
   readonly action_type: string;
 
   constructor({
@@ -10945,11 +10945,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_lifetime_actio
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_action_705';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_action_117';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_trigger_706 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_trigger_118 implements PcoreValue {
   readonly days_before_expiry: number|null;
   readonly lifetime_percentage: number|null;
 
@@ -10976,11 +10976,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_lifetime_actio
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_lifetime_action_704_trigger_706';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_lifetime_action_116_trigger_118';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_secret_properties_707 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_secret_properties_119 implements PcoreValue {
   readonly content_type: string;
 
   constructor({
@@ -10998,16 +10998,16 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_secret_propert
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_secret_properties_707';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_secret_properties_119';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120 implements PcoreValue {
   readonly key_usage: string[];
   readonly subject: string;
   readonly validity_in_months: number;
   readonly extended_key_usage: string[]|null;
-  readonly subject_alternative_names: Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708_subject_alternative_names_709[]|null;
+  readonly subject_alternative_names: Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120_subject_alternative_names_121[]|null;
 
   constructor({
     key_usage,
@@ -11020,7 +11020,7 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_x509_certifica
     subject: string,
     validity_in_months: number,
     extended_key_usage?: string[]|null,
-    subject_alternative_names?: Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708_subject_alternative_names_709[]|null
+    subject_alternative_names?: Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120_subject_alternative_names_121[]|null
   }) {
     this.key_usage = key_usage;
     this.subject = subject;
@@ -11044,11 +11044,11 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_x509_certifica
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120';
   }
 }
 
-export class Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708_subject_alternative_names_709 implements PcoreValue {
+export class Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120_subject_alternative_names_121 implements PcoreValue {
   readonly dns_names: string[]|null;
   readonly emails: string[]|null;
   readonly upns: string[]|null;
@@ -11082,7 +11082,7 @@ export class Azurerm_key_vault_certificate_certificate_policy_701_x509_certifica
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_701_x509_certificate_properties_708_subject_alternative_names_709';
+    return 'TerraformAzureRM::Azurerm_key_vault_certificate_certificate_policy_113_x509_certificate_properties_120_subject_alternative_names_121';
   }
 }
 
@@ -11173,7 +11173,7 @@ export class Azurerm_key_vault_keyHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_key_vault_network_acls_698 implements PcoreValue {
+export class Azurerm_key_vault_network_acls_110 implements PcoreValue {
   readonly bypass: string;
   readonly default_action: string;
   readonly ip_rules: string[]|null;
@@ -11210,7 +11210,7 @@ export class Azurerm_key_vault_network_acls_698 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_network_acls_698';
+    return 'TerraformAzureRM::Azurerm_key_vault_network_acls_110';
   }
 }
 
@@ -11284,7 +11284,7 @@ export class Azurerm_key_vault_secretHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_key_vault_sku_699 implements PcoreValue {
+export class Azurerm_key_vault_sku_111 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -11302,29 +11302,29 @@ export class Azurerm_key_vault_sku_699 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_key_vault_sku_699';
+    return 'TerraformAzureRM::Azurerm_key_vault_sku_111';
   }
 }
 
 export class Azurerm_kubernetes_cluster implements PcoreValue {
-  readonly agent_pool_profile: Azurerm_kubernetes_cluster_agent_pool_profile_714[];
+  readonly agent_pool_profile: Azurerm_kubernetes_cluster_agent_pool_profile_126[];
   readonly dns_prefix: string;
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly service_principal: Azurerm_kubernetes_cluster_service_principal_722[];
+  readonly service_principal: Azurerm_kubernetes_cluster_service_principal_134[];
   readonly azurerm_kubernetes_cluster_id: string|null;
-  readonly addon_profile: Azurerm_kubernetes_cluster_addon_profile_710[]|null;
+  readonly addon_profile: Azurerm_kubernetes_cluster_addon_profile_122[]|null;
   readonly fqdn: string|null;
-  readonly kube_admin_config: Azurerm_kubernetes_cluster_kube_admin_config_715[]|null;
+  readonly kube_admin_config: Azurerm_kubernetes_cluster_kube_admin_config_127[]|null;
   readonly kube_admin_config_raw: string|null;
-  readonly kube_config: Azurerm_kubernetes_cluster_kube_config_716[]|null;
+  readonly kube_config: Azurerm_kubernetes_cluster_kube_config_128[]|null;
   readonly kube_config_raw: string|null;
   readonly kubernetes_version: string|null;
-  readonly linux_profile: Azurerm_kubernetes_cluster_linux_profile_717[]|null;
-  readonly network_profile: Azurerm_kubernetes_cluster_network_profile_719[]|null;
+  readonly linux_profile: Azurerm_kubernetes_cluster_linux_profile_129[]|null;
+  readonly network_profile: Azurerm_kubernetes_cluster_network_profile_131[]|null;
   readonly node_resource_group: string|null;
-  readonly role_based_access_control: Azurerm_kubernetes_cluster_role_based_access_control_720[]|null;
+  readonly role_based_access_control: Azurerm_kubernetes_cluster_role_based_access_control_132[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -11348,24 +11348,24 @@ export class Azurerm_kubernetes_cluster implements PcoreValue {
     role_based_access_control = null,
     tags = null
   }: {
-    agent_pool_profile: Azurerm_kubernetes_cluster_agent_pool_profile_714[],
+    agent_pool_profile: Azurerm_kubernetes_cluster_agent_pool_profile_126[],
     dns_prefix: string,
     location: string,
     name: string,
     resource_group_name: string,
-    service_principal: Azurerm_kubernetes_cluster_service_principal_722[],
+    service_principal: Azurerm_kubernetes_cluster_service_principal_134[],
     azurerm_kubernetes_cluster_id?: string|null,
-    addon_profile?: Azurerm_kubernetes_cluster_addon_profile_710[]|null,
+    addon_profile?: Azurerm_kubernetes_cluster_addon_profile_122[]|null,
     fqdn?: string|null,
-    kube_admin_config?: Azurerm_kubernetes_cluster_kube_admin_config_715[]|null,
+    kube_admin_config?: Azurerm_kubernetes_cluster_kube_admin_config_127[]|null,
     kube_admin_config_raw?: string|null,
-    kube_config?: Azurerm_kubernetes_cluster_kube_config_716[]|null,
+    kube_config?: Azurerm_kubernetes_cluster_kube_config_128[]|null,
     kube_config_raw?: string|null,
     kubernetes_version?: string|null,
-    linux_profile?: Azurerm_kubernetes_cluster_linux_profile_717[]|null,
-    network_profile?: Azurerm_kubernetes_cluster_network_profile_719[]|null,
+    linux_profile?: Azurerm_kubernetes_cluster_linux_profile_129[]|null,
+    network_profile?: Azurerm_kubernetes_cluster_network_profile_131[]|null,
     node_resource_group?: string|null,
-    role_based_access_control?: Azurerm_kubernetes_cluster_role_based_access_control_720[]|null,
+    role_based_access_control?: Azurerm_kubernetes_cluster_role_based_access_control_132[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.agent_pool_profile = agent_pool_profile;
@@ -11454,19 +11454,19 @@ export class Azurerm_kubernetes_clusterHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_kubernetes_cluster_addon_profile_710 implements PcoreValue {
-  readonly aci_connector_linux: Azurerm_kubernetes_cluster_addon_profile_710_aci_connector_linux_711[]|null;
-  readonly http_application_routing: Azurerm_kubernetes_cluster_addon_profile_710_http_application_routing_712[]|null;
-  readonly oms_agent: Azurerm_kubernetes_cluster_addon_profile_710_oms_agent_713[]|null;
+export class Azurerm_kubernetes_cluster_addon_profile_122 implements PcoreValue {
+  readonly aci_connector_linux: Azurerm_kubernetes_cluster_addon_profile_122_aci_connector_linux_123[]|null;
+  readonly http_application_routing: Azurerm_kubernetes_cluster_addon_profile_122_http_application_routing_124[]|null;
+  readonly oms_agent: Azurerm_kubernetes_cluster_addon_profile_122_oms_agent_125[]|null;
 
   constructor({
     aci_connector_linux = null,
     http_application_routing = null,
     oms_agent = null
   }: {
-    aci_connector_linux?: Azurerm_kubernetes_cluster_addon_profile_710_aci_connector_linux_711[]|null,
-    http_application_routing?: Azurerm_kubernetes_cluster_addon_profile_710_http_application_routing_712[]|null,
-    oms_agent?: Azurerm_kubernetes_cluster_addon_profile_710_oms_agent_713[]|null
+    aci_connector_linux?: Azurerm_kubernetes_cluster_addon_profile_122_aci_connector_linux_123[]|null,
+    http_application_routing?: Azurerm_kubernetes_cluster_addon_profile_122_http_application_routing_124[]|null,
+    oms_agent?: Azurerm_kubernetes_cluster_addon_profile_122_oms_agent_125[]|null
   }) {
     this.aci_connector_linux = aci_connector_linux;
     this.http_application_routing = http_application_routing;
@@ -11488,11 +11488,11 @@ export class Azurerm_kubernetes_cluster_addon_profile_710 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_710';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_122';
   }
 }
 
-export class Azurerm_kubernetes_cluster_addon_profile_710_aci_connector_linux_711 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_addon_profile_122_aci_connector_linux_123 implements PcoreValue {
   readonly enabled: boolean;
   readonly subnet_name: string;
 
@@ -11515,11 +11515,11 @@ export class Azurerm_kubernetes_cluster_addon_profile_710_aci_connector_linux_71
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_710_aci_connector_linux_711';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_122_aci_connector_linux_123';
   }
 }
 
-export class Azurerm_kubernetes_cluster_addon_profile_710_http_application_routing_712 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_addon_profile_122_http_application_routing_124 implements PcoreValue {
   readonly enabled: boolean;
   readonly http_application_routing_zone_name: string|null;
 
@@ -11544,11 +11544,11 @@ export class Azurerm_kubernetes_cluster_addon_profile_710_http_application_routi
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_710_http_application_routing_712';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_122_http_application_routing_124';
   }
 }
 
-export class Azurerm_kubernetes_cluster_addon_profile_710_oms_agent_713 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_addon_profile_122_oms_agent_125 implements PcoreValue {
   readonly enabled: boolean;
   readonly log_analytics_workspace_id: string;
 
@@ -11571,11 +11571,11 @@ export class Azurerm_kubernetes_cluster_addon_profile_710_oms_agent_713 implemen
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_710_oms_agent_713';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_addon_profile_122_oms_agent_125';
   }
 }
 
-export class Azurerm_kubernetes_cluster_agent_pool_profile_714 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_agent_pool_profile_126 implements PcoreValue {
   readonly name: string;
   readonly vm_size: string;
   readonly count: number|null;
@@ -11647,11 +11647,11 @@ export class Azurerm_kubernetes_cluster_agent_pool_profile_714 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_agent_pool_profile_714';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_agent_pool_profile_126';
   }
 }
 
-export class Azurerm_kubernetes_cluster_kube_admin_config_715 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_kube_admin_config_127 implements PcoreValue {
   readonly client_certificate: string|null;
   readonly client_key: string|null;
   readonly cluster_ca_certificate: string|null;
@@ -11706,11 +11706,11 @@ export class Azurerm_kubernetes_cluster_kube_admin_config_715 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_kube_admin_config_715';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_kube_admin_config_127';
   }
 }
 
-export class Azurerm_kubernetes_cluster_kube_config_716 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_kube_config_128 implements PcoreValue {
   readonly client_certificate: string|null;
   readonly client_key: string|null;
   readonly cluster_ca_certificate: string|null;
@@ -11765,20 +11765,20 @@ export class Azurerm_kubernetes_cluster_kube_config_716 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_kube_config_716';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_kube_config_128';
   }
 }
 
-export class Azurerm_kubernetes_cluster_linux_profile_717 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_linux_profile_129 implements PcoreValue {
   readonly admin_username: string;
-  readonly ssh_key: Azurerm_kubernetes_cluster_linux_profile_717_ssh_key_718[];
+  readonly ssh_key: Azurerm_kubernetes_cluster_linux_profile_129_ssh_key_130[];
 
   constructor({
     admin_username,
     ssh_key
   }: {
     admin_username: string,
-    ssh_key: Azurerm_kubernetes_cluster_linux_profile_717_ssh_key_718[]
+    ssh_key: Azurerm_kubernetes_cluster_linux_profile_129_ssh_key_130[]
   }) {
     this.admin_username = admin_username;
     this.ssh_key = ssh_key;
@@ -11792,11 +11792,11 @@ export class Azurerm_kubernetes_cluster_linux_profile_717 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_linux_profile_717';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_linux_profile_129';
   }
 }
 
-export class Azurerm_kubernetes_cluster_linux_profile_717_ssh_key_718 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_linux_profile_129_ssh_key_130 implements PcoreValue {
   readonly key_data: string;
 
   constructor({
@@ -11814,11 +11814,11 @@ export class Azurerm_kubernetes_cluster_linux_profile_717_ssh_key_718 implements
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_linux_profile_717_ssh_key_718';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_linux_profile_129_ssh_key_130';
   }
 }
 
-export class Azurerm_kubernetes_cluster_network_profile_719 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_network_profile_131 implements PcoreValue {
   readonly network_plugin: string;
   readonly dns_service_ip: string|null;
   readonly docker_bridge_cidr: string|null;
@@ -11864,20 +11864,20 @@ export class Azurerm_kubernetes_cluster_network_profile_719 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_network_profile_719';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_network_profile_131';
   }
 }
 
-export class Azurerm_kubernetes_cluster_role_based_access_control_720 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_role_based_access_control_132 implements PcoreValue {
   readonly enabled: boolean;
-  readonly azure_active_directory: Azurerm_kubernetes_cluster_role_based_access_control_720_azure_active_directory_721[]|null;
+  readonly azure_active_directory: Azurerm_kubernetes_cluster_role_based_access_control_132_azure_active_directory_133[]|null;
 
   constructor({
     enabled,
     azure_active_directory = null
   }: {
     enabled: boolean,
-    azure_active_directory?: Azurerm_kubernetes_cluster_role_based_access_control_720_azure_active_directory_721[]|null
+    azure_active_directory?: Azurerm_kubernetes_cluster_role_based_access_control_132_azure_active_directory_133[]|null
   }) {
     this.enabled = enabled;
     this.azure_active_directory = azure_active_directory;
@@ -11893,11 +11893,11 @@ export class Azurerm_kubernetes_cluster_role_based_access_control_720 implements
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_role_based_access_control_720';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_role_based_access_control_132';
   }
 }
 
-export class Azurerm_kubernetes_cluster_role_based_access_control_720_azure_active_directory_721 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_role_based_access_control_132_azure_active_directory_133 implements PcoreValue {
   readonly client_app_id: string;
   readonly server_app_id: string;
   readonly server_app_secret: string;
@@ -11932,11 +11932,11 @@ export class Azurerm_kubernetes_cluster_role_based_access_control_720_azure_acti
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_role_based_access_control_720_azure_active_directory_721';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_role_based_access_control_132_azure_active_directory_133';
   }
 }
 
-export class Azurerm_kubernetes_cluster_service_principal_722 implements PcoreValue {
+export class Azurerm_kubernetes_cluster_service_principal_134 implements PcoreValue {
   readonly client_id: string;
   readonly client_secret: string;
 
@@ -11959,7 +11959,7 @@ export class Azurerm_kubernetes_cluster_service_principal_722 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_service_principal_722';
+    return 'TerraformAzureRM::Azurerm_kubernetes_cluster_service_principal_134';
   }
 }
 
@@ -11968,7 +11968,7 @@ export class Azurerm_lb implements PcoreValue {
   readonly name: string;
   readonly resource_group_name: string;
   readonly azurerm_lb_id: string|null;
-  readonly frontend_ip_configuration: Azurerm_lb_frontend_ip_configuration_723[]|null;
+  readonly frontend_ip_configuration: Azurerm_lb_frontend_ip_configuration_135[]|null;
   readonly private_ip_address: string|null;
   readonly private_ip_addresses: string[]|null;
   readonly sku: string|null;
@@ -11989,7 +11989,7 @@ export class Azurerm_lb implements PcoreValue {
     name: string,
     resource_group_name: string,
     azurerm_lb_id?: string|null,
-    frontend_ip_configuration?: Azurerm_lb_frontend_ip_configuration_723[]|null,
+    frontend_ip_configuration?: Azurerm_lb_frontend_ip_configuration_135[]|null,
     private_ip_address?: string|null,
     private_ip_addresses?: string[]|null,
     sku?: string|null,
@@ -12117,7 +12117,7 @@ export class Azurerm_lb_backend_address_poolHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_lb_frontend_ip_configuration_723 implements PcoreValue {
+export class Azurerm_lb_frontend_ip_configuration_135 implements PcoreValue {
   readonly name: string;
   readonly inbound_nat_rules: string[]|null;
   readonly load_balancer_rules: string[]|null;
@@ -12184,7 +12184,7 @@ export class Azurerm_lb_frontend_ip_configuration_723 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_lb_frontend_ip_configuration_723';
+    return 'TerraformAzureRM::Azurerm_lb_frontend_ip_configuration_135';
   }
 }
 
@@ -12594,7 +12594,7 @@ export class Azurerm_local_network_gateway implements PcoreValue {
   readonly name: string;
   readonly resource_group_name: string;
   readonly azurerm_local_network_gateway_id: string|null;
-  readonly bgp_settings: Azurerm_local_network_gateway_bgp_settings_724[]|null;
+  readonly bgp_settings: Azurerm_local_network_gateway_bgp_settings_136[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -12613,7 +12613,7 @@ export class Azurerm_local_network_gateway implements PcoreValue {
     name: string,
     resource_group_name: string,
     azurerm_local_network_gateway_id?: string|null,
-    bgp_settings?: Azurerm_local_network_gateway_bgp_settings_724[]|null,
+    bgp_settings?: Azurerm_local_network_gateway_bgp_settings_136[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.address_space = address_space;
@@ -12660,7 +12660,7 @@ export class Azurerm_local_network_gatewayHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_local_network_gateway_bgp_settings_724 implements PcoreValue {
+export class Azurerm_local_network_gateway_bgp_settings_136 implements PcoreValue {
   readonly asn: number;
   readonly bgp_peering_address: string;
   readonly peer_weight: number|null;
@@ -12690,13 +12690,13 @@ export class Azurerm_local_network_gateway_bgp_settings_724 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_local_network_gateway_bgp_settings_724';
+    return 'TerraformAzureRM::Azurerm_local_network_gateway_bgp_settings_136';
   }
 }
 
 export class Azurerm_log_analytics_solution implements PcoreValue {
   readonly location: string;
-  readonly plan: Azurerm_log_analytics_solution_plan_725[];
+  readonly plan: Azurerm_log_analytics_solution_plan_137[];
   readonly resource_group_name: string;
   readonly solution_name: string;
   readonly workspace_name: string;
@@ -12713,7 +12713,7 @@ export class Azurerm_log_analytics_solution implements PcoreValue {
     azurerm_log_analytics_solution_id = null
   }: {
     location: string,
-    plan: Azurerm_log_analytics_solution_plan_725[],
+    plan: Azurerm_log_analytics_solution_plan_137[],
     resource_group_name: string,
     solution_name: string,
     workspace_name: string,
@@ -12758,7 +12758,7 @@ export class Azurerm_log_analytics_solutionHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_log_analytics_solution_plan_725 implements PcoreValue {
+export class Azurerm_log_analytics_solution_plan_137 implements PcoreValue {
   readonly product: string;
   readonly publisher: string;
   readonly name: string|null;
@@ -12795,7 +12795,7 @@ export class Azurerm_log_analytics_solution_plan_725 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_log_analytics_solution_plan_725';
+    return 'TerraformAzureRM::Azurerm_log_analytics_solution_plan_137';
   }
 }
 
@@ -13340,7 +13340,7 @@ export class Azurerm_managed_disk implements PcoreValue {
   readonly storage_account_type: string;
   readonly azurerm_managed_disk_id: string|null;
   readonly disk_size_gb: number|null;
-  readonly encryption_settings: Azurerm_managed_disk_encryption_settings_726[]|null;
+  readonly encryption_settings: Azurerm_managed_disk_encryption_settings_138[]|null;
   readonly image_reference_id: string|null;
   readonly os_type: string|null;
   readonly source_resource_id: string|null;
@@ -13371,7 +13371,7 @@ export class Azurerm_managed_disk implements PcoreValue {
     storage_account_type: string,
     azurerm_managed_disk_id?: string|null,
     disk_size_gb?: number|null,
-    encryption_settings?: Azurerm_managed_disk_encryption_settings_726[]|null,
+    encryption_settings?: Azurerm_managed_disk_encryption_settings_138[]|null,
     image_reference_id?: string|null,
     os_type?: string|null,
     source_resource_id?: string|null,
@@ -13447,10 +13447,10 @@ export class Azurerm_managed_diskHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_managed_disk_encryption_settings_726 implements PcoreValue {
+export class Azurerm_managed_disk_encryption_settings_138 implements PcoreValue {
   readonly enabled: boolean;
-  readonly disk_encryption_key: Azurerm_managed_disk_encryption_settings_726_disk_encryption_key_727[]|null;
-  readonly key_encryption_key: Azurerm_managed_disk_encryption_settings_726_key_encryption_key_728[]|null;
+  readonly disk_encryption_key: Azurerm_managed_disk_encryption_settings_138_disk_encryption_key_139[]|null;
+  readonly key_encryption_key: Azurerm_managed_disk_encryption_settings_138_key_encryption_key_140[]|null;
 
   constructor({
     enabled,
@@ -13458,8 +13458,8 @@ export class Azurerm_managed_disk_encryption_settings_726 implements PcoreValue 
     key_encryption_key = null
   }: {
     enabled: boolean,
-    disk_encryption_key?: Azurerm_managed_disk_encryption_settings_726_disk_encryption_key_727[]|null,
-    key_encryption_key?: Azurerm_managed_disk_encryption_settings_726_key_encryption_key_728[]|null
+    disk_encryption_key?: Azurerm_managed_disk_encryption_settings_138_disk_encryption_key_139[]|null,
+    key_encryption_key?: Azurerm_managed_disk_encryption_settings_138_key_encryption_key_140[]|null
   }) {
     this.enabled = enabled;
     this.disk_encryption_key = disk_encryption_key;
@@ -13479,11 +13479,11 @@ export class Azurerm_managed_disk_encryption_settings_726 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_managed_disk_encryption_settings_726';
+    return 'TerraformAzureRM::Azurerm_managed_disk_encryption_settings_138';
   }
 }
 
-export class Azurerm_managed_disk_encryption_settings_726_disk_encryption_key_727 implements PcoreValue {
+export class Azurerm_managed_disk_encryption_settings_138_disk_encryption_key_139 implements PcoreValue {
   readonly secret_url: string;
   readonly source_vault_id: string;
 
@@ -13506,11 +13506,11 @@ export class Azurerm_managed_disk_encryption_settings_726_disk_encryption_key_72
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_managed_disk_encryption_settings_726_disk_encryption_key_727';
+    return 'TerraformAzureRM::Azurerm_managed_disk_encryption_settings_138_disk_encryption_key_139';
   }
 }
 
-export class Azurerm_managed_disk_encryption_settings_726_key_encryption_key_728 implements PcoreValue {
+export class Azurerm_managed_disk_encryption_settings_138_key_encryption_key_140 implements PcoreValue {
   readonly key_url: string;
   readonly source_vault_id: string;
 
@@ -13533,7 +13533,7 @@ export class Azurerm_managed_disk_encryption_settings_726_key_encryption_key_728
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_managed_disk_encryption_settings_726_key_encryption_key_728';
+    return 'TerraformAzureRM::Azurerm_managed_disk_encryption_settings_138_key_encryption_key_140';
   }
 }
 
@@ -13720,9 +13720,9 @@ export class Azurerm_mariadb_server implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_mariadb_server_sku_729[];
+  readonly sku: Azurerm_mariadb_server_sku_141[];
   readonly ssl_enforcement: string;
-  readonly storage_profile: Azurerm_mariadb_server_storage_profile_730[];
+  readonly storage_profile: Azurerm_mariadb_server_storage_profile_142[];
   readonly version: string;
   readonly azurerm_mariadb_server_id: string|null;
   readonly fqdn: string|null;
@@ -13747,9 +13747,9 @@ export class Azurerm_mariadb_server implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_mariadb_server_sku_729[],
+    sku: Azurerm_mariadb_server_sku_141[],
     ssl_enforcement: string,
-    storage_profile: Azurerm_mariadb_server_storage_profile_730[],
+    storage_profile: Azurerm_mariadb_server_storage_profile_142[],
     version: string,
     azurerm_mariadb_server_id?: string|null,
     fqdn?: string|null,
@@ -13807,7 +13807,7 @@ export class Azurerm_mariadb_serverHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_mariadb_server_sku_729 implements PcoreValue {
+export class Azurerm_mariadb_server_sku_141 implements PcoreValue {
   readonly capacity: number;
   readonly family: string;
   readonly name: string;
@@ -13840,11 +13840,11 @@ export class Azurerm_mariadb_server_sku_729 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mariadb_server_sku_729';
+    return 'TerraformAzureRM::Azurerm_mariadb_server_sku_141';
   }
 }
 
-export class Azurerm_mariadb_server_storage_profile_730 implements PcoreValue {
+export class Azurerm_mariadb_server_storage_profile_142 implements PcoreValue {
   readonly storage_mb: number;
   readonly backup_retention_days: number|null;
   readonly geo_redundant_backup: string|null;
@@ -13876,7 +13876,7 @@ export class Azurerm_mariadb_server_storage_profile_730 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mariadb_server_storage_profile_730';
+    return 'TerraformAzureRM::Azurerm_mariadb_server_storage_profile_142';
   }
 }
 
@@ -13892,10 +13892,10 @@ export class Azurerm_metric_alertrule implements PcoreValue {
   readonly threshold: number;
   readonly azurerm_metric_alertrule_id: string|null;
   readonly description: string|null;
-  readonly email_action: Azurerm_metric_alertrule_email_action_731[]|null;
+  readonly email_action: Azurerm_metric_alertrule_email_action_143[]|null;
   readonly enabled: boolean|null;
   readonly tags: {[s: string]: string}|null;
-  readonly webhook_action: Azurerm_metric_alertrule_webhook_action_732[]|null;
+  readonly webhook_action: Azurerm_metric_alertrule_webhook_action_144[]|null;
 
   constructor({
     aggregation,
@@ -13925,10 +13925,10 @@ export class Azurerm_metric_alertrule implements PcoreValue {
     threshold: number,
     azurerm_metric_alertrule_id?: string|null,
     description?: string|null,
-    email_action?: Azurerm_metric_alertrule_email_action_731[]|null,
+    email_action?: Azurerm_metric_alertrule_email_action_143[]|null,
     enabled?: boolean|null,
     tags?: {[s: string]: string}|null,
-    webhook_action?: Azurerm_metric_alertrule_webhook_action_732[]|null
+    webhook_action?: Azurerm_metric_alertrule_webhook_action_144[]|null
   }) {
     this.aggregation = aggregation;
     this.location = location;
@@ -13994,7 +13994,7 @@ export class Azurerm_metric_alertruleHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_metric_alertrule_email_action_731 implements PcoreValue {
+export class Azurerm_metric_alertrule_email_action_143 implements PcoreValue {
   readonly custom_emails: string[]|null;
   readonly send_to_service_owners: boolean|null;
 
@@ -14021,11 +14021,11 @@ export class Azurerm_metric_alertrule_email_action_731 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_metric_alertrule_email_action_731';
+    return 'TerraformAzureRM::Azurerm_metric_alertrule_email_action_143';
   }
 }
 
-export class Azurerm_metric_alertrule_webhook_action_732 implements PcoreValue {
+export class Azurerm_metric_alertrule_webhook_action_144 implements PcoreValue {
   readonly service_uri: string;
   readonly properties: {[s: string]: string}|null;
 
@@ -14050,7 +14050,7 @@ export class Azurerm_metric_alertrule_webhook_action_732 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_metric_alertrule_webhook_action_732';
+    return 'TerraformAzureRM::Azurerm_metric_alertrule_webhook_action_144';
   }
 }
 
@@ -14059,11 +14059,11 @@ export class Azurerm_monitor_action_group implements PcoreValue {
   readonly resource_group_name: string;
   readonly short_name: string;
   readonly azurerm_monitor_action_group_id: string|null;
-  readonly email_receiver: Azurerm_monitor_action_group_email_receiver_733[]|null;
+  readonly email_receiver: Azurerm_monitor_action_group_email_receiver_145[]|null;
   readonly enabled: boolean|null;
-  readonly sms_receiver: Azurerm_monitor_action_group_sms_receiver_734[]|null;
+  readonly sms_receiver: Azurerm_monitor_action_group_sms_receiver_146[]|null;
   readonly tags: {[s: string]: string}|null;
-  readonly webhook_receiver: Azurerm_monitor_action_group_webhook_receiver_735[]|null;
+  readonly webhook_receiver: Azurerm_monitor_action_group_webhook_receiver_147[]|null;
 
   constructor({
     name,
@@ -14080,11 +14080,11 @@ export class Azurerm_monitor_action_group implements PcoreValue {
     resource_group_name: string,
     short_name: string,
     azurerm_monitor_action_group_id?: string|null,
-    email_receiver?: Azurerm_monitor_action_group_email_receiver_733[]|null,
+    email_receiver?: Azurerm_monitor_action_group_email_receiver_145[]|null,
     enabled?: boolean|null,
-    sms_receiver?: Azurerm_monitor_action_group_sms_receiver_734[]|null,
+    sms_receiver?: Azurerm_monitor_action_group_sms_receiver_146[]|null,
     tags?: {[s: string]: string}|null,
-    webhook_receiver?: Azurerm_monitor_action_group_webhook_receiver_735[]|null
+    webhook_receiver?: Azurerm_monitor_action_group_webhook_receiver_147[]|null
   }) {
     this.name = name;
     this.resource_group_name = resource_group_name;
@@ -14138,7 +14138,7 @@ export class Azurerm_monitor_action_groupHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_monitor_action_group_email_receiver_733 implements PcoreValue {
+export class Azurerm_monitor_action_group_email_receiver_145 implements PcoreValue {
   readonly email_address: string;
   readonly name: string;
 
@@ -14161,11 +14161,11 @@ export class Azurerm_monitor_action_group_email_receiver_733 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_action_group_email_receiver_733';
+    return 'TerraformAzureRM::Azurerm_monitor_action_group_email_receiver_145';
   }
 }
 
-export class Azurerm_monitor_action_group_sms_receiver_734 implements PcoreValue {
+export class Azurerm_monitor_action_group_sms_receiver_146 implements PcoreValue {
   readonly country_code: string;
   readonly name: string;
   readonly phone_number: string;
@@ -14193,11 +14193,11 @@ export class Azurerm_monitor_action_group_sms_receiver_734 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_action_group_sms_receiver_734';
+    return 'TerraformAzureRM::Azurerm_monitor_action_group_sms_receiver_146';
   }
 }
 
-export class Azurerm_monitor_action_group_webhook_receiver_735 implements PcoreValue {
+export class Azurerm_monitor_action_group_webhook_receiver_147 implements PcoreValue {
   readonly name: string;
   readonly service_uri: string;
 
@@ -14220,17 +14220,17 @@ export class Azurerm_monitor_action_group_webhook_receiver_735 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_action_group_webhook_receiver_735';
+    return 'TerraformAzureRM::Azurerm_monitor_action_group_webhook_receiver_147';
   }
 }
 
 export class Azurerm_monitor_activity_log_alert implements PcoreValue {
-  readonly criteria: Azurerm_monitor_activity_log_alert_criteria_737[];
+  readonly criteria: Azurerm_monitor_activity_log_alert_criteria_149[];
   readonly name: string;
   readonly resource_group_name: string;
   readonly scopes: string[];
   readonly azurerm_monitor_activity_log_alert_id: string|null;
-  readonly action: Azurerm_monitor_activity_log_alert_action_736[]|null;
+  readonly action: Azurerm_monitor_activity_log_alert_action_148[]|null;
   readonly description: string|null;
   readonly enabled: boolean|null;
   readonly tags: {[s: string]: string}|null;
@@ -14246,12 +14246,12 @@ export class Azurerm_monitor_activity_log_alert implements PcoreValue {
     enabled = null,
     tags = null
   }: {
-    criteria: Azurerm_monitor_activity_log_alert_criteria_737[],
+    criteria: Azurerm_monitor_activity_log_alert_criteria_149[],
     name: string,
     resource_group_name: string,
     scopes: string[],
     azurerm_monitor_activity_log_alert_id?: string|null,
-    action?: Azurerm_monitor_activity_log_alert_action_736[]|null,
+    action?: Azurerm_monitor_activity_log_alert_action_148[]|null,
     description?: string|null,
     enabled?: boolean|null,
     tags?: {[s: string]: string}|null
@@ -14306,7 +14306,7 @@ export class Azurerm_monitor_activity_log_alertHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_monitor_activity_log_alert_action_736 implements PcoreValue {
+export class Azurerm_monitor_activity_log_alert_action_148 implements PcoreValue {
   readonly action_group_id: string;
   readonly webhook_properties: {[s: string]: string}|null;
 
@@ -14331,11 +14331,11 @@ export class Azurerm_monitor_activity_log_alert_action_736 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_activity_log_alert_action_736';
+    return 'TerraformAzureRM::Azurerm_monitor_activity_log_alert_action_148';
   }
 }
 
-export class Azurerm_monitor_activity_log_alert_criteria_737 implements PcoreValue {
+export class Azurerm_monitor_activity_log_alert_criteria_149 implements PcoreValue {
   readonly category: string;
   readonly caller: string|null;
   readonly level: string|null;
@@ -14416,7 +14416,7 @@ export class Azurerm_monitor_activity_log_alert_criteria_737 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_activity_log_alert_criteria_737';
+    return 'TerraformAzureRM::Azurerm_monitor_activity_log_alert_criteria_149';
   }
 }
 
@@ -14426,9 +14426,9 @@ export class Azurerm_monitor_diagnostic_setting implements PcoreValue {
   readonly azurerm_monitor_diagnostic_setting_id: string|null;
   readonly eventhub_authorization_rule_id: string|null;
   readonly eventhub_name: string|null;
-  readonly log: Azurerm_monitor_diagnostic_setting_log_738[]|null;
+  readonly log: Azurerm_monitor_diagnostic_setting_log_150[]|null;
   readonly log_analytics_workspace_id: string|null;
-  readonly metric: Azurerm_monitor_diagnostic_setting_metric_740[]|null;
+  readonly metric: Azurerm_monitor_diagnostic_setting_metric_152[]|null;
   readonly storage_account_id: string|null;
 
   constructor({
@@ -14447,9 +14447,9 @@ export class Azurerm_monitor_diagnostic_setting implements PcoreValue {
     azurerm_monitor_diagnostic_setting_id?: string|null,
     eventhub_authorization_rule_id?: string|null,
     eventhub_name?: string|null,
-    log?: Azurerm_monitor_diagnostic_setting_log_738[]|null,
+    log?: Azurerm_monitor_diagnostic_setting_log_150[]|null,
     log_analytics_workspace_id?: string|null,
-    metric?: Azurerm_monitor_diagnostic_setting_metric_740[]|null,
+    metric?: Azurerm_monitor_diagnostic_setting_metric_152[]|null,
     storage_account_id?: string|null
   }) {
     this.name = name;
@@ -14506,9 +14506,9 @@ export class Azurerm_monitor_diagnostic_settingHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_monitor_diagnostic_setting_log_738 implements PcoreValue {
+export class Azurerm_monitor_diagnostic_setting_log_150 implements PcoreValue {
   readonly category: string;
-  readonly retention_policy: Azurerm_monitor_diagnostic_setting_log_738_retention_policy_739[];
+  readonly retention_policy: Azurerm_monitor_diagnostic_setting_log_150_retention_policy_151[];
   readonly enabled: boolean|null;
 
   constructor({
@@ -14517,7 +14517,7 @@ export class Azurerm_monitor_diagnostic_setting_log_738 implements PcoreValue {
     enabled = null
   }: {
     category: string,
-    retention_policy: Azurerm_monitor_diagnostic_setting_log_738_retention_policy_739[],
+    retention_policy: Azurerm_monitor_diagnostic_setting_log_150_retention_policy_151[],
     enabled?: boolean|null
   }) {
     this.category = category;
@@ -14536,11 +14536,11 @@ export class Azurerm_monitor_diagnostic_setting_log_738 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_log_738';
+    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_log_150';
   }
 }
 
-export class Azurerm_monitor_diagnostic_setting_log_738_retention_policy_739 implements PcoreValue {
+export class Azurerm_monitor_diagnostic_setting_log_150_retention_policy_151 implements PcoreValue {
   readonly enabled: boolean;
   readonly days: number|null;
 
@@ -14565,13 +14565,13 @@ export class Azurerm_monitor_diagnostic_setting_log_738_retention_policy_739 imp
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_log_738_retention_policy_739';
+    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_log_150_retention_policy_151';
   }
 }
 
-export class Azurerm_monitor_diagnostic_setting_metric_740 implements PcoreValue {
+export class Azurerm_monitor_diagnostic_setting_metric_152 implements PcoreValue {
   readonly category: string;
-  readonly retention_policy: Azurerm_monitor_diagnostic_setting_metric_740_retention_policy_741[];
+  readonly retention_policy: Azurerm_monitor_diagnostic_setting_metric_152_retention_policy_153[];
   readonly enabled: boolean|null;
 
   constructor({
@@ -14580,7 +14580,7 @@ export class Azurerm_monitor_diagnostic_setting_metric_740 implements PcoreValue
     enabled = null
   }: {
     category: string,
-    retention_policy: Azurerm_monitor_diagnostic_setting_metric_740_retention_policy_741[],
+    retention_policy: Azurerm_monitor_diagnostic_setting_metric_152_retention_policy_153[],
     enabled?: boolean|null
   }) {
     this.category = category;
@@ -14599,11 +14599,11 @@ export class Azurerm_monitor_diagnostic_setting_metric_740 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_metric_740';
+    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_metric_152';
   }
 }
 
-export class Azurerm_monitor_diagnostic_setting_metric_740_retention_policy_741 implements PcoreValue {
+export class Azurerm_monitor_diagnostic_setting_metric_152_retention_policy_153 implements PcoreValue {
   readonly enabled: boolean;
   readonly days: number|null;
 
@@ -14628,7 +14628,7 @@ export class Azurerm_monitor_diagnostic_setting_metric_740_retention_policy_741 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_metric_740_retention_policy_741';
+    return 'TerraformAzureRM::Azurerm_monitor_diagnostic_setting_metric_152_retention_policy_153';
   }
 }
 
@@ -14636,7 +14636,7 @@ export class Azurerm_monitor_log_profile implements PcoreValue {
   readonly categories: string[];
   readonly locations: string[];
   readonly name: string;
-  readonly retention_policy: Azurerm_monitor_log_profile_retention_policy_742[];
+  readonly retention_policy: Azurerm_monitor_log_profile_retention_policy_154[];
   readonly azurerm_monitor_log_profile_id: string|null;
   readonly servicebus_rule_id: string|null;
   readonly storage_account_id: string|null;
@@ -14653,7 +14653,7 @@ export class Azurerm_monitor_log_profile implements PcoreValue {
     categories: string[],
     locations: string[],
     name: string,
-    retention_policy: Azurerm_monitor_log_profile_retention_policy_742[],
+    retention_policy: Azurerm_monitor_log_profile_retention_policy_154[],
     azurerm_monitor_log_profile_id?: string|null,
     servicebus_rule_id?: string|null,
     storage_account_id?: string|null
@@ -14700,7 +14700,7 @@ export class Azurerm_monitor_log_profileHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_monitor_log_profile_retention_policy_742 implements PcoreValue {
+export class Azurerm_monitor_log_profile_retention_policy_154 implements PcoreValue {
   readonly enabled: boolean;
   readonly days: number|null;
 
@@ -14725,17 +14725,17 @@ export class Azurerm_monitor_log_profile_retention_policy_742 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_log_profile_retention_policy_742';
+    return 'TerraformAzureRM::Azurerm_monitor_log_profile_retention_policy_154';
   }
 }
 
 export class Azurerm_monitor_metric_alert implements PcoreValue {
-  readonly criteria: Azurerm_monitor_metric_alert_criteria_744[];
+  readonly criteria: Azurerm_monitor_metric_alert_criteria_156[];
   readonly name: string;
   readonly resource_group_name: string;
   readonly scopes: string[];
   readonly azurerm_monitor_metric_alert_id: string|null;
-  readonly action: Azurerm_monitor_metric_alert_action_743[]|null;
+  readonly action: Azurerm_monitor_metric_alert_action_155[]|null;
   readonly auto_mitigate: boolean|null;
   readonly description: string|null;
   readonly enabled: boolean|null;
@@ -14759,12 +14759,12 @@ export class Azurerm_monitor_metric_alert implements PcoreValue {
     tags = null,
     window_size = null
   }: {
-    criteria: Azurerm_monitor_metric_alert_criteria_744[],
+    criteria: Azurerm_monitor_metric_alert_criteria_156[],
     name: string,
     resource_group_name: string,
     scopes: string[],
     azurerm_monitor_metric_alert_id?: string|null,
-    action?: Azurerm_monitor_metric_alert_action_743[]|null,
+    action?: Azurerm_monitor_metric_alert_action_155[]|null,
     auto_mitigate?: boolean|null,
     description?: string|null,
     enabled?: boolean|null,
@@ -14839,7 +14839,7 @@ export class Azurerm_monitor_metric_alertHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_monitor_metric_alert_action_743 implements PcoreValue {
+export class Azurerm_monitor_metric_alert_action_155 implements PcoreValue {
   readonly action_group_id: string;
   readonly webhook_properties: {[s: string]: string}|null;
 
@@ -14864,17 +14864,17 @@ export class Azurerm_monitor_metric_alert_action_743 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_metric_alert_action_743';
+    return 'TerraformAzureRM::Azurerm_monitor_metric_alert_action_155';
   }
 }
 
-export class Azurerm_monitor_metric_alert_criteria_744 implements PcoreValue {
+export class Azurerm_monitor_metric_alert_criteria_156 implements PcoreValue {
   readonly aggregation: string;
   readonly metric_name: string;
   readonly metric_namespace: string;
   readonly operator: string;
   readonly threshold: number;
-  readonly dimension: Azurerm_monitor_metric_alert_criteria_744_dimension_745[]|null;
+  readonly dimension: Azurerm_monitor_metric_alert_criteria_156_dimension_157[]|null;
 
   constructor({
     aggregation,
@@ -14889,7 +14889,7 @@ export class Azurerm_monitor_metric_alert_criteria_744 implements PcoreValue {
     metric_namespace: string,
     operator: string,
     threshold: number,
-    dimension?: Azurerm_monitor_metric_alert_criteria_744_dimension_745[]|null
+    dimension?: Azurerm_monitor_metric_alert_criteria_156_dimension_157[]|null
   }) {
     this.aggregation = aggregation;
     this.metric_name = metric_name;
@@ -14913,11 +14913,11 @@ export class Azurerm_monitor_metric_alert_criteria_744 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_metric_alert_criteria_744';
+    return 'TerraformAzureRM::Azurerm_monitor_metric_alert_criteria_156';
   }
 }
 
-export class Azurerm_monitor_metric_alert_criteria_744_dimension_745 implements PcoreValue {
+export class Azurerm_monitor_metric_alert_criteria_156_dimension_157 implements PcoreValue {
   readonly name: string;
   readonly operator: string;
   readonly values: string[];
@@ -14945,19 +14945,19 @@ export class Azurerm_monitor_metric_alert_criteria_744_dimension_745 implements 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_monitor_metric_alert_criteria_744_dimension_745';
+    return 'TerraformAzureRM::Azurerm_monitor_metric_alert_criteria_156_dimension_157';
   }
 }
 
 export class Azurerm_mssql_elasticpool implements PcoreValue {
   readonly location: string;
   readonly name: string;
-  readonly per_database_settings: Azurerm_mssql_elasticpool_per_database_settings_747[];
+  readonly per_database_settings: Azurerm_mssql_elasticpool_per_database_settings_159[];
   readonly resource_group_name: string;
   readonly server_name: string;
-  readonly sku: Azurerm_mssql_elasticpool_sku_748[];
+  readonly sku: Azurerm_mssql_elasticpool_sku_160[];
   readonly azurerm_mssql_elasticpool_id: string|null;
-  readonly elastic_pool_properties: Azurerm_mssql_elasticpool_elastic_pool_properties_746[]|null;
+  readonly elastic_pool_properties: Azurerm_mssql_elasticpool_elastic_pool_properties_158[]|null;
   readonly max_size_bytes: number|null;
   readonly tags: {[s: string]: string}|null;
   readonly zone_redundant: boolean|null;
@@ -14977,12 +14977,12 @@ export class Azurerm_mssql_elasticpool implements PcoreValue {
   }: {
     location: string,
     name: string,
-    per_database_settings: Azurerm_mssql_elasticpool_per_database_settings_747[],
+    per_database_settings: Azurerm_mssql_elasticpool_per_database_settings_159[],
     resource_group_name: string,
     server_name: string,
-    sku: Azurerm_mssql_elasticpool_sku_748[],
+    sku: Azurerm_mssql_elasticpool_sku_160[],
     azurerm_mssql_elasticpool_id?: string|null,
-    elastic_pool_properties?: Azurerm_mssql_elasticpool_elastic_pool_properties_746[]|null,
+    elastic_pool_properties?: Azurerm_mssql_elasticpool_elastic_pool_properties_158[]|null,
     max_size_bytes?: number|null,
     tags?: {[s: string]: string}|null,
     zone_redundant?: boolean|null
@@ -15041,7 +15041,7 @@ export class Azurerm_mssql_elasticpoolHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_mssql_elasticpool_elastic_pool_properties_746 implements PcoreValue {
+export class Azurerm_mssql_elasticpool_elastic_pool_properties_158 implements PcoreValue {
   readonly creation_date: string|null;
   readonly license_type: string|null;
   readonly max_size_bytes: number|null;
@@ -15089,11 +15089,11 @@ export class Azurerm_mssql_elasticpool_elastic_pool_properties_746 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mssql_elasticpool_elastic_pool_properties_746';
+    return 'TerraformAzureRM::Azurerm_mssql_elasticpool_elastic_pool_properties_158';
   }
 }
 
-export class Azurerm_mssql_elasticpool_per_database_settings_747 implements PcoreValue {
+export class Azurerm_mssql_elasticpool_per_database_settings_159 implements PcoreValue {
   readonly max_capacity: number;
   readonly min_capacity: number;
 
@@ -15116,11 +15116,11 @@ export class Azurerm_mssql_elasticpool_per_database_settings_747 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mssql_elasticpool_per_database_settings_747';
+    return 'TerraformAzureRM::Azurerm_mssql_elasticpool_per_database_settings_159';
   }
 }
 
-export class Azurerm_mssql_elasticpool_sku_748 implements PcoreValue {
+export class Azurerm_mssql_elasticpool_sku_160 implements PcoreValue {
   readonly capacity: number;
   readonly name: string;
   readonly tier: string;
@@ -15155,7 +15155,7 @@ export class Azurerm_mssql_elasticpool_sku_748 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mssql_elasticpool_sku_748';
+    return 'TerraformAzureRM::Azurerm_mssql_elasticpool_sku_160';
   }
 }
 
@@ -15337,9 +15337,9 @@ export class Azurerm_mysql_server implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_mysql_server_sku_749[];
+  readonly sku: Azurerm_mysql_server_sku_161[];
   readonly ssl_enforcement: string;
-  readonly storage_profile: Azurerm_mysql_server_storage_profile_750[];
+  readonly storage_profile: Azurerm_mysql_server_storage_profile_162[];
   readonly version: string;
   readonly azurerm_mysql_server_id: string|null;
   readonly fqdn: string|null;
@@ -15364,9 +15364,9 @@ export class Azurerm_mysql_server implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_mysql_server_sku_749[],
+    sku: Azurerm_mysql_server_sku_161[],
     ssl_enforcement: string,
-    storage_profile: Azurerm_mysql_server_storage_profile_750[],
+    storage_profile: Azurerm_mysql_server_storage_profile_162[],
     version: string,
     azurerm_mysql_server_id?: string|null,
     fqdn?: string|null,
@@ -15424,7 +15424,7 @@ export class Azurerm_mysql_serverHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_mysql_server_sku_749 implements PcoreValue {
+export class Azurerm_mysql_server_sku_161 implements PcoreValue {
   readonly capacity: number;
   readonly family: string;
   readonly name: string;
@@ -15457,11 +15457,11 @@ export class Azurerm_mysql_server_sku_749 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mysql_server_sku_749';
+    return 'TerraformAzureRM::Azurerm_mysql_server_sku_161';
   }
 }
 
-export class Azurerm_mysql_server_storage_profile_750 implements PcoreValue {
+export class Azurerm_mysql_server_storage_profile_162 implements PcoreValue {
   readonly storage_mb: number;
   readonly backup_retention_days: number|null;
   readonly geo_redundant_backup: string|null;
@@ -15493,7 +15493,7 @@ export class Azurerm_mysql_server_storage_profile_750 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_mysql_server_storage_profile_750';
+    return 'TerraformAzureRM::Azurerm_mysql_server_storage_profile_162';
   }
 }
 
@@ -15552,7 +15552,7 @@ export class Azurerm_mysql_virtual_network_ruleHandler implements PcoreValue {
 }
 
 export class Azurerm_network_interface implements PcoreValue {
-  readonly ip_configuration: Azurerm_network_interface_ip_configuration_751[];
+  readonly ip_configuration: Azurerm_network_interface_ip_configuration_163[];
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
@@ -15589,7 +15589,7 @@ export class Azurerm_network_interface implements PcoreValue {
     tags = null,
     virtual_machine_id = null
   }: {
-    ip_configuration: Azurerm_network_interface_ip_configuration_751[],
+    ip_configuration: Azurerm_network_interface_ip_configuration_163[],
     location: string,
     name: string,
     resource_group_name: string,
@@ -15787,7 +15787,7 @@ export class Azurerm_network_interface_backend_address_pool_associationHandler i
   }
 }
 
-export class Azurerm_network_interface_ip_configuration_751 implements PcoreValue {
+export class Azurerm_network_interface_ip_configuration_163 implements PcoreValue {
   readonly name: string;
   readonly private_ip_address_allocation: string;
   readonly application_gateway_backend_address_pools_ids: string[]|null;
@@ -15873,7 +15873,7 @@ export class Azurerm_network_interface_ip_configuration_751 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_network_interface_ip_configuration_751';
+    return 'TerraformAzureRM::Azurerm_network_interface_ip_configuration_163';
   }
 }
 
@@ -15931,7 +15931,7 @@ export class Azurerm_network_security_group implements PcoreValue {
   readonly name: string;
   readonly resource_group_name: string;
   readonly azurerm_network_security_group_id: string|null;
-  readonly security_rule: Azurerm_network_security_group_security_rule_752[]|null;
+  readonly security_rule: Azurerm_network_security_group_security_rule_164[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -15946,7 +15946,7 @@ export class Azurerm_network_security_group implements PcoreValue {
     name: string,
     resource_group_name: string,
     azurerm_network_security_group_id?: string|null,
-    security_rule?: Azurerm_network_security_group_security_rule_752[]|null,
+    security_rule?: Azurerm_network_security_group_security_rule_164[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.location = location;
@@ -15989,7 +15989,7 @@ export class Azurerm_network_security_groupHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_network_security_group_security_rule_752 implements PcoreValue {
+export class Azurerm_network_security_group_security_rule_164 implements PcoreValue {
   readonly access: string;
   readonly direction: string;
   readonly name: string;
@@ -16104,7 +16104,7 @@ export class Azurerm_network_security_group_security_rule_752 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_network_security_group_security_rule_752';
+    return 'TerraformAzureRM::Azurerm_network_security_group_security_rule_164';
   }
 }
 
@@ -16316,8 +16316,8 @@ export class Azurerm_notification_hub implements PcoreValue {
   readonly namespace_name: string;
   readonly resource_group_name: string;
   readonly azurerm_notification_hub_id: string|null;
-  readonly apns_credential: Azurerm_notification_hub_apns_credential_753[]|null;
-  readonly gcm_credential: Azurerm_notification_hub_gcm_credential_754[]|null;
+  readonly apns_credential: Azurerm_notification_hub_apns_credential_165[]|null;
+  readonly gcm_credential: Azurerm_notification_hub_gcm_credential_166[]|null;
 
   constructor({
     location,
@@ -16333,8 +16333,8 @@ export class Azurerm_notification_hub implements PcoreValue {
     namespace_name: string,
     resource_group_name: string,
     azurerm_notification_hub_id?: string|null,
-    apns_credential?: Azurerm_notification_hub_apns_credential_753[]|null,
-    gcm_credential?: Azurerm_notification_hub_gcm_credential_754[]|null
+    apns_credential?: Azurerm_notification_hub_apns_credential_165[]|null,
+    gcm_credential?: Azurerm_notification_hub_gcm_credential_166[]|null
   }) {
     this.location = location;
     this.name = name;
@@ -16378,7 +16378,7 @@ export class Azurerm_notification_hubHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_notification_hub_apns_credential_753 implements PcoreValue {
+export class Azurerm_notification_hub_apns_credential_165 implements PcoreValue {
   readonly application_mode: string;
   readonly bundle_id: string;
   readonly key_id: string;
@@ -16416,7 +16416,7 @@ export class Azurerm_notification_hub_apns_credential_753 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_notification_hub_apns_credential_753';
+    return 'TerraformAzureRM::Azurerm_notification_hub_apns_credential_165';
   }
 }
 
@@ -16509,7 +16509,7 @@ export class Azurerm_notification_hub_authorization_ruleHandler implements Pcore
   }
 }
 
-export class Azurerm_notification_hub_gcm_credential_754 implements PcoreValue {
+export class Azurerm_notification_hub_gcm_credential_166 implements PcoreValue {
   readonly api_key: string;
 
   constructor({
@@ -16527,7 +16527,7 @@ export class Azurerm_notification_hub_gcm_credential_754 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_notification_hub_gcm_credential_754';
+    return 'TerraformAzureRM::Azurerm_notification_hub_gcm_credential_166';
   }
 }
 
@@ -16536,7 +16536,7 @@ export class Azurerm_notification_hub_namespace implements PcoreValue {
   readonly name: string;
   readonly namespace_type: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_notification_hub_namespace_sku_755[];
+  readonly sku: Azurerm_notification_hub_namespace_sku_167[];
   readonly azurerm_notification_hub_namespace_id: string|null;
   readonly enabled: boolean|null;
   readonly servicebus_endpoint: string|null;
@@ -16555,7 +16555,7 @@ export class Azurerm_notification_hub_namespace implements PcoreValue {
     name: string,
     namespace_type: string,
     resource_group_name: string,
-    sku: Azurerm_notification_hub_namespace_sku_755[],
+    sku: Azurerm_notification_hub_namespace_sku_167[],
     azurerm_notification_hub_namespace_id?: string|null,
     enabled?: boolean|null,
     servicebus_endpoint?: string|null
@@ -16604,7 +16604,7 @@ export class Azurerm_notification_hub_namespaceHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_notification_hub_namespace_sku_755 implements PcoreValue {
+export class Azurerm_notification_hub_namespace_sku_167 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -16622,7 +16622,7 @@ export class Azurerm_notification_hub_namespace_sku_755 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_notification_hub_namespace_sku_755';
+    return 'TerraformAzureRM::Azurerm_notification_hub_namespace_sku_167';
   }
 }
 
@@ -16630,10 +16630,10 @@ export class Azurerm_packet_capture implements PcoreValue {
   readonly name: string;
   readonly network_watcher_name: string;
   readonly resource_group_name: string;
-  readonly storage_location: Azurerm_packet_capture_storage_location_757[];
+  readonly storage_location: Azurerm_packet_capture_storage_location_169[];
   readonly target_resource_id: string;
   readonly azurerm_packet_capture_id: string|null;
-  readonly filter: Azurerm_packet_capture_filter_756[]|null;
+  readonly filter: Azurerm_packet_capture_filter_168[]|null;
   readonly maximum_bytes_per_packet: number|null;
   readonly maximum_bytes_per_session: number|null;
   readonly maximum_capture_duration: number|null;
@@ -16653,10 +16653,10 @@ export class Azurerm_packet_capture implements PcoreValue {
     name: string,
     network_watcher_name: string,
     resource_group_name: string,
-    storage_location: Azurerm_packet_capture_storage_location_757[],
+    storage_location: Azurerm_packet_capture_storage_location_169[],
     target_resource_id: string,
     azurerm_packet_capture_id?: string|null,
-    filter?: Azurerm_packet_capture_filter_756[]|null,
+    filter?: Azurerm_packet_capture_filter_168[]|null,
     maximum_bytes_per_packet?: number|null,
     maximum_bytes_per_session?: number|null,
     maximum_capture_duration?: number|null
@@ -16713,7 +16713,7 @@ export class Azurerm_packet_captureHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_packet_capture_filter_756 implements PcoreValue {
+export class Azurerm_packet_capture_filter_168 implements PcoreValue {
   readonly protocol: string;
   readonly local_ip_address: string|null;
   readonly local_port: string|null;
@@ -16759,11 +16759,11 @@ export class Azurerm_packet_capture_filter_756 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_packet_capture_filter_756';
+    return 'TerraformAzureRM::Azurerm_packet_capture_filter_168';
   }
 }
 
-export class Azurerm_packet_capture_storage_location_757 implements PcoreValue {
+export class Azurerm_packet_capture_storage_location_169 implements PcoreValue {
   readonly file_path: string|null;
   readonly storage_account_id: string|null;
   readonly storage_path: string|null;
@@ -16797,7 +16797,7 @@ export class Azurerm_packet_capture_storage_location_757 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_packet_capture_storage_location_757';
+    return 'TerraformAzureRM::Azurerm_packet_capture_storage_location_169';
   }
 }
 
@@ -16808,7 +16808,7 @@ export class Azurerm_policy_assignment implements PcoreValue {
   readonly azurerm_policy_assignment_id: string|null;
   readonly description: string|null;
   readonly display_name: string|null;
-  readonly identity: Azurerm_policy_assignment_identity_758[]|null;
+  readonly identity: Azurerm_policy_assignment_identity_170[]|null;
   readonly location: string|null;
   readonly not_scopes: string[]|null;
   readonly parameters: string|null;
@@ -16831,7 +16831,7 @@ export class Azurerm_policy_assignment implements PcoreValue {
     azurerm_policy_assignment_id?: string|null,
     description?: string|null,
     display_name?: string|null,
-    identity?: Azurerm_policy_assignment_identity_758[]|null,
+    identity?: Azurerm_policy_assignment_identity_170[]|null,
     location?: string|null,
     not_scopes?: string[]|null,
     parameters?: string|null
@@ -16892,7 +16892,7 @@ export class Azurerm_policy_assignmentHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_policy_assignment_identity_758 implements PcoreValue {
+export class Azurerm_policy_assignment_identity_170 implements PcoreValue {
   readonly principal_id: string|null;
   readonly tenant_id: string|null;
   readonly type: string|null;
@@ -16926,7 +16926,7 @@ export class Azurerm_policy_assignment_identity_758 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_policy_assignment_identity_758';
+    return 'TerraformAzureRM::Azurerm_policy_assignment_identity_170';
   }
 }
 
@@ -17281,9 +17281,9 @@ export class Azurerm_postgresql_server implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_postgresql_server_sku_759[];
+  readonly sku: Azurerm_postgresql_server_sku_171[];
   readonly ssl_enforcement: string;
-  readonly storage_profile: Azurerm_postgresql_server_storage_profile_760[];
+  readonly storage_profile: Azurerm_postgresql_server_storage_profile_172[];
   readonly version: string;
   readonly azurerm_postgresql_server_id: string|null;
   readonly fqdn: string|null;
@@ -17308,9 +17308,9 @@ export class Azurerm_postgresql_server implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_postgresql_server_sku_759[],
+    sku: Azurerm_postgresql_server_sku_171[],
     ssl_enforcement: string,
-    storage_profile: Azurerm_postgresql_server_storage_profile_760[],
+    storage_profile: Azurerm_postgresql_server_storage_profile_172[],
     version: string,
     azurerm_postgresql_server_id?: string|null,
     fqdn?: string|null,
@@ -17368,7 +17368,7 @@ export class Azurerm_postgresql_serverHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_postgresql_server_sku_759 implements PcoreValue {
+export class Azurerm_postgresql_server_sku_171 implements PcoreValue {
   readonly capacity: number;
   readonly family: string;
   readonly name: string;
@@ -17401,11 +17401,11 @@ export class Azurerm_postgresql_server_sku_759 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_postgresql_server_sku_759';
+    return 'TerraformAzureRM::Azurerm_postgresql_server_sku_171';
   }
 }
 
-export class Azurerm_postgresql_server_storage_profile_760 implements PcoreValue {
+export class Azurerm_postgresql_server_storage_profile_172 implements PcoreValue {
   readonly storage_mb: number;
   readonly backup_retention_days: number|null;
   readonly geo_redundant_backup: string|null;
@@ -17437,7 +17437,7 @@ export class Azurerm_postgresql_server_storage_profile_760 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_postgresql_server_storage_profile_760';
+    return 'TerraformAzureRM::Azurerm_postgresql_server_storage_profile_172';
   }
 }
 
@@ -17690,15 +17690,15 @@ export class Azurerm_recovery_services_protected_vmHandler implements PcoreValue
 }
 
 export class Azurerm_recovery_services_protection_policy_vm implements PcoreValue {
-  readonly backup: Azurerm_recovery_services_protection_policy_vm_backup_761[];
+  readonly backup: Azurerm_recovery_services_protection_policy_vm_backup_173[];
   readonly name: string;
   readonly recovery_vault_name: string;
   readonly resource_group_name: string;
   readonly azurerm_recovery_services_protection_policy_vm_id: string|null;
-  readonly retention_daily: Azurerm_recovery_services_protection_policy_vm_retention_daily_762[]|null;
-  readonly retention_monthly: Azurerm_recovery_services_protection_policy_vm_retention_monthly_763[]|null;
-  readonly retention_weekly: Azurerm_recovery_services_protection_policy_vm_retention_weekly_764[]|null;
-  readonly retention_yearly: Azurerm_recovery_services_protection_policy_vm_retention_yearly_765[]|null;
+  readonly retention_daily: Azurerm_recovery_services_protection_policy_vm_retention_daily_174[]|null;
+  readonly retention_monthly: Azurerm_recovery_services_protection_policy_vm_retention_monthly_175[]|null;
+  readonly retention_weekly: Azurerm_recovery_services_protection_policy_vm_retention_weekly_176[]|null;
+  readonly retention_yearly: Azurerm_recovery_services_protection_policy_vm_retention_yearly_177[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly timezone: string|null;
 
@@ -17715,15 +17715,15 @@ export class Azurerm_recovery_services_protection_policy_vm implements PcoreValu
     tags = null,
     timezone = null
   }: {
-    backup: Azurerm_recovery_services_protection_policy_vm_backup_761[],
+    backup: Azurerm_recovery_services_protection_policy_vm_backup_173[],
     name: string,
     recovery_vault_name: string,
     resource_group_name: string,
     azurerm_recovery_services_protection_policy_vm_id?: string|null,
-    retention_daily?: Azurerm_recovery_services_protection_policy_vm_retention_daily_762[]|null,
-    retention_monthly?: Azurerm_recovery_services_protection_policy_vm_retention_monthly_763[]|null,
-    retention_weekly?: Azurerm_recovery_services_protection_policy_vm_retention_weekly_764[]|null,
-    retention_yearly?: Azurerm_recovery_services_protection_policy_vm_retention_yearly_765[]|null,
+    retention_daily?: Azurerm_recovery_services_protection_policy_vm_retention_daily_174[]|null,
+    retention_monthly?: Azurerm_recovery_services_protection_policy_vm_retention_monthly_175[]|null,
+    retention_weekly?: Azurerm_recovery_services_protection_policy_vm_retention_weekly_176[]|null,
+    retention_yearly?: Azurerm_recovery_services_protection_policy_vm_retention_yearly_177[]|null,
     tags?: {[s: string]: string}|null,
     timezone?: string|null
   }) {
@@ -17785,7 +17785,7 @@ export class Azurerm_recovery_services_protection_policy_vmHandler implements Pc
   }
 }
 
-export class Azurerm_recovery_services_protection_policy_vm_backup_761 implements PcoreValue {
+export class Azurerm_recovery_services_protection_policy_vm_backup_173 implements PcoreValue {
   readonly frequency: string;
   readonly time: string;
   readonly weekdays: string[]|null;
@@ -17815,11 +17815,11 @@ export class Azurerm_recovery_services_protection_policy_vm_backup_761 implement
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_backup_761';
+    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_backup_173';
   }
 }
 
-export class Azurerm_recovery_services_protection_policy_vm_retention_daily_762 implements PcoreValue {
+export class Azurerm_recovery_services_protection_policy_vm_retention_daily_174 implements PcoreValue {
   readonly count: number;
 
   constructor({
@@ -17837,11 +17837,11 @@ export class Azurerm_recovery_services_protection_policy_vm_retention_daily_762 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_daily_762';
+    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_daily_174';
   }
 }
 
-export class Azurerm_recovery_services_protection_policy_vm_retention_monthly_763 implements PcoreValue {
+export class Azurerm_recovery_services_protection_policy_vm_retention_monthly_175 implements PcoreValue {
   readonly count: number;
   readonly weekdays: string[];
   readonly weeks: string[];
@@ -17869,11 +17869,11 @@ export class Azurerm_recovery_services_protection_policy_vm_retention_monthly_76
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_monthly_763';
+    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_monthly_175';
   }
 }
 
-export class Azurerm_recovery_services_protection_policy_vm_retention_weekly_764 implements PcoreValue {
+export class Azurerm_recovery_services_protection_policy_vm_retention_weekly_176 implements PcoreValue {
   readonly count: number;
   readonly weekdays: string[];
 
@@ -17896,11 +17896,11 @@ export class Azurerm_recovery_services_protection_policy_vm_retention_weekly_764
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_weekly_764';
+    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_weekly_176';
   }
 }
 
-export class Azurerm_recovery_services_protection_policy_vm_retention_yearly_765 implements PcoreValue {
+export class Azurerm_recovery_services_protection_policy_vm_retention_yearly_177 implements PcoreValue {
   readonly count: number;
   readonly months: string[];
   readonly weekdays: string[];
@@ -17933,7 +17933,7 @@ export class Azurerm_recovery_services_protection_policy_vm_retention_yearly_765
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_yearly_765';
+    return 'TerraformAzureRM::Azurerm_recovery_services_protection_policy_vm_retention_yearly_177';
   }
 }
 
@@ -18003,13 +18003,13 @@ export class Azurerm_redis_cache implements PcoreValue {
   readonly family: string;
   readonly location: string;
   readonly name: string;
-  readonly redis_configuration: Azurerm_redis_cache_redis_configuration_767[];
+  readonly redis_configuration: Azurerm_redis_cache_redis_configuration_179[];
   readonly resource_group_name: string;
   readonly sku_name: string;
   readonly azurerm_redis_cache_id: string|null;
   readonly enable_non_ssl_port: boolean|null;
   readonly hostname: string|null;
-  readonly patch_schedule: Azurerm_redis_cache_patch_schedule_766[]|null;
+  readonly patch_schedule: Azurerm_redis_cache_patch_schedule_178[]|null;
   readonly port: number|null;
   readonly primary_access_key: string|null;
   readonly private_static_ip_address: string|null;
@@ -18046,13 +18046,13 @@ export class Azurerm_redis_cache implements PcoreValue {
     family: string,
     location: string,
     name: string,
-    redis_configuration: Azurerm_redis_cache_redis_configuration_767[],
+    redis_configuration: Azurerm_redis_cache_redis_configuration_179[],
     resource_group_name: string,
     sku_name: string,
     azurerm_redis_cache_id?: string|null,
     enable_non_ssl_port?: boolean|null,
     hostname?: string|null,
-    patch_schedule?: Azurerm_redis_cache_patch_schedule_766[]|null,
+    patch_schedule?: Azurerm_redis_cache_patch_schedule_178[]|null,
     port?: number|null,
     primary_access_key?: string|null,
     private_static_ip_address?: string|null,
@@ -18151,7 +18151,7 @@ export class Azurerm_redis_cacheHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_redis_cache_patch_schedule_766 implements PcoreValue {
+export class Azurerm_redis_cache_patch_schedule_178 implements PcoreValue {
   readonly day_of_week: string;
   readonly start_hour_utc: number|null;
 
@@ -18176,11 +18176,11 @@ export class Azurerm_redis_cache_patch_schedule_766 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_redis_cache_patch_schedule_766';
+    return 'TerraformAzureRM::Azurerm_redis_cache_patch_schedule_178';
   }
 }
 
-export class Azurerm_redis_cache_redis_configuration_767 implements PcoreValue {
+export class Azurerm_redis_cache_redis_configuration_179 implements PcoreValue {
   readonly maxclients: number|null;
   readonly maxmemory_delta: number|null;
   readonly maxmemory_policy: string|null;
@@ -18256,7 +18256,7 @@ export class Azurerm_redis_cache_redis_configuration_767 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_redis_cache_redis_configuration_767';
+    return 'TerraformAzureRM::Azurerm_redis_cache_redis_configuration_179';
   }
 }
 
@@ -18323,7 +18323,7 @@ export class Azurerm_relay_namespace implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_relay_namespace_sku_768[];
+  readonly sku: Azurerm_relay_namespace_sku_180[];
   readonly azurerm_relay_namespace_id: string|null;
   readonly metric_id: string|null;
   readonly primary_connection_string: string|null;
@@ -18348,7 +18348,7 @@ export class Azurerm_relay_namespace implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_relay_namespace_sku_768[],
+    sku: Azurerm_relay_namespace_sku_180[],
     azurerm_relay_namespace_id?: string|null,
     metric_id?: string|null,
     primary_connection_string?: string|null,
@@ -18415,7 +18415,7 @@ export class Azurerm_relay_namespaceHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_relay_namespace_sku_768 implements PcoreValue {
+export class Azurerm_relay_namespace_sku_180 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -18433,7 +18433,7 @@ export class Azurerm_relay_namespace_sku_768 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_relay_namespace_sku_768';
+    return 'TerraformAzureRM::Azurerm_relay_namespace_sku_180';
   }
 }
 
@@ -18556,7 +18556,7 @@ export class Azurerm_role_assignmentHandler implements PcoreValue {
 export class Azurerm_role_definition implements PcoreValue {
   readonly assignable_scopes: string[];
   readonly name: string;
-  readonly permissions: Azurerm_role_definition_permissions_769[];
+  readonly permissions: Azurerm_role_definition_permissions_181[];
   readonly scope: string;
   readonly azurerm_role_definition_id: string|null;
   readonly description: string|null;
@@ -18573,7 +18573,7 @@ export class Azurerm_role_definition implements PcoreValue {
   }: {
     assignable_scopes: string[],
     name: string,
-    permissions: Azurerm_role_definition_permissions_769[],
+    permissions: Azurerm_role_definition_permissions_181[],
     scope: string,
     azurerm_role_definition_id?: string|null,
     description?: string|null,
@@ -18621,7 +18621,7 @@ export class Azurerm_role_definitionHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_role_definition_permissions_769 implements PcoreValue {
+export class Azurerm_role_definition_permissions_181 implements PcoreValue {
   readonly actions: string[]|null;
   readonly data_actions: string[]|null;
   readonly not_actions: string[]|null;
@@ -18662,7 +18662,7 @@ export class Azurerm_role_definition_permissions_769 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_role_definition_permissions_769';
+    return 'TerraformAzureRM::Azurerm_role_definition_permissions_181';
   }
 }
 
@@ -18738,7 +18738,7 @@ export class Azurerm_route_table implements PcoreValue {
   readonly resource_group_name: string;
   readonly azurerm_route_table_id: string|null;
   readonly disable_bgp_route_propagation: boolean|null;
-  readonly route: Azurerm_route_table_route_770[]|null;
+  readonly route: Azurerm_route_table_route_182[]|null;
   readonly subnets: string[]|null;
   readonly tags: {[s: string]: string}|null;
 
@@ -18757,7 +18757,7 @@ export class Azurerm_route_table implements PcoreValue {
     resource_group_name: string,
     azurerm_route_table_id?: string|null,
     disable_bgp_route_propagation?: boolean|null,
-    route?: Azurerm_route_table_route_770[]|null,
+    route?: Azurerm_route_table_route_182[]|null,
     subnets?: string[]|null,
     tags?: {[s: string]: string}|null
   }) {
@@ -18809,7 +18809,7 @@ export class Azurerm_route_tableHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_route_table_route_770 implements PcoreValue {
+export class Azurerm_route_table_route_182 implements PcoreValue {
   readonly address_prefix: string;
   readonly name: string;
   readonly next_hop_type: string;
@@ -18844,7 +18844,7 @@ export class Azurerm_route_table_route_770 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_route_table_route_770';
+    return 'TerraformAzureRM::Azurerm_route_table_route_182';
   }
 }
 
@@ -18853,12 +18853,12 @@ export class Azurerm_scheduler_job implements PcoreValue {
   readonly name: string;
   readonly resource_group_name: string;
   readonly azurerm_scheduler_job_id: string|null;
-  readonly action_storage_queue: Azurerm_scheduler_job_action_storage_queue_771[]|null;
-  readonly action_web: Azurerm_scheduler_job_action_web_772[]|null;
-  readonly error_action_storage_queue: Azurerm_scheduler_job_error_action_storage_queue_776[]|null;
-  readonly error_action_web: Azurerm_scheduler_job_error_action_web_777[]|null;
-  readonly recurrence: Azurerm_scheduler_job_recurrence_781[]|null;
-  readonly retry: Azurerm_scheduler_job_retry_783[]|null;
+  readonly action_storage_queue: Azurerm_scheduler_job_action_storage_queue_183[]|null;
+  readonly action_web: Azurerm_scheduler_job_action_web_184[]|null;
+  readonly error_action_storage_queue: Azurerm_scheduler_job_error_action_storage_queue_188[]|null;
+  readonly error_action_web: Azurerm_scheduler_job_error_action_web_189[]|null;
+  readonly recurrence: Azurerm_scheduler_job_recurrence_193[]|null;
+  readonly retry: Azurerm_scheduler_job_retry_195[]|null;
   readonly start_time: string|null;
   readonly state: string|null;
 
@@ -18880,12 +18880,12 @@ export class Azurerm_scheduler_job implements PcoreValue {
     name: string,
     resource_group_name: string,
     azurerm_scheduler_job_id?: string|null,
-    action_storage_queue?: Azurerm_scheduler_job_action_storage_queue_771[]|null,
-    action_web?: Azurerm_scheduler_job_action_web_772[]|null,
-    error_action_storage_queue?: Azurerm_scheduler_job_error_action_storage_queue_776[]|null,
-    error_action_web?: Azurerm_scheduler_job_error_action_web_777[]|null,
-    recurrence?: Azurerm_scheduler_job_recurrence_781[]|null,
-    retry?: Azurerm_scheduler_job_retry_783[]|null,
+    action_storage_queue?: Azurerm_scheduler_job_action_storage_queue_183[]|null,
+    action_web?: Azurerm_scheduler_job_action_web_184[]|null,
+    error_action_storage_queue?: Azurerm_scheduler_job_error_action_storage_queue_188[]|null,
+    error_action_web?: Azurerm_scheduler_job_error_action_web_189[]|null,
+    recurrence?: Azurerm_scheduler_job_recurrence_193[]|null,
+    retry?: Azurerm_scheduler_job_retry_195[]|null,
     start_time?: string|null,
     state?: string|null
   }) {
@@ -18953,7 +18953,7 @@ export class Azurerm_scheduler_jobHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_scheduler_job_action_storage_queue_771 implements PcoreValue {
+export class Azurerm_scheduler_job_action_storage_queue_183 implements PcoreValue {
   readonly message: string;
   readonly sas_token: string;
   readonly storage_account_name: string;
@@ -18986,16 +18986,16 @@ export class Azurerm_scheduler_job_action_storage_queue_771 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_action_storage_queue_771';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_action_storage_queue_183';
   }
 }
 
-export class Azurerm_scheduler_job_action_web_772 implements PcoreValue {
+export class Azurerm_scheduler_job_action_web_184 implements PcoreValue {
   readonly method: string;
   readonly url: string;
-  readonly authentication_active_directory: Azurerm_scheduler_job_action_web_772_authentication_active_directory_773[]|null;
-  readonly authentication_basic: Azurerm_scheduler_job_action_web_772_authentication_basic_774[]|null;
-  readonly authentication_certificate: Azurerm_scheduler_job_action_web_772_authentication_certificate_775[]|null;
+  readonly authentication_active_directory: Azurerm_scheduler_job_action_web_184_authentication_active_directory_185[]|null;
+  readonly authentication_basic: Azurerm_scheduler_job_action_web_184_authentication_basic_186[]|null;
+  readonly authentication_certificate: Azurerm_scheduler_job_action_web_184_authentication_certificate_187[]|null;
   readonly body: string|null;
   readonly headers: {[s: string]: string}|null;
 
@@ -19010,9 +19010,9 @@ export class Azurerm_scheduler_job_action_web_772 implements PcoreValue {
   }: {
     method: string,
     url: string,
-    authentication_active_directory?: Azurerm_scheduler_job_action_web_772_authentication_active_directory_773[]|null,
-    authentication_basic?: Azurerm_scheduler_job_action_web_772_authentication_basic_774[]|null,
-    authentication_certificate?: Azurerm_scheduler_job_action_web_772_authentication_certificate_775[]|null,
+    authentication_active_directory?: Azurerm_scheduler_job_action_web_184_authentication_active_directory_185[]|null,
+    authentication_basic?: Azurerm_scheduler_job_action_web_184_authentication_basic_186[]|null,
+    authentication_certificate?: Azurerm_scheduler_job_action_web_184_authentication_certificate_187[]|null,
     body?: string|null,
     headers?: {[s: string]: string}|null
   }) {
@@ -19048,11 +19048,11 @@ export class Azurerm_scheduler_job_action_web_772 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_772';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_184';
   }
 }
 
-export class Azurerm_scheduler_job_action_web_772_authentication_active_directory_773 implements PcoreValue {
+export class Azurerm_scheduler_job_action_web_184_authentication_active_directory_185 implements PcoreValue {
   readonly client_id: string;
   readonly secret: string;
   readonly tenant_id: string;
@@ -19087,11 +19087,11 @@ export class Azurerm_scheduler_job_action_web_772_authentication_active_director
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_772_authentication_active_directory_773';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_184_authentication_active_directory_185';
   }
 }
 
-export class Azurerm_scheduler_job_action_web_772_authentication_basic_774 implements PcoreValue {
+export class Azurerm_scheduler_job_action_web_184_authentication_basic_186 implements PcoreValue {
   readonly password: string;
   readonly username: string;
 
@@ -19114,11 +19114,11 @@ export class Azurerm_scheduler_job_action_web_772_authentication_basic_774 imple
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_772_authentication_basic_774';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_184_authentication_basic_186';
   }
 }
 
-export class Azurerm_scheduler_job_action_web_772_authentication_certificate_775 implements PcoreValue {
+export class Azurerm_scheduler_job_action_web_184_authentication_certificate_187 implements PcoreValue {
   readonly password: string;
   readonly pfx: string;
   readonly expiration: string|null;
@@ -19162,7 +19162,7 @@ export class Azurerm_scheduler_job_action_web_772_authentication_certificate_775
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_772_authentication_certificate_775';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_action_web_184_authentication_certificate_187';
   }
 }
 
@@ -19172,7 +19172,7 @@ export class Azurerm_scheduler_job_collection implements PcoreValue {
   readonly resource_group_name: string;
   readonly sku: string;
   readonly azurerm_scheduler_job_collection_id: string|null;
-  readonly quota: Azurerm_scheduler_job_collection_quota_784[]|null;
+  readonly quota: Azurerm_scheduler_job_collection_quota_196[]|null;
   readonly state: string|null;
   readonly tags: {[s: string]: string}|null;
 
@@ -19191,7 +19191,7 @@ export class Azurerm_scheduler_job_collection implements PcoreValue {
     resource_group_name: string,
     sku: string,
     azurerm_scheduler_job_collection_id?: string|null,
-    quota?: Azurerm_scheduler_job_collection_quota_784[]|null,
+    quota?: Azurerm_scheduler_job_collection_quota_196[]|null,
     state?: string|null,
     tags?: {[s: string]: string}|null
   }) {
@@ -19241,7 +19241,7 @@ export class Azurerm_scheduler_job_collectionHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_scheduler_job_collection_quota_784 implements PcoreValue {
+export class Azurerm_scheduler_job_collection_quota_196 implements PcoreValue {
   readonly max_recurrence_frequency: string;
   readonly max_job_count: number|null;
   readonly max_recurrence_interval: number|null;
@@ -19280,11 +19280,11 @@ export class Azurerm_scheduler_job_collection_quota_784 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_collection_quota_784';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_collection_quota_196';
   }
 }
 
-export class Azurerm_scheduler_job_error_action_storage_queue_776 implements PcoreValue {
+export class Azurerm_scheduler_job_error_action_storage_queue_188 implements PcoreValue {
   readonly message: string;
   readonly sas_token: string;
   readonly storage_account_name: string;
@@ -19317,16 +19317,16 @@ export class Azurerm_scheduler_job_error_action_storage_queue_776 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_storage_queue_776';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_storage_queue_188';
   }
 }
 
-export class Azurerm_scheduler_job_error_action_web_777 implements PcoreValue {
+export class Azurerm_scheduler_job_error_action_web_189 implements PcoreValue {
   readonly method: string;
   readonly url: string;
-  readonly authentication_active_directory: Azurerm_scheduler_job_error_action_web_777_authentication_active_directory_778[]|null;
-  readonly authentication_basic: Azurerm_scheduler_job_error_action_web_777_authentication_basic_779[]|null;
-  readonly authentication_certificate: Azurerm_scheduler_job_error_action_web_777_authentication_certificate_780[]|null;
+  readonly authentication_active_directory: Azurerm_scheduler_job_error_action_web_189_authentication_active_directory_190[]|null;
+  readonly authentication_basic: Azurerm_scheduler_job_error_action_web_189_authentication_basic_191[]|null;
+  readonly authentication_certificate: Azurerm_scheduler_job_error_action_web_189_authentication_certificate_192[]|null;
   readonly body: string|null;
   readonly headers: {[s: string]: string}|null;
 
@@ -19341,9 +19341,9 @@ export class Azurerm_scheduler_job_error_action_web_777 implements PcoreValue {
   }: {
     method: string,
     url: string,
-    authentication_active_directory?: Azurerm_scheduler_job_error_action_web_777_authentication_active_directory_778[]|null,
-    authentication_basic?: Azurerm_scheduler_job_error_action_web_777_authentication_basic_779[]|null,
-    authentication_certificate?: Azurerm_scheduler_job_error_action_web_777_authentication_certificate_780[]|null,
+    authentication_active_directory?: Azurerm_scheduler_job_error_action_web_189_authentication_active_directory_190[]|null,
+    authentication_basic?: Azurerm_scheduler_job_error_action_web_189_authentication_basic_191[]|null,
+    authentication_certificate?: Azurerm_scheduler_job_error_action_web_189_authentication_certificate_192[]|null,
     body?: string|null,
     headers?: {[s: string]: string}|null
   }) {
@@ -19379,11 +19379,11 @@ export class Azurerm_scheduler_job_error_action_web_777 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_777';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_189';
   }
 }
 
-export class Azurerm_scheduler_job_error_action_web_777_authentication_active_directory_778 implements PcoreValue {
+export class Azurerm_scheduler_job_error_action_web_189_authentication_active_directory_190 implements PcoreValue {
   readonly client_id: string;
   readonly secret: string;
   readonly tenant_id: string;
@@ -19418,11 +19418,11 @@ export class Azurerm_scheduler_job_error_action_web_777_authentication_active_di
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_777_authentication_active_directory_778';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_189_authentication_active_directory_190';
   }
 }
 
-export class Azurerm_scheduler_job_error_action_web_777_authentication_basic_779 implements PcoreValue {
+export class Azurerm_scheduler_job_error_action_web_189_authentication_basic_191 implements PcoreValue {
   readonly password: string;
   readonly username: string;
 
@@ -19445,11 +19445,11 @@ export class Azurerm_scheduler_job_error_action_web_777_authentication_basic_779
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_777_authentication_basic_779';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_189_authentication_basic_191';
   }
 }
 
-export class Azurerm_scheduler_job_error_action_web_777_authentication_certificate_780 implements PcoreValue {
+export class Azurerm_scheduler_job_error_action_web_189_authentication_certificate_192 implements PcoreValue {
   readonly password: string;
   readonly pfx: string;
   readonly expiration: string|null;
@@ -19493,11 +19493,11 @@ export class Azurerm_scheduler_job_error_action_web_777_authentication_certifica
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_777_authentication_certificate_780';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_error_action_web_189_authentication_certificate_192';
   }
 }
 
-export class Azurerm_scheduler_job_recurrence_781 implements PcoreValue {
+export class Azurerm_scheduler_job_recurrence_193 implements PcoreValue {
   readonly frequency: string;
   readonly count: number|null;
   readonly end_time: string|null;
@@ -19505,7 +19505,7 @@ export class Azurerm_scheduler_job_recurrence_781 implements PcoreValue {
   readonly interval: number|null;
   readonly minutes: number[]|null;
   readonly month_days: number[]|null;
-  readonly monthly_occurrences: Azurerm_scheduler_job_recurrence_781_monthly_occurrences_782[]|null;
+  readonly monthly_occurrences: Azurerm_scheduler_job_recurrence_193_monthly_occurrences_194[]|null;
   readonly week_days: string[]|null;
 
   constructor({
@@ -19526,7 +19526,7 @@ export class Azurerm_scheduler_job_recurrence_781 implements PcoreValue {
     interval?: number|null,
     minutes?: number[]|null,
     month_days?: number[]|null,
-    monthly_occurrences?: Azurerm_scheduler_job_recurrence_781_monthly_occurrences_782[]|null,
+    monthly_occurrences?: Azurerm_scheduler_job_recurrence_193_monthly_occurrences_194[]|null,
     week_days?: string[]|null
   }) {
     this.frequency = frequency;
@@ -19571,11 +19571,11 @@ export class Azurerm_scheduler_job_recurrence_781 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_recurrence_781';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_recurrence_193';
   }
 }
 
-export class Azurerm_scheduler_job_recurrence_781_monthly_occurrences_782 implements PcoreValue {
+export class Azurerm_scheduler_job_recurrence_193_monthly_occurrences_194 implements PcoreValue {
   readonly day: string;
   readonly occurrence: number;
 
@@ -19598,11 +19598,11 @@ export class Azurerm_scheduler_job_recurrence_781_monthly_occurrences_782 implem
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_recurrence_781_monthly_occurrences_782';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_recurrence_193_monthly_occurrences_194';
   }
 }
 
-export class Azurerm_scheduler_job_retry_783 implements PcoreValue {
+export class Azurerm_scheduler_job_retry_195 implements PcoreValue {
   readonly count: number|null;
   readonly interval: string|null;
 
@@ -19629,7 +19629,7 @@ export class Azurerm_scheduler_job_retry_783 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_scheduler_job_retry_783';
+    return 'TerraformAzureRM::Azurerm_scheduler_job_retry_195';
   }
 }
 
@@ -19863,21 +19863,21 @@ export class Azurerm_service_fabric_cluster implements PcoreValue {
   readonly location: string;
   readonly management_endpoint: string;
   readonly name: string;
-  readonly node_type: Azurerm_service_fabric_cluster_node_type_790[];
+  readonly node_type: Azurerm_service_fabric_cluster_node_type_202[];
   readonly reliability_level: string;
   readonly resource_group_name: string;
   readonly upgrade_mode: string;
   readonly vm_image: string;
   readonly azurerm_service_fabric_cluster_id: string|null;
   readonly add_on_features: string[]|null;
-  readonly azure_active_directory: Azurerm_service_fabric_cluster_azure_active_directory_785[]|null;
-  readonly certificate: Azurerm_service_fabric_cluster_certificate_786[]|null;
-  readonly client_certificate_thumbprint: Azurerm_service_fabric_cluster_client_certificate_thumbprint_787[]|null;
+  readonly azure_active_directory: Azurerm_service_fabric_cluster_azure_active_directory_197[]|null;
+  readonly certificate: Azurerm_service_fabric_cluster_certificate_198[]|null;
+  readonly client_certificate_thumbprint: Azurerm_service_fabric_cluster_client_certificate_thumbprint_199[]|null;
   readonly cluster_code_version: string|null;
   readonly cluster_endpoint: string|null;
-  readonly diagnostics_config: Azurerm_service_fabric_cluster_diagnostics_config_788[]|null;
-  readonly fabric_settings: Azurerm_service_fabric_cluster_fabric_settings_789[]|null;
-  readonly reverse_proxy_certificate: Azurerm_service_fabric_cluster_reverse_proxy_certificate_793[]|null;
+  readonly diagnostics_config: Azurerm_service_fabric_cluster_diagnostics_config_200[]|null;
+  readonly fabric_settings: Azurerm_service_fabric_cluster_fabric_settings_201[]|null;
+  readonly reverse_proxy_certificate: Azurerm_service_fabric_cluster_reverse_proxy_certificate_205[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -19904,21 +19904,21 @@ export class Azurerm_service_fabric_cluster implements PcoreValue {
     location: string,
     management_endpoint: string,
     name: string,
-    node_type: Azurerm_service_fabric_cluster_node_type_790[],
+    node_type: Azurerm_service_fabric_cluster_node_type_202[],
     reliability_level: string,
     resource_group_name: string,
     upgrade_mode: string,
     vm_image: string,
     azurerm_service_fabric_cluster_id?: string|null,
     add_on_features?: string[]|null,
-    azure_active_directory?: Azurerm_service_fabric_cluster_azure_active_directory_785[]|null,
-    certificate?: Azurerm_service_fabric_cluster_certificate_786[]|null,
-    client_certificate_thumbprint?: Azurerm_service_fabric_cluster_client_certificate_thumbprint_787[]|null,
+    azure_active_directory?: Azurerm_service_fabric_cluster_azure_active_directory_197[]|null,
+    certificate?: Azurerm_service_fabric_cluster_certificate_198[]|null,
+    client_certificate_thumbprint?: Azurerm_service_fabric_cluster_client_certificate_thumbprint_199[]|null,
     cluster_code_version?: string|null,
     cluster_endpoint?: string|null,
-    diagnostics_config?: Azurerm_service_fabric_cluster_diagnostics_config_788[]|null,
-    fabric_settings?: Azurerm_service_fabric_cluster_fabric_settings_789[]|null,
-    reverse_proxy_certificate?: Azurerm_service_fabric_cluster_reverse_proxy_certificate_793[]|null,
+    diagnostics_config?: Azurerm_service_fabric_cluster_diagnostics_config_200[]|null,
+    fabric_settings?: Azurerm_service_fabric_cluster_fabric_settings_201[]|null,
+    reverse_proxy_certificate?: Azurerm_service_fabric_cluster_reverse_proxy_certificate_205[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.location = location;
@@ -20003,7 +20003,7 @@ export class Azurerm_service_fabric_clusterHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_service_fabric_cluster_azure_active_directory_785 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_azure_active_directory_197 implements PcoreValue {
   readonly client_application_id: string;
   readonly cluster_application_id: string;
   readonly tenant_id: string;
@@ -20031,11 +20031,11 @@ export class Azurerm_service_fabric_cluster_azure_active_directory_785 implement
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_azure_active_directory_785';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_azure_active_directory_197';
   }
 }
 
-export class Azurerm_service_fabric_cluster_certificate_786 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_certificate_198 implements PcoreValue {
   readonly thumbprint: string;
   readonly x509_store_name: string;
   readonly thumbprint_secondary: string|null;
@@ -20065,11 +20065,11 @@ export class Azurerm_service_fabric_cluster_certificate_786 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_certificate_786';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_certificate_198';
   }
 }
 
-export class Azurerm_service_fabric_cluster_client_certificate_thumbprint_787 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_client_certificate_thumbprint_199 implements PcoreValue {
   readonly is_admin: boolean;
   readonly thumbprint: string;
 
@@ -20092,11 +20092,11 @@ export class Azurerm_service_fabric_cluster_client_certificate_thumbprint_787 im
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_client_certificate_thumbprint_787';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_client_certificate_thumbprint_199';
   }
 }
 
-export class Azurerm_service_fabric_cluster_diagnostics_config_788 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_diagnostics_config_200 implements PcoreValue {
   readonly blob_endpoint: string;
   readonly protected_account_key_name: string;
   readonly queue_endpoint: string;
@@ -20134,11 +20134,11 @@ export class Azurerm_service_fabric_cluster_diagnostics_config_788 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_diagnostics_config_788';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_diagnostics_config_200';
   }
 }
 
-export class Azurerm_service_fabric_cluster_fabric_settings_789 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_fabric_settings_201 implements PcoreValue {
   readonly name: string;
   readonly parameters: {[s: string]: string}|null;
 
@@ -20163,19 +20163,19 @@ export class Azurerm_service_fabric_cluster_fabric_settings_789 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_fabric_settings_789';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_fabric_settings_201';
   }
 }
 
-export class Azurerm_service_fabric_cluster_node_type_790 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_node_type_202 implements PcoreValue {
   readonly client_endpoint_port: number;
   readonly http_endpoint_port: number;
   readonly instance_count: number;
   readonly is_primary: boolean;
   readonly name: string;
-  readonly application_ports: Azurerm_service_fabric_cluster_node_type_790_application_ports_791[]|null;
+  readonly application_ports: Azurerm_service_fabric_cluster_node_type_202_application_ports_203[]|null;
   readonly durability_level: string|null;
-  readonly ephemeral_ports: Azurerm_service_fabric_cluster_node_type_790_ephemeral_ports_792[]|null;
+  readonly ephemeral_ports: Azurerm_service_fabric_cluster_node_type_202_ephemeral_ports_204[]|null;
   readonly reverse_proxy_endpoint_port: number|null;
 
   constructor({
@@ -20194,9 +20194,9 @@ export class Azurerm_service_fabric_cluster_node_type_790 implements PcoreValue 
     instance_count: number,
     is_primary: boolean,
     name: string,
-    application_ports?: Azurerm_service_fabric_cluster_node_type_790_application_ports_791[]|null,
+    application_ports?: Azurerm_service_fabric_cluster_node_type_202_application_ports_203[]|null,
     durability_level?: string|null,
-    ephemeral_ports?: Azurerm_service_fabric_cluster_node_type_790_ephemeral_ports_792[]|null,
+    ephemeral_ports?: Azurerm_service_fabric_cluster_node_type_202_ephemeral_ports_204[]|null,
     reverse_proxy_endpoint_port?: number|null
   }) {
     this.client_endpoint_port = client_endpoint_port;
@@ -20233,11 +20233,11 @@ export class Azurerm_service_fabric_cluster_node_type_790 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_node_type_790';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_node_type_202';
   }
 }
 
-export class Azurerm_service_fabric_cluster_node_type_790_application_ports_791 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_node_type_202_application_ports_203 implements PcoreValue {
   readonly end_port: number;
   readonly start_port: number;
 
@@ -20260,11 +20260,11 @@ export class Azurerm_service_fabric_cluster_node_type_790_application_ports_791 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_node_type_790_application_ports_791';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_node_type_202_application_ports_203';
   }
 }
 
-export class Azurerm_service_fabric_cluster_node_type_790_ephemeral_ports_792 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_node_type_202_ephemeral_ports_204 implements PcoreValue {
   readonly end_port: number;
   readonly start_port: number;
 
@@ -20287,11 +20287,11 @@ export class Azurerm_service_fabric_cluster_node_type_790_ephemeral_ports_792 im
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_node_type_790_ephemeral_ports_792';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_node_type_202_ephemeral_ports_204';
   }
 }
 
-export class Azurerm_service_fabric_cluster_reverse_proxy_certificate_793 implements PcoreValue {
+export class Azurerm_service_fabric_cluster_reverse_proxy_certificate_205 implements PcoreValue {
   readonly thumbprint: string;
   readonly x509_store_name: string;
   readonly thumbprint_secondary: string|null;
@@ -20321,7 +20321,7 @@ export class Azurerm_service_fabric_cluster_reverse_proxy_certificate_793 implem
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_reverse_proxy_certificate_793';
+    return 'TerraformAzureRM::Azurerm_service_fabric_cluster_reverse_proxy_certificate_205';
   }
 }
 
@@ -20900,7 +20900,7 @@ export class Azurerm_servicebus_subscription_rule implements PcoreValue {
   readonly topic_name: string;
   readonly azurerm_servicebus_subscription_rule_id: string|null;
   readonly action: string|null;
-  readonly correlation_filter: Azurerm_servicebus_subscription_rule_correlation_filter_794[]|null;
+  readonly correlation_filter: Azurerm_servicebus_subscription_rule_correlation_filter_206[]|null;
   readonly sql_filter: string|null;
 
   constructor({
@@ -20923,7 +20923,7 @@ export class Azurerm_servicebus_subscription_rule implements PcoreValue {
     topic_name: string,
     azurerm_servicebus_subscription_rule_id?: string|null,
     action?: string|null,
-    correlation_filter?: Azurerm_servicebus_subscription_rule_correlation_filter_794[]|null,
+    correlation_filter?: Azurerm_servicebus_subscription_rule_correlation_filter_206[]|null,
     sql_filter?: string|null
   }) {
     this.filter_type = filter_type;
@@ -20976,7 +20976,7 @@ export class Azurerm_servicebus_subscription_ruleHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_servicebus_subscription_rule_correlation_filter_794 implements PcoreValue {
+export class Azurerm_servicebus_subscription_rule_correlation_filter_206 implements PcoreValue {
   readonly content_type: string|null;
   readonly correlation_id: string|null;
   readonly label: string|null;
@@ -21045,7 +21045,7 @@ export class Azurerm_servicebus_subscription_rule_correlation_filter_794 impleme
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_servicebus_subscription_rule_correlation_filter_794';
+    return 'TerraformAzureRM::Azurerm_servicebus_subscription_rule_correlation_filter_206';
   }
 }
 
@@ -21287,7 +21287,7 @@ export class Azurerm_servicebus_topic_authorization_ruleHandler implements Pcore
 
 export class Azurerm_shared_image implements PcoreValue {
   readonly gallery_name: string;
-  readonly identifier: Azurerm_shared_image_identifier_795[];
+  readonly identifier: Azurerm_shared_image_identifier_207[];
   readonly location: string;
   readonly name: string;
   readonly os_type: string;
@@ -21314,7 +21314,7 @@ export class Azurerm_shared_image implements PcoreValue {
     tags = null
   }: {
     gallery_name: string,
-    identifier: Azurerm_shared_image_identifier_795[],
+    identifier: Azurerm_shared_image_identifier_207[],
     location: string,
     name: string,
     os_type: string,
@@ -21454,7 +21454,7 @@ export class Azurerm_shared_image_galleryHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_shared_image_identifier_795 implements PcoreValue {
+export class Azurerm_shared_image_identifier_207 implements PcoreValue {
   readonly offer: string;
   readonly publisher: string;
   readonly sku: string;
@@ -21482,7 +21482,7 @@ export class Azurerm_shared_image_identifier_795 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_shared_image_identifier_795';
+    return 'TerraformAzureRM::Azurerm_shared_image_identifier_207';
   }
 }
 
@@ -21493,7 +21493,7 @@ export class Azurerm_shared_image_version implements PcoreValue {
   readonly managed_image_id: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly target_region: Azurerm_shared_image_version_target_region_796[];
+  readonly target_region: Azurerm_shared_image_version_target_region_208[];
   readonly azurerm_shared_image_version_id: string|null;
   readonly exclude_from_latest: boolean|null;
   readonly tags: {[s: string]: string}|null;
@@ -21516,7 +21516,7 @@ export class Azurerm_shared_image_version implements PcoreValue {
     managed_image_id: string,
     name: string,
     resource_group_name: string,
-    target_region: Azurerm_shared_image_version_target_region_796[],
+    target_region: Azurerm_shared_image_version_target_region_208[],
     azurerm_shared_image_version_id?: string|null,
     exclude_from_latest?: boolean|null,
     tags?: {[s: string]: string}|null
@@ -21569,7 +21569,7 @@ export class Azurerm_shared_image_versionHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_shared_image_version_target_region_796 implements PcoreValue {
+export class Azurerm_shared_image_version_target_region_208 implements PcoreValue {
   readonly name: string;
   readonly regional_replica_count: number;
 
@@ -21592,7 +21592,7 @@ export class Azurerm_shared_image_version_target_region_796 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_shared_image_version_target_region_796';
+    return 'TerraformAzureRM::Azurerm_shared_image_version_target_region_208';
   }
 }
 
@@ -21600,7 +21600,7 @@ export class Azurerm_signalr_service implements PcoreValue {
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
-  readonly sku: Azurerm_signalr_service_sku_797[];
+  readonly sku: Azurerm_signalr_service_sku_209[];
   readonly azurerm_signalr_service_id: string|null;
   readonly hostname: string|null;
   readonly ip_address: string|null;
@@ -21623,7 +21623,7 @@ export class Azurerm_signalr_service implements PcoreValue {
     location: string,
     name: string,
     resource_group_name: string,
-    sku: Azurerm_signalr_service_sku_797[],
+    sku: Azurerm_signalr_service_sku_209[],
     azurerm_signalr_service_id?: string|null,
     hostname?: string|null,
     ip_address?: string|null,
@@ -21685,7 +21685,7 @@ export class Azurerm_signalr_serviceHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_signalr_service_sku_797 implements PcoreValue {
+export class Azurerm_signalr_service_sku_209 implements PcoreValue {
   readonly capacity: number;
   readonly name: string;
 
@@ -21708,7 +21708,7 @@ export class Azurerm_signalr_service_sku_797 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_signalr_service_sku_797';
+    return 'TerraformAzureRM::Azurerm_signalr_service_sku_209';
   }
 }
 
@@ -21719,7 +21719,7 @@ export class Azurerm_snapshot implements PcoreValue {
   readonly resource_group_name: string;
   readonly azurerm_snapshot_id: string|null;
   readonly disk_size_gb: number|null;
-  readonly encryption_settings: Azurerm_snapshot_encryption_settings_798[]|null;
+  readonly encryption_settings: Azurerm_snapshot_encryption_settings_210[]|null;
   readonly source_resource_id: string|null;
   readonly source_uri: string|null;
   readonly storage_account_id: string|null;
@@ -21744,7 +21744,7 @@ export class Azurerm_snapshot implements PcoreValue {
     resource_group_name: string,
     azurerm_snapshot_id?: string|null,
     disk_size_gb?: number|null,
-    encryption_settings?: Azurerm_snapshot_encryption_settings_798[]|null,
+    encryption_settings?: Azurerm_snapshot_encryption_settings_210[]|null,
     source_resource_id?: string|null,
     source_uri?: string|null,
     storage_account_id?: string|null,
@@ -21808,10 +21808,10 @@ export class Azurerm_snapshotHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_snapshot_encryption_settings_798 implements PcoreValue {
+export class Azurerm_snapshot_encryption_settings_210 implements PcoreValue {
   readonly enabled: boolean;
-  readonly disk_encryption_key: Azurerm_snapshot_encryption_settings_798_disk_encryption_key_799[]|null;
-  readonly key_encryption_key: Azurerm_snapshot_encryption_settings_798_key_encryption_key_800[]|null;
+  readonly disk_encryption_key: Azurerm_snapshot_encryption_settings_210_disk_encryption_key_211[]|null;
+  readonly key_encryption_key: Azurerm_snapshot_encryption_settings_210_key_encryption_key_212[]|null;
 
   constructor({
     enabled,
@@ -21819,8 +21819,8 @@ export class Azurerm_snapshot_encryption_settings_798 implements PcoreValue {
     key_encryption_key = null
   }: {
     enabled: boolean,
-    disk_encryption_key?: Azurerm_snapshot_encryption_settings_798_disk_encryption_key_799[]|null,
-    key_encryption_key?: Azurerm_snapshot_encryption_settings_798_key_encryption_key_800[]|null
+    disk_encryption_key?: Azurerm_snapshot_encryption_settings_210_disk_encryption_key_211[]|null,
+    key_encryption_key?: Azurerm_snapshot_encryption_settings_210_key_encryption_key_212[]|null
   }) {
     this.enabled = enabled;
     this.disk_encryption_key = disk_encryption_key;
@@ -21840,11 +21840,11 @@ export class Azurerm_snapshot_encryption_settings_798 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_snapshot_encryption_settings_798';
+    return 'TerraformAzureRM::Azurerm_snapshot_encryption_settings_210';
   }
 }
 
-export class Azurerm_snapshot_encryption_settings_798_disk_encryption_key_799 implements PcoreValue {
+export class Azurerm_snapshot_encryption_settings_210_disk_encryption_key_211 implements PcoreValue {
   readonly secret_url: string;
   readonly source_vault_id: string;
 
@@ -21867,11 +21867,11 @@ export class Azurerm_snapshot_encryption_settings_798_disk_encryption_key_799 im
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_snapshot_encryption_settings_798_disk_encryption_key_799';
+    return 'TerraformAzureRM::Azurerm_snapshot_encryption_settings_210_disk_encryption_key_211';
   }
 }
 
-export class Azurerm_snapshot_encryption_settings_798_key_encryption_key_800 implements PcoreValue {
+export class Azurerm_snapshot_encryption_settings_210_key_encryption_key_212 implements PcoreValue {
   readonly key_url: string;
   readonly source_vault_id: string;
 
@@ -21894,7 +21894,7 @@ export class Azurerm_snapshot_encryption_settings_798_key_encryption_key_800 imp
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_snapshot_encryption_settings_798_key_encryption_key_800';
+    return 'TerraformAzureRM::Azurerm_snapshot_encryption_settings_210_key_encryption_key_212';
   }
 }
 
@@ -21970,7 +21970,7 @@ export class Azurerm_sql_database implements PcoreValue {
   readonly edition: string|null;
   readonly elastic_pool_name: string|null;
   readonly encryption: string|null;
-  readonly import_: Azurerm_sql_database_import_801[]|null;
+  readonly import_: Azurerm_sql_database_import_213[]|null;
   readonly max_size_bytes: string|null;
   readonly requested_service_objective_id: string|null;
   readonly requested_service_objective_name: string|null;
@@ -21978,7 +21978,7 @@ export class Azurerm_sql_database implements PcoreValue {
   readonly source_database_deletion_date: string|null;
   readonly source_database_id: string|null;
   readonly tags: {[s: string]: string}|null;
-  readonly threat_detection_policy: Azurerm_sql_database_threat_detection_policy_802[]|null;
+  readonly threat_detection_policy: Azurerm_sql_database_threat_detection_policy_214[]|null;
 
   constructor({
     location,
@@ -22015,7 +22015,7 @@ export class Azurerm_sql_database implements PcoreValue {
     edition?: string|null,
     elastic_pool_name?: string|null,
     encryption?: string|null,
-    import_?: Azurerm_sql_database_import_801[]|null,
+    import_?: Azurerm_sql_database_import_213[]|null,
     max_size_bytes?: string|null,
     requested_service_objective_id?: string|null,
     requested_service_objective_name?: string|null,
@@ -22023,7 +22023,7 @@ export class Azurerm_sql_database implements PcoreValue {
     source_database_deletion_date?: string|null,
     source_database_id?: string|null,
     tags?: {[s: string]: string}|null,
-    threat_detection_policy?: Azurerm_sql_database_threat_detection_policy_802[]|null
+    threat_detection_policy?: Azurerm_sql_database_threat_detection_policy_214[]|null
   }) {
     this.location = location;
     this.name = name;
@@ -22123,7 +22123,7 @@ export class Azurerm_sql_databaseHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_sql_database_import_801 implements PcoreValue {
+export class Azurerm_sql_database_import_213 implements PcoreValue {
   readonly administrator_login: string;
   readonly administrator_login_password: string;
   readonly authentication_type: string;
@@ -22173,11 +22173,11 @@ export class Azurerm_sql_database_import_801 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_sql_database_import_801';
+    return 'TerraformAzureRM::Azurerm_sql_database_import_213';
   }
 }
 
-export class Azurerm_sql_database_threat_detection_policy_802 implements PcoreValue {
+export class Azurerm_sql_database_threat_detection_policy_214 implements PcoreValue {
   readonly disabled_alerts: string[]|null;
   readonly email_account_admins: string|null;
   readonly email_addresses: string[]|null;
@@ -22246,7 +22246,7 @@ export class Azurerm_sql_database_threat_detection_policy_802 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_sql_database_threat_detection_policy_802';
+    return 'TerraformAzureRM::Azurerm_sql_database_threat_detection_policy_214';
   }
 }
 
@@ -22558,12 +22558,12 @@ export class Azurerm_storage_account implements PcoreValue {
   readonly account_encryption_source: string|null;
   readonly account_kind: string|null;
   readonly account_type: string|null;
-  readonly custom_domain: Azurerm_storage_account_custom_domain_803[]|null;
+  readonly custom_domain: Azurerm_storage_account_custom_domain_215[]|null;
   readonly enable_blob_encryption: boolean|null;
   readonly enable_file_encryption: boolean|null;
   readonly enable_https_traffic_only: boolean|null;
-  readonly identity: Azurerm_storage_account_identity_804[]|null;
-  readonly network_rules: Azurerm_storage_account_network_rules_805[]|null;
+  readonly identity: Azurerm_storage_account_identity_216[]|null;
+  readonly network_rules: Azurerm_storage_account_network_rules_217[]|null;
   readonly primary_access_key: string|null;
   readonly primary_blob_connection_string: string|null;
   readonly primary_blob_endpoint: string|null;
@@ -22625,12 +22625,12 @@ export class Azurerm_storage_account implements PcoreValue {
     account_encryption_source?: string|null,
     account_kind?: string|null,
     account_type?: string|null,
-    custom_domain?: Azurerm_storage_account_custom_domain_803[]|null,
+    custom_domain?: Azurerm_storage_account_custom_domain_215[]|null,
     enable_blob_encryption?: boolean|null,
     enable_file_encryption?: boolean|null,
     enable_https_traffic_only?: boolean|null,
-    identity?: Azurerm_storage_account_identity_804[]|null,
-    network_rules?: Azurerm_storage_account_network_rules_805[]|null,
+    identity?: Azurerm_storage_account_identity_216[]|null,
+    network_rules?: Azurerm_storage_account_network_rules_217[]|null,
     primary_access_key?: string|null,
     primary_blob_connection_string?: string|null,
     primary_blob_endpoint?: string|null,
@@ -22788,7 +22788,7 @@ export class Azurerm_storage_accountHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_storage_account_custom_domain_803 implements PcoreValue {
+export class Azurerm_storage_account_custom_domain_215 implements PcoreValue {
   readonly name: string;
   readonly use_subdomain: boolean|null;
 
@@ -22813,11 +22813,11 @@ export class Azurerm_storage_account_custom_domain_803 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_storage_account_custom_domain_803';
+    return 'TerraformAzureRM::Azurerm_storage_account_custom_domain_215';
   }
 }
 
-export class Azurerm_storage_account_identity_804 implements PcoreValue {
+export class Azurerm_storage_account_identity_216 implements PcoreValue {
   readonly type: string;
   readonly principal_id: string|null;
   readonly tenant_id: string|null;
@@ -22849,11 +22849,11 @@ export class Azurerm_storage_account_identity_804 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_storage_account_identity_804';
+    return 'TerraformAzureRM::Azurerm_storage_account_identity_216';
   }
 }
 
-export class Azurerm_storage_account_network_rules_805 implements PcoreValue {
+export class Azurerm_storage_account_network_rules_217 implements PcoreValue {
   readonly bypass: string[]|null;
   readonly ip_rules: string[]|null;
   readonly virtual_network_subnet_ids: string[]|null;
@@ -22887,7 +22887,7 @@ export class Azurerm_storage_account_network_rules_805 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_storage_account_network_rules_805';
+    return 'TerraformAzureRM::Azurerm_storage_account_network_rules_217';
   }
 }
 
@@ -23231,7 +23231,7 @@ export class Azurerm_subnet implements PcoreValue {
   readonly resource_group_name: string;
   readonly virtual_network_name: string;
   readonly azurerm_subnet_id: string|null;
-  readonly delegation: Azurerm_subnet_delegation_806[]|null;
+  readonly delegation: Azurerm_subnet_delegation_218[]|null;
   readonly ip_configurations: string[]|null;
   readonly network_security_group_id: string|null;
   readonly route_table_id: string|null;
@@ -23254,7 +23254,7 @@ export class Azurerm_subnet implements PcoreValue {
     resource_group_name: string,
     virtual_network_name: string,
     azurerm_subnet_id?: string|null,
-    delegation?: Azurerm_subnet_delegation_806[]|null,
+    delegation?: Azurerm_subnet_delegation_218[]|null,
     ip_configurations?: string[]|null,
     network_security_group_id?: string|null,
     route_table_id?: string|null,
@@ -23314,16 +23314,16 @@ export class Azurerm_subnetHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_subnet_delegation_806 implements PcoreValue {
+export class Azurerm_subnet_delegation_218 implements PcoreValue {
   readonly name: string;
-  readonly service_delegation: Azurerm_subnet_delegation_806_service_delegation_807[];
+  readonly service_delegation: Azurerm_subnet_delegation_218_service_delegation_219[];
 
   constructor({
     name,
     service_delegation
   }: {
     name: string,
-    service_delegation: Azurerm_subnet_delegation_806_service_delegation_807[]
+    service_delegation: Azurerm_subnet_delegation_218_service_delegation_219[]
   }) {
     this.name = name;
     this.service_delegation = service_delegation;
@@ -23337,11 +23337,11 @@ export class Azurerm_subnet_delegation_806 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_subnet_delegation_806';
+    return 'TerraformAzureRM::Azurerm_subnet_delegation_218';
   }
 }
 
-export class Azurerm_subnet_delegation_806_service_delegation_807 implements PcoreValue {
+export class Azurerm_subnet_delegation_218_service_delegation_219 implements PcoreValue {
   readonly name: string;
   readonly actions: string[]|null;
 
@@ -23366,7 +23366,7 @@ export class Azurerm_subnet_delegation_806_service_delegation_807 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_subnet_delegation_806_service_delegation_807';
+    return 'TerraformAzureRM::Azurerm_subnet_delegation_218_service_delegation_219';
   }
 }
 
@@ -23653,8 +23653,8 @@ export class Azurerm_traffic_manager_endpointHandler implements PcoreValue {
 }
 
 export class Azurerm_traffic_manager_profile implements PcoreValue {
-  readonly dns_config: Azurerm_traffic_manager_profile_dns_config_808[];
-  readonly monitor_config: Azurerm_traffic_manager_profile_monitor_config_809[];
+  readonly dns_config: Azurerm_traffic_manager_profile_dns_config_220[];
+  readonly monitor_config: Azurerm_traffic_manager_profile_monitor_config_221[];
   readonly name: string;
   readonly resource_group_name: string;
   readonly traffic_routing_method: string;
@@ -23674,8 +23674,8 @@ export class Azurerm_traffic_manager_profile implements PcoreValue {
     profile_status = null,
     tags = null
   }: {
-    dns_config: Azurerm_traffic_manager_profile_dns_config_808[],
-    monitor_config: Azurerm_traffic_manager_profile_monitor_config_809[],
+    dns_config: Azurerm_traffic_manager_profile_dns_config_220[],
+    monitor_config: Azurerm_traffic_manager_profile_monitor_config_221[],
     name: string,
     resource_group_name: string,
     traffic_routing_method: string,
@@ -23732,7 +23732,7 @@ export class Azurerm_traffic_manager_profileHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_traffic_manager_profile_dns_config_808 implements PcoreValue {
+export class Azurerm_traffic_manager_profile_dns_config_220 implements PcoreValue {
   readonly relative_name: string;
   readonly ttl: number;
 
@@ -23755,11 +23755,11 @@ export class Azurerm_traffic_manager_profile_dns_config_808 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_traffic_manager_profile_dns_config_808';
+    return 'TerraformAzureRM::Azurerm_traffic_manager_profile_dns_config_220';
   }
 }
 
-export class Azurerm_traffic_manager_profile_monitor_config_809 implements PcoreValue {
+export class Azurerm_traffic_manager_profile_monitor_config_221 implements PcoreValue {
   readonly port: number;
   readonly protocol: string;
   readonly path: string|null;
@@ -23789,7 +23789,7 @@ export class Azurerm_traffic_manager_profile_monitor_config_809 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_traffic_manager_profile_monitor_config_809';
+    return 'TerraformAzureRM::Azurerm_traffic_manager_profile_monitor_config_221';
   }
 }
 
@@ -23868,23 +23868,23 @@ export class Azurerm_virtual_machine implements PcoreValue {
   readonly name: string;
   readonly network_interface_ids: string[];
   readonly resource_group_name: string;
-  readonly storage_os_disk: Azurerm_virtual_machine_storage_os_disk_823[];
+  readonly storage_os_disk: Azurerm_virtual_machine_storage_os_disk_235[];
   readonly vm_size: string;
   readonly azurerm_virtual_machine_id: string|null;
   readonly availability_set_id: string|null;
-  readonly boot_diagnostics: Azurerm_virtual_machine_boot_diagnostics_810[]|null;
+  readonly boot_diagnostics: Azurerm_virtual_machine_boot_diagnostics_222[]|null;
   readonly delete_data_disks_on_termination: boolean|null;
   readonly delete_os_disk_on_termination: boolean|null;
-  readonly identity: Azurerm_virtual_machine_identity_811[]|null;
+  readonly identity: Azurerm_virtual_machine_identity_223[]|null;
   readonly license_type: string|null;
-  readonly os_profile: Azurerm_virtual_machine_os_profile_812[]|null;
-  readonly os_profile_linux_config: Azurerm_virtual_machine_os_profile_linux_config_813[]|null;
-  readonly os_profile_secrets: Azurerm_virtual_machine_os_profile_secrets_815[]|null;
-  readonly os_profile_windows_config: Azurerm_virtual_machine_os_profile_windows_config_817[]|null;
-  readonly plan: Azurerm_virtual_machine_plan_820[]|null;
+  readonly os_profile: Azurerm_virtual_machine_os_profile_224[]|null;
+  readonly os_profile_linux_config: Azurerm_virtual_machine_os_profile_linux_config_225[]|null;
+  readonly os_profile_secrets: Azurerm_virtual_machine_os_profile_secrets_227[]|null;
+  readonly os_profile_windows_config: Azurerm_virtual_machine_os_profile_windows_config_229[]|null;
+  readonly plan: Azurerm_virtual_machine_plan_232[]|null;
   readonly primary_network_interface_id: string|null;
-  readonly storage_data_disk: Azurerm_virtual_machine_storage_data_disk_821[]|null;
-  readonly storage_image_reference: Azurerm_virtual_machine_storage_image_reference_822[]|null;
+  readonly storage_data_disk: Azurerm_virtual_machine_storage_data_disk_233[]|null;
+  readonly storage_image_reference: Azurerm_virtual_machine_storage_image_reference_234[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly zones: string[]|null;
 
@@ -23917,23 +23917,23 @@ export class Azurerm_virtual_machine implements PcoreValue {
     name: string,
     network_interface_ids: string[],
     resource_group_name: string,
-    storage_os_disk: Azurerm_virtual_machine_storage_os_disk_823[],
+    storage_os_disk: Azurerm_virtual_machine_storage_os_disk_235[],
     vm_size: string,
     azurerm_virtual_machine_id?: string|null,
     availability_set_id?: string|null,
-    boot_diagnostics?: Azurerm_virtual_machine_boot_diagnostics_810[]|null,
+    boot_diagnostics?: Azurerm_virtual_machine_boot_diagnostics_222[]|null,
     delete_data_disks_on_termination?: boolean|null,
     delete_os_disk_on_termination?: boolean|null,
-    identity?: Azurerm_virtual_machine_identity_811[]|null,
+    identity?: Azurerm_virtual_machine_identity_223[]|null,
     license_type?: string|null,
-    os_profile?: Azurerm_virtual_machine_os_profile_812[]|null,
-    os_profile_linux_config?: Azurerm_virtual_machine_os_profile_linux_config_813[]|null,
-    os_profile_secrets?: Azurerm_virtual_machine_os_profile_secrets_815[]|null,
-    os_profile_windows_config?: Azurerm_virtual_machine_os_profile_windows_config_817[]|null,
-    plan?: Azurerm_virtual_machine_plan_820[]|null,
+    os_profile?: Azurerm_virtual_machine_os_profile_224[]|null,
+    os_profile_linux_config?: Azurerm_virtual_machine_os_profile_linux_config_225[]|null,
+    os_profile_secrets?: Azurerm_virtual_machine_os_profile_secrets_227[]|null,
+    os_profile_windows_config?: Azurerm_virtual_machine_os_profile_windows_config_229[]|null,
+    plan?: Azurerm_virtual_machine_plan_232[]|null,
     primary_network_interface_id?: string|null,
-    storage_data_disk?: Azurerm_virtual_machine_storage_data_disk_821[]|null,
-    storage_image_reference?: Azurerm_virtual_machine_storage_image_reference_822[]|null,
+    storage_data_disk?: Azurerm_virtual_machine_storage_data_disk_233[]|null,
+    storage_image_reference?: Azurerm_virtual_machine_storage_image_reference_234[]|null,
     tags?: {[s: string]: string}|null,
     zones?: string[]|null
   }) {
@@ -24039,7 +24039,7 @@ export class Azurerm_virtual_machineHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_virtual_machine_boot_diagnostics_810 implements PcoreValue {
+export class Azurerm_virtual_machine_boot_diagnostics_222 implements PcoreValue {
   readonly enabled: boolean;
   readonly storage_uri: string;
 
@@ -24062,7 +24062,7 @@ export class Azurerm_virtual_machine_boot_diagnostics_810 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_boot_diagnostics_810';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_boot_diagnostics_222';
   }
 }
 
@@ -24231,7 +24231,7 @@ export class Azurerm_virtual_machine_extensionHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_virtual_machine_identity_811 implements PcoreValue {
+export class Azurerm_virtual_machine_identity_223 implements PcoreValue {
   readonly type: string;
   readonly identity_ids: string[]|null;
   readonly principal_id: string|null;
@@ -24263,11 +24263,11 @@ export class Azurerm_virtual_machine_identity_811 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_identity_811';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_identity_223';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_812 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_224 implements PcoreValue {
   readonly admin_username: string;
   readonly computer_name: string;
   readonly admin_password: string|null;
@@ -24304,20 +24304,20 @@ export class Azurerm_virtual_machine_os_profile_812 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_812';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_224';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_linux_config_813 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_linux_config_225 implements PcoreValue {
   readonly disable_password_authentication: boolean;
-  readonly ssh_keys: Azurerm_virtual_machine_os_profile_linux_config_813_ssh_keys_814[]|null;
+  readonly ssh_keys: Azurerm_virtual_machine_os_profile_linux_config_225_ssh_keys_226[]|null;
 
   constructor({
     disable_password_authentication,
     ssh_keys = null
   }: {
     disable_password_authentication: boolean,
-    ssh_keys?: Azurerm_virtual_machine_os_profile_linux_config_813_ssh_keys_814[]|null
+    ssh_keys?: Azurerm_virtual_machine_os_profile_linux_config_225_ssh_keys_226[]|null
   }) {
     this.disable_password_authentication = disable_password_authentication;
     this.ssh_keys = ssh_keys;
@@ -24333,11 +24333,11 @@ export class Azurerm_virtual_machine_os_profile_linux_config_813 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_linux_config_813';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_linux_config_225';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_linux_config_813_ssh_keys_814 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_linux_config_225_ssh_keys_226 implements PcoreValue {
   readonly key_data: string;
   readonly path: string;
 
@@ -24360,20 +24360,20 @@ export class Azurerm_virtual_machine_os_profile_linux_config_813_ssh_keys_814 im
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_linux_config_813_ssh_keys_814';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_linux_config_225_ssh_keys_226';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_secrets_815 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_secrets_227 implements PcoreValue {
   readonly source_vault_id: string;
-  readonly vault_certificates: Azurerm_virtual_machine_os_profile_secrets_815_vault_certificates_816[]|null;
+  readonly vault_certificates: Azurerm_virtual_machine_os_profile_secrets_227_vault_certificates_228[]|null;
 
   constructor({
     source_vault_id,
     vault_certificates = null
   }: {
     source_vault_id: string,
-    vault_certificates?: Azurerm_virtual_machine_os_profile_secrets_815_vault_certificates_816[]|null
+    vault_certificates?: Azurerm_virtual_machine_os_profile_secrets_227_vault_certificates_228[]|null
   }) {
     this.source_vault_id = source_vault_id;
     this.vault_certificates = vault_certificates;
@@ -24389,11 +24389,11 @@ export class Azurerm_virtual_machine_os_profile_secrets_815 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_secrets_815';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_secrets_227';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_secrets_815_vault_certificates_816 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_secrets_227_vault_certificates_228 implements PcoreValue {
   readonly certificate_url: string;
   readonly certificate_store: string|null;
 
@@ -24418,16 +24418,16 @@ export class Azurerm_virtual_machine_os_profile_secrets_815_vault_certificates_8
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_secrets_815_vault_certificates_816';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_secrets_227_vault_certificates_228';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_windows_config_817 implements PcoreValue {
-  readonly additional_unattend_config: Azurerm_virtual_machine_os_profile_windows_config_817_additional_unattend_config_818[]|null;
+export class Azurerm_virtual_machine_os_profile_windows_config_229 implements PcoreValue {
+  readonly additional_unattend_config: Azurerm_virtual_machine_os_profile_windows_config_229_additional_unattend_config_230[]|null;
   readonly enable_automatic_upgrades: boolean|null;
   readonly provision_vm_agent: boolean|null;
   readonly timezone: string|null;
-  readonly winrm: Azurerm_virtual_machine_os_profile_windows_config_817_winrm_819[]|null;
+  readonly winrm: Azurerm_virtual_machine_os_profile_windows_config_229_winrm_231[]|null;
 
   constructor({
     additional_unattend_config = null,
@@ -24436,11 +24436,11 @@ export class Azurerm_virtual_machine_os_profile_windows_config_817 implements Pc
     timezone = null,
     winrm = null
   }: {
-    additional_unattend_config?: Azurerm_virtual_machine_os_profile_windows_config_817_additional_unattend_config_818[]|null,
+    additional_unattend_config?: Azurerm_virtual_machine_os_profile_windows_config_229_additional_unattend_config_230[]|null,
     enable_automatic_upgrades?: boolean|null,
     provision_vm_agent?: boolean|null,
     timezone?: string|null,
-    winrm?: Azurerm_virtual_machine_os_profile_windows_config_817_winrm_819[]|null
+    winrm?: Azurerm_virtual_machine_os_profile_windows_config_229_winrm_231[]|null
   }) {
     this.additional_unattend_config = additional_unattend_config;
     this.enable_automatic_upgrades = enable_automatic_upgrades;
@@ -24470,11 +24470,11 @@ export class Azurerm_virtual_machine_os_profile_windows_config_817 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_windows_config_817';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_windows_config_229';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_windows_config_817_additional_unattend_config_818 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_windows_config_229_additional_unattend_config_230 implements PcoreValue {
   readonly component: string;
   readonly content: string;
   readonly pass: string;
@@ -24507,11 +24507,11 @@ export class Azurerm_virtual_machine_os_profile_windows_config_817_additional_un
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_windows_config_817_additional_unattend_config_818';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_windows_config_229_additional_unattend_config_230';
   }
 }
 
-export class Azurerm_virtual_machine_os_profile_windows_config_817_winrm_819 implements PcoreValue {
+export class Azurerm_virtual_machine_os_profile_windows_config_229_winrm_231 implements PcoreValue {
   readonly protocol: string;
   readonly certificate_url: string|null;
 
@@ -24536,11 +24536,11 @@ export class Azurerm_virtual_machine_os_profile_windows_config_817_winrm_819 imp
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_windows_config_817_winrm_819';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_os_profile_windows_config_229_winrm_231';
   }
 }
 
-export class Azurerm_virtual_machine_plan_820 implements PcoreValue {
+export class Azurerm_virtual_machine_plan_232 implements PcoreValue {
   readonly name: string;
   readonly product: string;
   readonly publisher: string;
@@ -24568,37 +24568,37 @@ export class Azurerm_virtual_machine_plan_820 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_plan_820';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_plan_232';
   }
 }
 
 export class Azurerm_virtual_machine_scale_set implements PcoreValue {
   readonly location: string;
   readonly name: string;
-  readonly network_profile: Azurerm_virtual_machine_scale_set_network_profile_827[];
-  readonly os_profile: Azurerm_virtual_machine_scale_set_os_profile_831[];
+  readonly network_profile: Azurerm_virtual_machine_scale_set_network_profile_239[];
+  readonly os_profile: Azurerm_virtual_machine_scale_set_os_profile_243[];
   readonly resource_group_name: string;
-  readonly sku: Azurerm_virtual_machine_scale_set_sku_841[];
-  readonly storage_profile_os_disk: Azurerm_virtual_machine_scale_set_storage_profile_os_disk_844[];
+  readonly sku: Azurerm_virtual_machine_scale_set_sku_253[];
+  readonly storage_profile_os_disk: Azurerm_virtual_machine_scale_set_storage_profile_os_disk_256[];
   readonly upgrade_policy_mode: string;
   readonly azurerm_virtual_machine_scale_set_id: string|null;
   readonly automatic_os_upgrade: boolean|null;
-  readonly boot_diagnostics: Azurerm_virtual_machine_scale_set_boot_diagnostics_824[]|null;
+  readonly boot_diagnostics: Azurerm_virtual_machine_scale_set_boot_diagnostics_236[]|null;
   readonly eviction_policy: string|null;
-  readonly extension: Azurerm_virtual_machine_scale_set_extension_825[]|null;
+  readonly extension: Azurerm_virtual_machine_scale_set_extension_237[]|null;
   readonly health_probe_id: string|null;
-  readonly identity: Azurerm_virtual_machine_scale_set_identity_826[]|null;
+  readonly identity: Azurerm_virtual_machine_scale_set_identity_238[]|null;
   readonly license_type: string|null;
-  readonly os_profile_linux_config: Azurerm_virtual_machine_scale_set_os_profile_linux_config_832[]|null;
-  readonly os_profile_secrets: Azurerm_virtual_machine_scale_set_os_profile_secrets_834[]|null;
-  readonly os_profile_windows_config: Azurerm_virtual_machine_scale_set_os_profile_windows_config_836[]|null;
+  readonly os_profile_linux_config: Azurerm_virtual_machine_scale_set_os_profile_linux_config_244[]|null;
+  readonly os_profile_secrets: Azurerm_virtual_machine_scale_set_os_profile_secrets_246[]|null;
+  readonly os_profile_windows_config: Azurerm_virtual_machine_scale_set_os_profile_windows_config_248[]|null;
   readonly overprovision: boolean|null;
-  readonly plan: Azurerm_virtual_machine_scale_set_plan_839[]|null;
+  readonly plan: Azurerm_virtual_machine_scale_set_plan_251[]|null;
   readonly priority: string|null;
-  readonly rolling_upgrade_policy: Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_840[]|null;
+  readonly rolling_upgrade_policy: Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_252[]|null;
   readonly single_placement_group: boolean|null;
-  readonly storage_profile_data_disk: Azurerm_virtual_machine_scale_set_storage_profile_data_disk_842[]|null;
-  readonly storage_profile_image_reference: Azurerm_virtual_machine_scale_set_storage_profile_image_reference_843[]|null;
+  readonly storage_profile_data_disk: Azurerm_virtual_machine_scale_set_storage_profile_data_disk_254[]|null;
+  readonly storage_profile_image_reference: Azurerm_virtual_machine_scale_set_storage_profile_image_reference_255[]|null;
   readonly tags: {[s: string]: string}|null;
   readonly zones: string[]|null;
 
@@ -24634,30 +24634,30 @@ export class Azurerm_virtual_machine_scale_set implements PcoreValue {
   }: {
     location: string,
     name: string,
-    network_profile: Azurerm_virtual_machine_scale_set_network_profile_827[],
-    os_profile: Azurerm_virtual_machine_scale_set_os_profile_831[],
+    network_profile: Azurerm_virtual_machine_scale_set_network_profile_239[],
+    os_profile: Azurerm_virtual_machine_scale_set_os_profile_243[],
     resource_group_name: string,
-    sku: Azurerm_virtual_machine_scale_set_sku_841[],
-    storage_profile_os_disk: Azurerm_virtual_machine_scale_set_storage_profile_os_disk_844[],
+    sku: Azurerm_virtual_machine_scale_set_sku_253[],
+    storage_profile_os_disk: Azurerm_virtual_machine_scale_set_storage_profile_os_disk_256[],
     upgrade_policy_mode: string,
     azurerm_virtual_machine_scale_set_id?: string|null,
     automatic_os_upgrade?: boolean|null,
-    boot_diagnostics?: Azurerm_virtual_machine_scale_set_boot_diagnostics_824[]|null,
+    boot_diagnostics?: Azurerm_virtual_machine_scale_set_boot_diagnostics_236[]|null,
     eviction_policy?: string|null,
-    extension?: Azurerm_virtual_machine_scale_set_extension_825[]|null,
+    extension?: Azurerm_virtual_machine_scale_set_extension_237[]|null,
     health_probe_id?: string|null,
-    identity?: Azurerm_virtual_machine_scale_set_identity_826[]|null,
+    identity?: Azurerm_virtual_machine_scale_set_identity_238[]|null,
     license_type?: string|null,
-    os_profile_linux_config?: Azurerm_virtual_machine_scale_set_os_profile_linux_config_832[]|null,
-    os_profile_secrets?: Azurerm_virtual_machine_scale_set_os_profile_secrets_834[]|null,
-    os_profile_windows_config?: Azurerm_virtual_machine_scale_set_os_profile_windows_config_836[]|null,
+    os_profile_linux_config?: Azurerm_virtual_machine_scale_set_os_profile_linux_config_244[]|null,
+    os_profile_secrets?: Azurerm_virtual_machine_scale_set_os_profile_secrets_246[]|null,
+    os_profile_windows_config?: Azurerm_virtual_machine_scale_set_os_profile_windows_config_248[]|null,
     overprovision?: boolean|null,
-    plan?: Azurerm_virtual_machine_scale_set_plan_839[]|null,
+    plan?: Azurerm_virtual_machine_scale_set_plan_251[]|null,
     priority?: string|null,
-    rolling_upgrade_policy?: Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_840[]|null,
+    rolling_upgrade_policy?: Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_252[]|null,
     single_placement_group?: boolean|null,
-    storage_profile_data_disk?: Azurerm_virtual_machine_scale_set_storage_profile_data_disk_842[]|null,
-    storage_profile_image_reference?: Azurerm_virtual_machine_scale_set_storage_profile_image_reference_843[]|null,
+    storage_profile_data_disk?: Azurerm_virtual_machine_scale_set_storage_profile_data_disk_254[]|null,
+    storage_profile_image_reference?: Azurerm_virtual_machine_scale_set_storage_profile_image_reference_255[]|null,
     tags?: {[s: string]: string}|null,
     zones?: string[]|null
   }) {
@@ -24779,7 +24779,7 @@ export class Azurerm_virtual_machine_scale_setHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_boot_diagnostics_824 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_boot_diagnostics_236 implements PcoreValue {
   readonly storage_uri: string;
   readonly enabled: boolean|null;
 
@@ -24804,11 +24804,11 @@ export class Azurerm_virtual_machine_scale_set_boot_diagnostics_824 implements P
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_boot_diagnostics_824';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_boot_diagnostics_236';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_extension_825 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_extension_237 implements PcoreValue {
   readonly name: string;
   readonly publisher: string;
   readonly type: string;
@@ -24862,11 +24862,11 @@ export class Azurerm_virtual_machine_scale_set_extension_825 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_extension_825';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_extension_237';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_identity_826 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_identity_238 implements PcoreValue {
   readonly type: string;
   readonly identity_ids: string[]|null;
   readonly principal_id: string|null;
@@ -24898,16 +24898,16 @@ export class Azurerm_virtual_machine_scale_set_identity_826 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_identity_826';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_identity_238';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_network_profile_827 implements PcoreValue {
-  readonly ip_configuration: Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829[];
+export class Azurerm_virtual_machine_scale_set_network_profile_239 implements PcoreValue {
+  readonly ip_configuration: Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241[];
   readonly name: string;
   readonly primary: boolean;
   readonly accelerated_networking: boolean|null;
-  readonly dns_settings: Azurerm_virtual_machine_scale_set_network_profile_827_dns_settings_828[]|null;
+  readonly dns_settings: Azurerm_virtual_machine_scale_set_network_profile_239_dns_settings_240[]|null;
   readonly ip_forwarding: boolean|null;
   readonly network_security_group_id: string|null;
 
@@ -24920,11 +24920,11 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827 implements Pc
     ip_forwarding = null,
     network_security_group_id = null
   }: {
-    ip_configuration: Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829[],
+    ip_configuration: Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241[],
     name: string,
     primary: boolean,
     accelerated_networking?: boolean|null,
-    dns_settings?: Azurerm_virtual_machine_scale_set_network_profile_827_dns_settings_828[]|null,
+    dns_settings?: Azurerm_virtual_machine_scale_set_network_profile_239_dns_settings_240[]|null,
     ip_forwarding?: boolean|null,
     network_security_group_id?: string|null
   }) {
@@ -24958,11 +24958,11 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_827';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_239';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_network_profile_827_dns_settings_828 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_network_profile_239_dns_settings_240 implements PcoreValue {
   readonly dns_servers: string[];
 
   constructor({
@@ -24980,11 +24980,11 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827_dns_settings_
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_827_dns_settings_828';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_239_dns_settings_240';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241 implements PcoreValue {
   readonly name: string;
   readonly primary: boolean;
   readonly subnet_id: string;
@@ -24992,7 +24992,7 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827_ip_configurat
   readonly application_security_group_ids: string[]|null;
   readonly load_balancer_backend_address_pool_ids: string[]|null;
   readonly load_balancer_inbound_nat_rules_ids: string[]|null;
-  readonly public_ip_address_configuration: Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829_public_ip_address_configuration_830[]|null;
+  readonly public_ip_address_configuration: Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241_public_ip_address_configuration_242[]|null;
 
   constructor({
     name,
@@ -25011,7 +25011,7 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827_ip_configurat
     application_security_group_ids?: string[]|null,
     load_balancer_backend_address_pool_ids?: string[]|null,
     load_balancer_inbound_nat_rules_ids?: string[]|null,
-    public_ip_address_configuration?: Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829_public_ip_address_configuration_830[]|null
+    public_ip_address_configuration?: Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241_public_ip_address_configuration_242[]|null
   }) {
     this.name = name;
     this.primary = primary;
@@ -25047,11 +25047,11 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827_ip_configurat
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829_public_ip_address_configuration_830 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241_public_ip_address_configuration_242 implements PcoreValue {
   readonly domain_name_label: string;
   readonly idle_timeout: number;
   readonly name: string;
@@ -25079,11 +25079,11 @@ export class Azurerm_virtual_machine_scale_set_network_profile_827_ip_configurat
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_827_ip_configuration_829_public_ip_address_configuration_830';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_network_profile_239_ip_configuration_241_public_ip_address_configuration_242';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_831 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_243 implements PcoreValue {
   readonly admin_username: string;
   readonly computer_name_prefix: string;
   readonly admin_password: string|null;
@@ -25120,20 +25120,20 @@ export class Azurerm_virtual_machine_scale_set_os_profile_831 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_831';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_243';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_linux_config_832 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_linux_config_244 implements PcoreValue {
   readonly disable_password_authentication: boolean|null;
-  readonly ssh_keys: Azurerm_virtual_machine_scale_set_os_profile_linux_config_832_ssh_keys_833[]|null;
+  readonly ssh_keys: Azurerm_virtual_machine_scale_set_os_profile_linux_config_244_ssh_keys_245[]|null;
 
   constructor({
     disable_password_authentication = null,
     ssh_keys = null
   }: {
     disable_password_authentication?: boolean|null,
-    ssh_keys?: Azurerm_virtual_machine_scale_set_os_profile_linux_config_832_ssh_keys_833[]|null
+    ssh_keys?: Azurerm_virtual_machine_scale_set_os_profile_linux_config_244_ssh_keys_245[]|null
   }) {
     this.disable_password_authentication = disable_password_authentication;
     this.ssh_keys = ssh_keys;
@@ -25151,11 +25151,11 @@ export class Azurerm_virtual_machine_scale_set_os_profile_linux_config_832 imple
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_linux_config_832';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_linux_config_244';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_linux_config_832_ssh_keys_833 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_linux_config_244_ssh_keys_245 implements PcoreValue {
   readonly path: string;
   readonly key_data: string|null;
 
@@ -25180,20 +25180,20 @@ export class Azurerm_virtual_machine_scale_set_os_profile_linux_config_832_ssh_k
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_linux_config_832_ssh_keys_833';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_linux_config_244_ssh_keys_245';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_secrets_834 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_secrets_246 implements PcoreValue {
   readonly source_vault_id: string;
-  readonly vault_certificates: Azurerm_virtual_machine_scale_set_os_profile_secrets_834_vault_certificates_835[]|null;
+  readonly vault_certificates: Azurerm_virtual_machine_scale_set_os_profile_secrets_246_vault_certificates_247[]|null;
 
   constructor({
     source_vault_id,
     vault_certificates = null
   }: {
     source_vault_id: string,
-    vault_certificates?: Azurerm_virtual_machine_scale_set_os_profile_secrets_834_vault_certificates_835[]|null
+    vault_certificates?: Azurerm_virtual_machine_scale_set_os_profile_secrets_246_vault_certificates_247[]|null
   }) {
     this.source_vault_id = source_vault_id;
     this.vault_certificates = vault_certificates;
@@ -25209,11 +25209,11 @@ export class Azurerm_virtual_machine_scale_set_os_profile_secrets_834 implements
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_secrets_834';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_secrets_246';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_secrets_834_vault_certificates_835 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_secrets_246_vault_certificates_247 implements PcoreValue {
   readonly certificate_url: string;
   readonly certificate_store: string|null;
 
@@ -25238,15 +25238,15 @@ export class Azurerm_virtual_machine_scale_set_os_profile_secrets_834_vault_cert
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_secrets_834_vault_certificates_835';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_secrets_246_vault_certificates_247';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836 implements PcoreValue {
-  readonly additional_unattend_config: Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_additional_unattend_config_837[]|null;
+export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_248 implements PcoreValue {
+  readonly additional_unattend_config: Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_additional_unattend_config_249[]|null;
   readonly enable_automatic_upgrades: boolean|null;
   readonly provision_vm_agent: boolean|null;
-  readonly winrm: Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_winrm_838[]|null;
+  readonly winrm: Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_winrm_250[]|null;
 
   constructor({
     additional_unattend_config = null,
@@ -25254,10 +25254,10 @@ export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836 imp
     provision_vm_agent = null,
     winrm = null
   }: {
-    additional_unattend_config?: Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_additional_unattend_config_837[]|null,
+    additional_unattend_config?: Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_additional_unattend_config_249[]|null,
     enable_automatic_upgrades?: boolean|null,
     provision_vm_agent?: boolean|null,
-    winrm?: Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_winrm_838[]|null
+    winrm?: Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_winrm_250[]|null
   }) {
     this.additional_unattend_config = additional_unattend_config;
     this.enable_automatic_upgrades = enable_automatic_upgrades;
@@ -25283,11 +25283,11 @@ export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836 imp
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_windows_config_836';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_windows_config_248';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_additional_unattend_config_837 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_additional_unattend_config_249 implements PcoreValue {
   readonly component: string;
   readonly content: string;
   readonly pass: string;
@@ -25320,11 +25320,11 @@ export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_add
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_additional_unattend_config_837';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_additional_unattend_config_249';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_winrm_838 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_winrm_250 implements PcoreValue {
   readonly protocol: string;
   readonly certificate_url: string|null;
 
@@ -25349,11 +25349,11 @@ export class Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_win
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_windows_config_836_winrm_838';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_os_profile_windows_config_248_winrm_250';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_plan_839 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_plan_251 implements PcoreValue {
   readonly name: string;
   readonly product: string;
   readonly publisher: string;
@@ -25381,11 +25381,11 @@ export class Azurerm_virtual_machine_scale_set_plan_839 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_plan_839';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_plan_251';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_840 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_252 implements PcoreValue {
   readonly max_batch_instance_percent: number|null;
   readonly max_unhealthy_instance_percent: number|null;
   readonly max_unhealthy_upgraded_instance_percent: number|null;
@@ -25426,11 +25426,11 @@ export class Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_840 implem
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_840';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_rolling_upgrade_policy_252';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_sku_841 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_sku_253 implements PcoreValue {
   readonly capacity: number;
   readonly name: string;
   readonly tier: string|null;
@@ -25460,11 +25460,11 @@ export class Azurerm_virtual_machine_scale_set_sku_841 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_sku_841';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_sku_253';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_storage_profile_data_disk_842 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_storage_profile_data_disk_254 implements PcoreValue {
   readonly create_option: string;
   readonly lun: number;
   readonly caching: string|null;
@@ -25508,11 +25508,11 @@ export class Azurerm_virtual_machine_scale_set_storage_profile_data_disk_842 imp
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_storage_profile_data_disk_842';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_storage_profile_data_disk_254';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_storage_profile_image_reference_843 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_storage_profile_image_reference_255 implements PcoreValue {
   readonly id: string|null;
   readonly offer: string|null;
   readonly publisher: string|null;
@@ -25560,11 +25560,11 @@ export class Azurerm_virtual_machine_scale_set_storage_profile_image_reference_8
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_storage_profile_image_reference_843';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_storage_profile_image_reference_255';
   }
 }
 
-export class Azurerm_virtual_machine_scale_set_storage_profile_os_disk_844 implements PcoreValue {
+export class Azurerm_virtual_machine_scale_set_storage_profile_os_disk_256 implements PcoreValue {
   readonly create_option: string;
   readonly caching: string|null;
   readonly image: string|null;
@@ -25624,11 +25624,11 @@ export class Azurerm_virtual_machine_scale_set_storage_profile_os_disk_844 imple
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_storage_profile_os_disk_844';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_scale_set_storage_profile_os_disk_256';
   }
 }
 
-export class Azurerm_virtual_machine_storage_data_disk_821 implements PcoreValue {
+export class Azurerm_virtual_machine_storage_data_disk_233 implements PcoreValue {
   readonly create_option: string;
   readonly lun: number;
   readonly name: string;
@@ -25698,11 +25698,11 @@ export class Azurerm_virtual_machine_storage_data_disk_821 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_storage_data_disk_821';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_storage_data_disk_233';
   }
 }
 
-export class Azurerm_virtual_machine_storage_image_reference_822 implements PcoreValue {
+export class Azurerm_virtual_machine_storage_image_reference_234 implements PcoreValue {
   readonly id: string|null;
   readonly offer: string|null;
   readonly publisher: string|null;
@@ -25750,11 +25750,11 @@ export class Azurerm_virtual_machine_storage_image_reference_822 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_storage_image_reference_822';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_storage_image_reference_234';
   }
 }
 
-export class Azurerm_virtual_machine_storage_os_disk_823 implements PcoreValue {
+export class Azurerm_virtual_machine_storage_os_disk_235 implements PcoreValue {
   readonly create_option: string;
   readonly name: string;
   readonly caching: string|null;
@@ -25833,7 +25833,7 @@ export class Azurerm_virtual_machine_storage_os_disk_823 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_machine_storage_os_disk_823';
+    return 'TerraformAzureRM::Azurerm_virtual_machine_storage_os_disk_235';
   }
 }
 
@@ -25844,7 +25844,7 @@ export class Azurerm_virtual_network implements PcoreValue {
   readonly resource_group_name: string;
   readonly azurerm_virtual_network_id: string|null;
   readonly dns_servers: string[]|null;
-  readonly subnet: Azurerm_virtual_network_subnet_845[]|null;
+  readonly subnet: Azurerm_virtual_network_subnet_257[]|null;
   readonly tags: {[s: string]: string}|null;
 
   constructor({
@@ -25863,7 +25863,7 @@ export class Azurerm_virtual_network implements PcoreValue {
     resource_group_name: string,
     azurerm_virtual_network_id?: string|null,
     dns_servers?: string[]|null,
-    subnet?: Azurerm_virtual_network_subnet_845[]|null,
+    subnet?: Azurerm_virtual_network_subnet_257[]|null,
     tags?: {[s: string]: string}|null
   }) {
     this.address_space = address_space;
@@ -25913,7 +25913,7 @@ export class Azurerm_virtual_networkHandler implements PcoreValue {
 }
 
 export class Azurerm_virtual_network_gateway implements PcoreValue {
-  readonly ip_configuration: Azurerm_virtual_network_gateway_ip_configuration_847[];
+  readonly ip_configuration: Azurerm_virtual_network_gateway_ip_configuration_259[];
   readonly location: string;
   readonly name: string;
   readonly resource_group_name: string;
@@ -25921,11 +25921,11 @@ export class Azurerm_virtual_network_gateway implements PcoreValue {
   readonly type: string;
   readonly azurerm_virtual_network_gateway_id: string|null;
   readonly active_active: boolean|null;
-  readonly bgp_settings: Azurerm_virtual_network_gateway_bgp_settings_846[]|null;
+  readonly bgp_settings: Azurerm_virtual_network_gateway_bgp_settings_258[]|null;
   readonly default_local_network_gateway_id: string|null;
   readonly enable_bgp: boolean|null;
   readonly tags: {[s: string]: string}|null;
-  readonly vpn_client_configuration: Azurerm_virtual_network_gateway_vpn_client_configuration_848[]|null;
+  readonly vpn_client_configuration: Azurerm_virtual_network_gateway_vpn_client_configuration_260[]|null;
   readonly vpn_type: string|null;
 
   constructor({
@@ -25944,7 +25944,7 @@ export class Azurerm_virtual_network_gateway implements PcoreValue {
     vpn_client_configuration = null,
     vpn_type = null
   }: {
-    ip_configuration: Azurerm_virtual_network_gateway_ip_configuration_847[],
+    ip_configuration: Azurerm_virtual_network_gateway_ip_configuration_259[],
     location: string,
     name: string,
     resource_group_name: string,
@@ -25952,11 +25952,11 @@ export class Azurerm_virtual_network_gateway implements PcoreValue {
     type: string,
     azurerm_virtual_network_gateway_id?: string|null,
     active_active?: boolean|null,
-    bgp_settings?: Azurerm_virtual_network_gateway_bgp_settings_846[]|null,
+    bgp_settings?: Azurerm_virtual_network_gateway_bgp_settings_258[]|null,
     default_local_network_gateway_id?: string|null,
     enable_bgp?: boolean|null,
     tags?: {[s: string]: string}|null,
-    vpn_client_configuration?: Azurerm_virtual_network_gateway_vpn_client_configuration_848[]|null,
+    vpn_client_configuration?: Azurerm_virtual_network_gateway_vpn_client_configuration_260[]|null,
     vpn_type?: string|null
   }) {
     this.ip_configuration = ip_configuration;
@@ -26025,7 +26025,7 @@ export class Azurerm_virtual_network_gatewayHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_virtual_network_gateway_bgp_settings_846 implements PcoreValue {
+export class Azurerm_virtual_network_gateway_bgp_settings_258 implements PcoreValue {
   readonly asn: number|null;
   readonly peer_weight: number|null;
   readonly peering_address: string|null;
@@ -26059,7 +26059,7 @@ export class Azurerm_virtual_network_gateway_bgp_settings_846 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_bgp_settings_846';
+    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_bgp_settings_258';
   }
 }
 
@@ -26073,7 +26073,7 @@ export class Azurerm_virtual_network_gateway_connection implements PcoreValue {
   readonly authorization_key: string|null;
   readonly enable_bgp: boolean|null;
   readonly express_route_circuit_id: string|null;
-  readonly ipsec_policy: Azurerm_virtual_network_gateway_connection_ipsec_policy_851[]|null;
+  readonly ipsec_policy: Azurerm_virtual_network_gateway_connection_ipsec_policy_263[]|null;
   readonly local_network_gateway_id: string|null;
   readonly peer_virtual_network_gateway_id: string|null;
   readonly routing_weight: number|null;
@@ -26108,7 +26108,7 @@ export class Azurerm_virtual_network_gateway_connection implements PcoreValue {
     authorization_key?: string|null,
     enable_bgp?: boolean|null,
     express_route_circuit_id?: string|null,
-    ipsec_policy?: Azurerm_virtual_network_gateway_connection_ipsec_policy_851[]|null,
+    ipsec_policy?: Azurerm_virtual_network_gateway_connection_ipsec_policy_263[]|null,
     local_network_gateway_id?: string|null,
     peer_virtual_network_gateway_id?: string|null,
     routing_weight?: number|null,
@@ -26192,7 +26192,7 @@ export class Azurerm_virtual_network_gateway_connectionHandler implements PcoreV
   }
 }
 
-export class Azurerm_virtual_network_gateway_connection_ipsec_policy_851 implements PcoreValue {
+export class Azurerm_virtual_network_gateway_connection_ipsec_policy_263 implements PcoreValue {
   readonly dh_group: string;
   readonly ike_encryption: string;
   readonly ike_integrity: string;
@@ -26249,11 +26249,11 @@ export class Azurerm_virtual_network_gateway_connection_ipsec_policy_851 impleme
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_connection_ipsec_policy_851';
+    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_connection_ipsec_policy_263';
   }
 }
 
-export class Azurerm_virtual_network_gateway_ip_configuration_847 implements PcoreValue {
+export class Azurerm_virtual_network_gateway_ip_configuration_259 implements PcoreValue {
   readonly subnet_id: string;
   readonly name: string|null;
   readonly private_ip_address_allocation: string|null;
@@ -26292,16 +26292,16 @@ export class Azurerm_virtual_network_gateway_ip_configuration_847 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_ip_configuration_847';
+    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_ip_configuration_259';
   }
 }
 
-export class Azurerm_virtual_network_gateway_vpn_client_configuration_848 implements PcoreValue {
+export class Azurerm_virtual_network_gateway_vpn_client_configuration_260 implements PcoreValue {
   readonly address_space: string[];
   readonly radius_server_address: string|null;
   readonly radius_server_secret: string|null;
-  readonly revoked_certificate: Azurerm_virtual_network_gateway_vpn_client_configuration_848_revoked_certificate_849[]|null;
-  readonly root_certificate: Azurerm_virtual_network_gateway_vpn_client_configuration_848_root_certificate_850[]|null;
+  readonly revoked_certificate: Azurerm_virtual_network_gateway_vpn_client_configuration_260_revoked_certificate_261[]|null;
+  readonly root_certificate: Azurerm_virtual_network_gateway_vpn_client_configuration_260_root_certificate_262[]|null;
   readonly vpn_client_protocols: string[]|null;
 
   constructor({
@@ -26315,8 +26315,8 @@ export class Azurerm_virtual_network_gateway_vpn_client_configuration_848 implem
     address_space: string[],
     radius_server_address?: string|null,
     radius_server_secret?: string|null,
-    revoked_certificate?: Azurerm_virtual_network_gateway_vpn_client_configuration_848_revoked_certificate_849[]|null,
-    root_certificate?: Azurerm_virtual_network_gateway_vpn_client_configuration_848_root_certificate_850[]|null,
+    revoked_certificate?: Azurerm_virtual_network_gateway_vpn_client_configuration_260_revoked_certificate_261[]|null,
+    root_certificate?: Azurerm_virtual_network_gateway_vpn_client_configuration_260_root_certificate_262[]|null,
     vpn_client_protocols?: string[]|null
   }) {
     this.address_space = address_space;
@@ -26349,11 +26349,11 @@ export class Azurerm_virtual_network_gateway_vpn_client_configuration_848 implem
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_vpn_client_configuration_848';
+    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_vpn_client_configuration_260';
   }
 }
 
-export class Azurerm_virtual_network_gateway_vpn_client_configuration_848_revoked_certificate_849 implements PcoreValue {
+export class Azurerm_virtual_network_gateway_vpn_client_configuration_260_revoked_certificate_261 implements PcoreValue {
   readonly name: string;
   readonly thumbprint: string;
 
@@ -26376,11 +26376,11 @@ export class Azurerm_virtual_network_gateway_vpn_client_configuration_848_revoke
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_vpn_client_configuration_848_revoked_certificate_849';
+    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_vpn_client_configuration_260_revoked_certificate_261';
   }
 }
 
-export class Azurerm_virtual_network_gateway_vpn_client_configuration_848_root_certificate_850 implements PcoreValue {
+export class Azurerm_virtual_network_gateway_vpn_client_configuration_260_root_certificate_262 implements PcoreValue {
   readonly name: string;
   readonly public_cert_data: string;
 
@@ -26403,7 +26403,7 @@ export class Azurerm_virtual_network_gateway_vpn_client_configuration_848_root_c
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_vpn_client_configuration_848_root_certificate_850';
+    return 'TerraformAzureRM::Azurerm_virtual_network_gateway_vpn_client_configuration_260_root_certificate_262';
   }
 }
 
@@ -26489,7 +26489,7 @@ export class Azurerm_virtual_network_peeringHandler implements PcoreValue {
   }
 }
 
-export class Azurerm_virtual_network_subnet_845 implements PcoreValue {
+export class Azurerm_virtual_network_subnet_257 implements PcoreValue {
   readonly address_prefix: string;
   readonly name: string;
   readonly id: string|null;
@@ -26526,6 +26526,6 @@ export class Azurerm_virtual_network_subnet_845 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformAzureRM::Azurerm_virtual_network_subnet_845';
+    return 'TerraformAzureRM::Azurerm_virtual_network_subnet_257';
   }
 }

--- a/examples/ts-samples/src/types/TerraformGitHub.ts
+++ b/examples/ts-samples/src/types/TerraformGitHub.ts
@@ -7,9 +7,9 @@ export class Github_branch_protection implements PcoreValue {
   readonly github_branch_protection_id: string|null;
   readonly enforce_admins: boolean|null;
   readonly etag: string|null;
-  readonly required_pull_request_reviews: Github_branch_protection_required_pull_request_reviews_852[]|null;
-  readonly required_status_checks: Github_branch_protection_required_status_checks_853[]|null;
-  readonly restrictions: Github_branch_protection_restrictions_854[]|null;
+  readonly required_pull_request_reviews: Github_branch_protection_required_pull_request_reviews_1[]|null;
+  readonly required_status_checks: Github_branch_protection_required_status_checks_2[]|null;
+  readonly restrictions: Github_branch_protection_restrictions_3[]|null;
 
   constructor({
     branch,
@@ -26,9 +26,9 @@ export class Github_branch_protection implements PcoreValue {
     github_branch_protection_id?: string|null,
     enforce_admins?: boolean|null,
     etag?: string|null,
-    required_pull_request_reviews?: Github_branch_protection_required_pull_request_reviews_852[]|null,
-    required_status_checks?: Github_branch_protection_required_status_checks_853[]|null,
-    restrictions?: Github_branch_protection_restrictions_854[]|null
+    required_pull_request_reviews?: Github_branch_protection_required_pull_request_reviews_1[]|null,
+    required_status_checks?: Github_branch_protection_required_status_checks_2[]|null,
+    restrictions?: Github_branch_protection_restrictions_3[]|null
   }) {
     this.branch = branch;
     this.repository = repository;
@@ -80,7 +80,7 @@ export class Github_branch_protectionHandler implements PcoreValue {
   }
 }
 
-export class Github_branch_protection_required_pull_request_reviews_852 implements PcoreValue {
+export class Github_branch_protection_required_pull_request_reviews_1 implements PcoreValue {
   readonly dismiss_stale_reviews: boolean|null;
   readonly dismissal_teams: string[]|null;
   readonly dismissal_users: string[]|null;
@@ -128,11 +128,11 @@ export class Github_branch_protection_required_pull_request_reviews_852 implemen
   }
 
   __ptype(): string {
-    return 'TerraformGitHub::Github_branch_protection_required_pull_request_reviews_852';
+    return 'TerraformGitHub::Github_branch_protection_required_pull_request_reviews_1';
   }
 }
 
-export class Github_branch_protection_required_status_checks_853 implements PcoreValue {
+export class Github_branch_protection_required_status_checks_2 implements PcoreValue {
   readonly contexts: string[]|null;
   readonly include_admins: boolean|null;
   readonly strict: boolean|null;
@@ -166,11 +166,11 @@ export class Github_branch_protection_required_status_checks_853 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGitHub::Github_branch_protection_required_status_checks_853';
+    return 'TerraformGitHub::Github_branch_protection_required_status_checks_2';
   }
 }
 
-export class Github_branch_protection_restrictions_854 implements PcoreValue {
+export class Github_branch_protection_restrictions_3 implements PcoreValue {
   readonly teams: string[]|null;
   readonly users: string[]|null;
 
@@ -197,7 +197,7 @@ export class Github_branch_protection_restrictions_854 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGitHub::Github_branch_protection_restrictions_854';
+    return 'TerraformGitHub::Github_branch_protection_restrictions_3';
   }
 }
 
@@ -389,7 +389,7 @@ export class Github_organization_webhook implements PcoreValue {
   readonly name: string;
   readonly github_organization_webhook_id: string|null;
   readonly active: boolean|null;
-  readonly configuration: Github_organization_webhook_configuration_855[]|null;
+  readonly configuration: Github_organization_webhook_configuration_4[]|null;
   readonly etag: string|null;
   readonly url: string|null;
 
@@ -406,7 +406,7 @@ export class Github_organization_webhook implements PcoreValue {
     name: string,
     github_organization_webhook_id?: string|null,
     active?: boolean|null,
-    configuration?: Github_organization_webhook_configuration_855[]|null,
+    configuration?: Github_organization_webhook_configuration_4[]|null,
     etag?: string|null,
     url?: string|null
   }) {
@@ -456,7 +456,7 @@ export class Github_organization_webhookHandler implements PcoreValue {
   }
 }
 
-export class Github_organization_webhook_configuration_855 implements PcoreValue {
+export class Github_organization_webhook_configuration_4 implements PcoreValue {
   readonly url: string;
   readonly content_type: string|null;
   readonly insecure_ssl: string|null;
@@ -495,7 +495,7 @@ export class Github_organization_webhook_configuration_855 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformGitHub::Github_organization_webhook_configuration_855';
+    return 'TerraformGitHub::Github_organization_webhook_configuration_4';
   }
 }
 
@@ -935,7 +935,7 @@ export class Github_repository_webhook implements PcoreValue {
   readonly repository: string;
   readonly github_repository_webhook_id: string|null;
   readonly active: boolean|null;
-  readonly configuration: Github_repository_webhook_configuration_856[]|null;
+  readonly configuration: Github_repository_webhook_configuration_5[]|null;
   readonly etag: string|null;
   readonly url: string|null;
 
@@ -954,7 +954,7 @@ export class Github_repository_webhook implements PcoreValue {
     repository: string,
     github_repository_webhook_id?: string|null,
     active?: boolean|null,
-    configuration?: Github_repository_webhook_configuration_856[]|null,
+    configuration?: Github_repository_webhook_configuration_5[]|null,
     etag?: string|null,
     url?: string|null
   }) {
@@ -1006,7 +1006,7 @@ export class Github_repository_webhookHandler implements PcoreValue {
   }
 }
 
-export class Github_repository_webhook_configuration_856 implements PcoreValue {
+export class Github_repository_webhook_configuration_5 implements PcoreValue {
   readonly url: string;
   readonly content_type: string|null;
   readonly insecure_ssl: string|null;
@@ -1045,7 +1045,7 @@ export class Github_repository_webhook_configuration_856 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGitHub::Github_repository_webhook_configuration_856';
+    return 'TerraformGitHub::Github_repository_webhook_configuration_5';
   }
 }
 

--- a/examples/ts-samples/src/types/TerraformGoogle.ts
+++ b/examples/ts-samples/src/types/TerraformGoogle.ts
@@ -8,12 +8,12 @@ export class Google_app_engine_application implements PcoreValue {
   readonly code_bucket: string|null;
   readonly default_bucket: string|null;
   readonly default_hostname: string|null;
-  readonly feature_settings: Google_app_engine_application_feature_settings_857[]|null;
+  readonly feature_settings: Google_app_engine_application_feature_settings_1[]|null;
   readonly gcr_domain: string|null;
   readonly name: string|null;
   readonly project: string|null;
   readonly serving_status: string|null;
-  readonly url_dispatch_rule: Google_app_engine_application_url_dispatch_rule_858[]|null;
+  readonly url_dispatch_rule: Google_app_engine_application_url_dispatch_rule_2[]|null;
 
   constructor({
     location_id,
@@ -35,12 +35,12 @@ export class Google_app_engine_application implements PcoreValue {
     code_bucket?: string|null,
     default_bucket?: string|null,
     default_hostname?: string|null,
-    feature_settings?: Google_app_engine_application_feature_settings_857[]|null,
+    feature_settings?: Google_app_engine_application_feature_settings_1[]|null,
     gcr_domain?: string|null,
     name?: string|null,
     project?: string|null,
     serving_status?: string|null,
-    url_dispatch_rule?: Google_app_engine_application_url_dispatch_rule_858[]|null
+    url_dispatch_rule?: Google_app_engine_application_url_dispatch_rule_2[]|null
   }) {
     this.location_id = location_id;
     this.google_app_engine_application_id = google_app_engine_application_id;
@@ -110,7 +110,7 @@ export class Google_app_engine_applicationHandler implements PcoreValue {
   }
 }
 
-export class Google_app_engine_application_feature_settings_857 implements PcoreValue {
+export class Google_app_engine_application_feature_settings_1 implements PcoreValue {
   readonly split_health_checks: boolean|null;
 
   constructor({
@@ -130,11 +130,11 @@ export class Google_app_engine_application_feature_settings_857 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_app_engine_application_feature_settings_857';
+    return 'TerraformGoogle::Google_app_engine_application_feature_settings_1';
   }
 }
 
-export class Google_app_engine_application_url_dispatch_rule_858 implements PcoreValue {
+export class Google_app_engine_application_url_dispatch_rule_2 implements PcoreValue {
   readonly domain: string|null;
   readonly path: string|null;
   readonly service: string|null;
@@ -168,14 +168,14 @@ export class Google_app_engine_application_url_dispatch_rule_858 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_app_engine_application_url_dispatch_rule_858';
+    return 'TerraformGoogle::Google_app_engine_application_url_dispatch_rule_2';
   }
 }
 
 export class Google_bigquery_dataset implements PcoreValue {
   readonly dataset_id: string;
   readonly google_bigquery_dataset_id: string|null;
-  readonly access: Google_bigquery_dataset_access_859[]|null;
+  readonly access: Google_bigquery_dataset_access_3[]|null;
   readonly creation_time: number|null;
   readonly default_table_expiration_ms: number|null;
   readonly description: string|null;
@@ -204,7 +204,7 @@ export class Google_bigquery_dataset implements PcoreValue {
   }: {
     dataset_id: string,
     google_bigquery_dataset_id?: string|null,
-    access?: Google_bigquery_dataset_access_859[]|null,
+    access?: Google_bigquery_dataset_access_3[]|null,
     creation_time?: number|null,
     default_table_expiration_ms?: number|null,
     description?: string|null,
@@ -288,13 +288,13 @@ export class Google_bigquery_datasetHandler implements PcoreValue {
   }
 }
 
-export class Google_bigquery_dataset_access_859 implements PcoreValue {
+export class Google_bigquery_dataset_access_3 implements PcoreValue {
   readonly domain: string|null;
   readonly group_by_email: string|null;
   readonly role: string|null;
   readonly special_group: string|null;
   readonly user_by_email: string|null;
-  readonly view: Google_bigquery_dataset_access_859_view_860[]|null;
+  readonly view: Google_bigquery_dataset_access_3_view_4[]|null;
 
   constructor({
     domain = null,
@@ -309,7 +309,7 @@ export class Google_bigquery_dataset_access_859 implements PcoreValue {
     role?: string|null,
     special_group?: string|null,
     user_by_email?: string|null,
-    view?: Google_bigquery_dataset_access_859_view_860[]|null
+    view?: Google_bigquery_dataset_access_3_view_4[]|null
   }) {
     this.domain = domain;
     this.group_by_email = group_by_email;
@@ -343,11 +343,11 @@ export class Google_bigquery_dataset_access_859 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_bigquery_dataset_access_859';
+    return 'TerraformGoogle::Google_bigquery_dataset_access_3';
   }
 }
 
-export class Google_bigquery_dataset_access_859_view_860 implements PcoreValue {
+export class Google_bigquery_dataset_access_3_view_4 implements PcoreValue {
   readonly dataset_id: string;
   readonly project_id: string;
   readonly table_id: string;
@@ -375,7 +375,7 @@ export class Google_bigquery_dataset_access_859_view_860 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_bigquery_dataset_access_859_view_860';
+    return 'TerraformGoogle::Google_bigquery_dataset_access_3_view_4';
   }
 }
 
@@ -397,9 +397,9 @@ export class Google_bigquery_table implements PcoreValue {
   readonly project: string|null;
   readonly schema: string|null;
   readonly self_link: string|null;
-  readonly time_partitioning: Google_bigquery_table_time_partitioning_861[]|null;
+  readonly time_partitioning: Google_bigquery_table_time_partitioning_5[]|null;
   readonly type: string|null;
-  readonly view: Google_bigquery_table_view_862[]|null;
+  readonly view: Google_bigquery_table_view_6[]|null;
 
   constructor({
     dataset_id,
@@ -440,9 +440,9 @@ export class Google_bigquery_table implements PcoreValue {
     project?: string|null,
     schema?: string|null,
     self_link?: string|null,
-    time_partitioning?: Google_bigquery_table_time_partitioning_861[]|null,
+    time_partitioning?: Google_bigquery_table_time_partitioning_5[]|null,
     type?: string|null,
-    view?: Google_bigquery_table_view_862[]|null
+    view?: Google_bigquery_table_view_6[]|null
   }) {
     this.dataset_id = dataset_id;
     this.table_id = table_id;
@@ -542,7 +542,7 @@ export class Google_bigquery_tableHandler implements PcoreValue {
   }
 }
 
-export class Google_bigquery_table_time_partitioning_861 implements PcoreValue {
+export class Google_bigquery_table_time_partitioning_5 implements PcoreValue {
   readonly type: string;
   readonly expiration_ms: number|null;
   readonly field: string|null;
@@ -574,11 +574,11 @@ export class Google_bigquery_table_time_partitioning_861 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_bigquery_table_time_partitioning_861';
+    return 'TerraformGoogle::Google_bigquery_table_time_partitioning_5';
   }
 }
 
-export class Google_bigquery_table_view_862 implements PcoreValue {
+export class Google_bigquery_table_view_6 implements PcoreValue {
   readonly query: string;
   readonly use_legacy_sql: boolean|null;
 
@@ -603,14 +603,14 @@ export class Google_bigquery_table_view_862 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_bigquery_table_view_862';
+    return 'TerraformGoogle::Google_bigquery_table_view_6';
   }
 }
 
 export class Google_bigtable_instance implements PcoreValue {
   readonly name: string;
   readonly google_bigtable_instance_id: string|null;
-  readonly cluster: Google_bigtable_instance_cluster_863[]|null;
+  readonly cluster: Google_bigtable_instance_cluster_7[]|null;
   readonly cluster_id: string|null;
   readonly display_name: string|null;
   readonly instance_type: string|null;
@@ -633,7 +633,7 @@ export class Google_bigtable_instance implements PcoreValue {
   }: {
     name: string,
     google_bigtable_instance_id?: string|null,
-    cluster?: Google_bigtable_instance_cluster_863[]|null,
+    cluster?: Google_bigtable_instance_cluster_7[]|null,
     cluster_id?: string|null,
     display_name?: string|null,
     instance_type?: string|null,
@@ -702,7 +702,7 @@ export class Google_bigtable_instanceHandler implements PcoreValue {
   }
 }
 
-export class Google_bigtable_instance_cluster_863 implements PcoreValue {
+export class Google_bigtable_instance_cluster_7 implements PcoreValue {
   readonly cluster_id: string|null;
   readonly num_nodes: number|null;
   readonly storage_type: string|null;
@@ -743,7 +743,7 @@ export class Google_bigtable_instance_cluster_863 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_bigtable_instance_cluster_863';
+    return 'TerraformGoogle::Google_bigtable_instance_cluster_7';
   }
 }
 
@@ -969,7 +969,7 @@ export class Google_billing_account_iam_policyHandler implements PcoreValue {
 }
 
 export class Google_binary_authorization_attestor implements PcoreValue {
-  readonly attestation_authority_note: Google_binary_authorization_attestor_attestation_authority_note_864[];
+  readonly attestation_authority_note: Google_binary_authorization_attestor_attestation_authority_note_8[];
   readonly name: string;
   readonly google_binary_authorization_attestor_id: string|null;
   readonly description: string|null;
@@ -982,7 +982,7 @@ export class Google_binary_authorization_attestor implements PcoreValue {
     description = null,
     project = null
   }: {
-    attestation_authority_note: Google_binary_authorization_attestor_attestation_authority_note_864[],
+    attestation_authority_note: Google_binary_authorization_attestor_attestation_authority_note_8[],
     name: string,
     google_binary_authorization_attestor_id?: string|null,
     description?: string|null,
@@ -1026,10 +1026,10 @@ export class Google_binary_authorization_attestorHandler implements PcoreValue {
   }
 }
 
-export class Google_binary_authorization_attestor_attestation_authority_note_864 implements PcoreValue {
+export class Google_binary_authorization_attestor_attestation_authority_note_8 implements PcoreValue {
   readonly note_reference: string;
   readonly delegation_service_account_email: string|null;
-  readonly public_keys: Google_binary_authorization_attestor_attestation_authority_note_864_public_keys_865[]|null;
+  readonly public_keys: Google_binary_authorization_attestor_attestation_authority_note_8_public_keys_9[]|null;
 
   constructor({
     note_reference,
@@ -1038,7 +1038,7 @@ export class Google_binary_authorization_attestor_attestation_authority_note_864
   }: {
     note_reference: string,
     delegation_service_account_email?: string|null,
-    public_keys?: Google_binary_authorization_attestor_attestation_authority_note_864_public_keys_865[]|null
+    public_keys?: Google_binary_authorization_attestor_attestation_authority_note_8_public_keys_9[]|null
   }) {
     this.note_reference = note_reference;
     this.delegation_service_account_email = delegation_service_account_email;
@@ -1058,11 +1058,11 @@ export class Google_binary_authorization_attestor_attestation_authority_note_864
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_binary_authorization_attestor_attestation_authority_note_864';
+    return 'TerraformGoogle::Google_binary_authorization_attestor_attestation_authority_note_8';
   }
 }
 
-export class Google_binary_authorization_attestor_attestation_authority_note_864_public_keys_865 implements PcoreValue {
+export class Google_binary_authorization_attestor_attestation_authority_note_8_public_keys_9 implements PcoreValue {
   readonly ascii_armored_pgp_public_key: string;
   readonly comment: string|null;
   readonly id: string|null;
@@ -1094,15 +1094,15 @@ export class Google_binary_authorization_attestor_attestation_authority_note_864
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_binary_authorization_attestor_attestation_authority_note_864_public_keys_865';
+    return 'TerraformGoogle::Google_binary_authorization_attestor_attestation_authority_note_8_public_keys_9';
   }
 }
 
 export class Google_binary_authorization_policy implements PcoreValue {
-  readonly default_admission_rule: Google_binary_authorization_policy_default_admission_rule_868[];
+  readonly default_admission_rule: Google_binary_authorization_policy_default_admission_rule_12[];
   readonly google_binary_authorization_policy_id: string|null;
-  readonly admission_whitelist_patterns: Google_binary_authorization_policy_admission_whitelist_patterns_866[]|null;
-  readonly cluster_admission_rules: Google_binary_authorization_policy_cluster_admission_rules_867[]|null;
+  readonly admission_whitelist_patterns: Google_binary_authorization_policy_admission_whitelist_patterns_10[]|null;
+  readonly cluster_admission_rules: Google_binary_authorization_policy_cluster_admission_rules_11[]|null;
   readonly description: string|null;
   readonly project: string|null;
 
@@ -1114,10 +1114,10 @@ export class Google_binary_authorization_policy implements PcoreValue {
     description = null,
     project = null
   }: {
-    default_admission_rule: Google_binary_authorization_policy_default_admission_rule_868[],
+    default_admission_rule: Google_binary_authorization_policy_default_admission_rule_12[],
     google_binary_authorization_policy_id?: string|null,
-    admission_whitelist_patterns?: Google_binary_authorization_policy_admission_whitelist_patterns_866[]|null,
-    cluster_admission_rules?: Google_binary_authorization_policy_cluster_admission_rules_867[]|null,
+    admission_whitelist_patterns?: Google_binary_authorization_policy_admission_whitelist_patterns_10[]|null,
+    cluster_admission_rules?: Google_binary_authorization_policy_cluster_admission_rules_11[]|null,
     description?: string|null,
     project?: string|null
   }) {
@@ -1165,7 +1165,7 @@ export class Google_binary_authorization_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_binary_authorization_policy_admission_whitelist_patterns_866 implements PcoreValue {
+export class Google_binary_authorization_policy_admission_whitelist_patterns_10 implements PcoreValue {
   readonly name_pattern: string|null;
 
   constructor({
@@ -1185,11 +1185,11 @@ export class Google_binary_authorization_policy_admission_whitelist_patterns_866
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_binary_authorization_policy_admission_whitelist_patterns_866';
+    return 'TerraformGoogle::Google_binary_authorization_policy_admission_whitelist_patterns_10';
   }
 }
 
-export class Google_binary_authorization_policy_cluster_admission_rules_867 implements PcoreValue {
+export class Google_binary_authorization_policy_cluster_admission_rules_11 implements PcoreValue {
   readonly cluster: string;
   readonly enforcement_mode: string|null;
   readonly evaluation_mode: string|null;
@@ -1228,11 +1228,11 @@ export class Google_binary_authorization_policy_cluster_admission_rules_867 impl
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_binary_authorization_policy_cluster_admission_rules_867';
+    return 'TerraformGoogle::Google_binary_authorization_policy_cluster_admission_rules_11';
   }
 }
 
-export class Google_binary_authorization_policy_default_admission_rule_868 implements PcoreValue {
+export class Google_binary_authorization_policy_default_admission_rule_12 implements PcoreValue {
   readonly enforcement_mode: string;
   readonly evaluation_mode: string;
   readonly require_attestations_by: string[]|null;
@@ -1262,18 +1262,18 @@ export class Google_binary_authorization_policy_default_admission_rule_868 imple
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_binary_authorization_policy_default_admission_rule_868';
+    return 'TerraformGoogle::Google_binary_authorization_policy_default_admission_rule_12';
   }
 }
 
 export class Google_cloudbuild_trigger implements PcoreValue {
   readonly google_cloudbuild_trigger_id: string|null;
-  readonly build: Google_cloudbuild_trigger_build_869[]|null;
+  readonly build: Google_cloudbuild_trigger_build_13[]|null;
   readonly description: string|null;
   readonly filename: string|null;
   readonly project: string|null;
   readonly substitutions: {[s: string]: string}|null;
-  readonly trigger_template: Google_cloudbuild_trigger_trigger_template_871[]|null;
+  readonly trigger_template: Google_cloudbuild_trigger_trigger_template_15[]|null;
 
   constructor({
     google_cloudbuild_trigger_id = null,
@@ -1285,12 +1285,12 @@ export class Google_cloudbuild_trigger implements PcoreValue {
     trigger_template = null
   }: {
     google_cloudbuild_trigger_id?: string|null,
-    build?: Google_cloudbuild_trigger_build_869[]|null,
+    build?: Google_cloudbuild_trigger_build_13[]|null,
     description?: string|null,
     filename?: string|null,
     project?: string|null,
     substitutions?: {[s: string]: string}|null,
-    trigger_template?: Google_cloudbuild_trigger_trigger_template_871[]|null
+    trigger_template?: Google_cloudbuild_trigger_trigger_template_15[]|null
   }) {
     this.google_cloudbuild_trigger_id = google_cloudbuild_trigger_id;
     this.build = build;
@@ -1342,9 +1342,9 @@ export class Google_cloudbuild_triggerHandler implements PcoreValue {
   }
 }
 
-export class Google_cloudbuild_trigger_build_869 implements PcoreValue {
+export class Google_cloudbuild_trigger_build_13 implements PcoreValue {
   readonly images: string[]|null;
-  readonly step: Google_cloudbuild_trigger_build_869_step_870[]|null;
+  readonly step: Google_cloudbuild_trigger_build_13_step_14[]|null;
   readonly tags: string[]|null;
 
   constructor({
@@ -1353,7 +1353,7 @@ export class Google_cloudbuild_trigger_build_869 implements PcoreValue {
     tags = null
   }: {
     images?: string[]|null,
-    step?: Google_cloudbuild_trigger_build_869_step_870[]|null,
+    step?: Google_cloudbuild_trigger_build_13_step_14[]|null,
     tags?: string[]|null
   }) {
     this.images = images;
@@ -1376,11 +1376,11 @@ export class Google_cloudbuild_trigger_build_869 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_cloudbuild_trigger_build_869';
+    return 'TerraformGoogle::Google_cloudbuild_trigger_build_13';
   }
 }
 
-export class Google_cloudbuild_trigger_build_869_step_870 implements PcoreValue {
+export class Google_cloudbuild_trigger_build_13_step_14 implements PcoreValue {
   readonly args: string|null;
   readonly name: string|null;
 
@@ -1407,11 +1407,11 @@ export class Google_cloudbuild_trigger_build_869_step_870 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_cloudbuild_trigger_build_869_step_870';
+    return 'TerraformGoogle::Google_cloudbuild_trigger_build_13_step_14';
   }
 }
 
-export class Google_cloudbuild_trigger_trigger_template_871 implements PcoreValue {
+export class Google_cloudbuild_trigger_trigger_template_15 implements PcoreValue {
   readonly branch_name: string|null;
   readonly commit_sha: string|null;
   readonly dir: string|null;
@@ -1466,7 +1466,7 @@ export class Google_cloudbuild_trigger_trigger_template_871 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_cloudbuild_trigger_trigger_template_871';
+    return 'TerraformGoogle::Google_cloudbuild_trigger_trigger_template_15';
   }
 }
 
@@ -1479,7 +1479,7 @@ export class Google_cloudfunctions_function implements PcoreValue {
   readonly description: string|null;
   readonly entry_point: string|null;
   readonly environment_variables: {[s: string]: string}|null;
-  readonly event_trigger: Google_cloudfunctions_function_event_trigger_872[]|null;
+  readonly event_trigger: Google_cloudfunctions_function_event_trigger_16[]|null;
   readonly https_trigger_url: string|null;
   readonly labels: {[s: string]: string}|null;
   readonly project: string|null;
@@ -1520,7 +1520,7 @@ export class Google_cloudfunctions_function implements PcoreValue {
     description?: string|null,
     entry_point?: string|null,
     environment_variables?: {[s: string]: string}|null,
-    event_trigger?: Google_cloudfunctions_function_event_trigger_872[]|null,
+    event_trigger?: Google_cloudfunctions_function_event_trigger_16[]|null,
     https_trigger_url?: string|null,
     labels?: {[s: string]: string}|null,
     project?: string|null,
@@ -1624,10 +1624,10 @@ export class Google_cloudfunctions_functionHandler implements PcoreValue {
   }
 }
 
-export class Google_cloudfunctions_function_event_trigger_872 implements PcoreValue {
+export class Google_cloudfunctions_function_event_trigger_16 implements PcoreValue {
   readonly event_type: string;
   readonly resource: string;
-  readonly failure_policy: Google_cloudfunctions_function_event_trigger_872_failure_policy_873[]|null;
+  readonly failure_policy: Google_cloudfunctions_function_event_trigger_16_failure_policy_17[]|null;
 
   constructor({
     event_type,
@@ -1636,7 +1636,7 @@ export class Google_cloudfunctions_function_event_trigger_872 implements PcoreVa
   }: {
     event_type: string,
     resource: string,
-    failure_policy?: Google_cloudfunctions_function_event_trigger_872_failure_policy_873[]|null
+    failure_policy?: Google_cloudfunctions_function_event_trigger_16_failure_policy_17[]|null
   }) {
     this.event_type = event_type;
     this.resource = resource;
@@ -1654,11 +1654,11 @@ export class Google_cloudfunctions_function_event_trigger_872 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_cloudfunctions_function_event_trigger_872';
+    return 'TerraformGoogle::Google_cloudfunctions_function_event_trigger_16';
   }
 }
 
-export class Google_cloudfunctions_function_event_trigger_872_failure_policy_873 implements PcoreValue {
+export class Google_cloudfunctions_function_event_trigger_16_failure_policy_17 implements PcoreValue {
   readonly retry: boolean;
 
   constructor({
@@ -1676,14 +1676,14 @@ export class Google_cloudfunctions_function_event_trigger_872_failure_policy_873
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_cloudfunctions_function_event_trigger_872_failure_policy_873';
+    return 'TerraformGoogle::Google_cloudfunctions_function_event_trigger_16_failure_policy_17';
   }
 }
 
 export class Google_cloudiot_registry implements PcoreValue {
   readonly name: string;
   readonly google_cloudiot_registry_id: string|null;
-  readonly credentials: Google_cloudiot_registry_credentials_874[]|null;
+  readonly credentials: Google_cloudiot_registry_credentials_18[]|null;
   readonly event_notification_config: {[s: string]: string}|null;
   readonly http_config: {[s: string]: string}|null;
   readonly mqtt_config: {[s: string]: string}|null;
@@ -1704,7 +1704,7 @@ export class Google_cloudiot_registry implements PcoreValue {
   }: {
     name: string,
     google_cloudiot_registry_id?: string|null,
-    credentials?: Google_cloudiot_registry_credentials_874[]|null,
+    credentials?: Google_cloudiot_registry_credentials_18[]|null,
     event_notification_config?: {[s: string]: string}|null,
     http_config?: {[s: string]: string}|null,
     mqtt_config?: {[s: string]: string}|null,
@@ -1768,7 +1768,7 @@ export class Google_cloudiot_registryHandler implements PcoreValue {
   }
 }
 
-export class Google_cloudiot_registry_credentials_874 implements PcoreValue {
+export class Google_cloudiot_registry_credentials_18 implements PcoreValue {
   readonly public_key_certificate: {[s: string]: string}|null;
 
   constructor({
@@ -1788,14 +1788,14 @@ export class Google_cloudiot_registry_credentials_874 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_cloudiot_registry_credentials_874';
+    return 'TerraformGoogle::Google_cloudiot_registry_credentials_18';
   }
 }
 
 export class Google_composer_environment implements PcoreValue {
   readonly name: string;
   readonly google_composer_environment_id: string|null;
-  readonly config: Google_composer_environment_config_875[]|null;
+  readonly config: Google_composer_environment_config_19[]|null;
   readonly labels: {[s: string]: string}|null;
   readonly project: string|null;
   readonly region: string|null;
@@ -1810,7 +1810,7 @@ export class Google_composer_environment implements PcoreValue {
   }: {
     name: string,
     google_composer_environment_id?: string|null,
-    config?: Google_composer_environment_config_875[]|null,
+    config?: Google_composer_environment_config_19[]|null,
     labels?: {[s: string]: string}|null,
     project?: string|null,
     region?: string|null
@@ -1859,13 +1859,13 @@ export class Google_composer_environmentHandler implements PcoreValue {
   }
 }
 
-export class Google_composer_environment_config_875 implements PcoreValue {
+export class Google_composer_environment_config_19 implements PcoreValue {
   readonly airflow_uri: string|null;
   readonly dag_gcs_prefix: string|null;
   readonly gke_cluster: string|null;
-  readonly node_config: Google_composer_environment_config_875_node_config_876[]|null;
+  readonly node_config: Google_composer_environment_config_19_node_config_20[]|null;
   readonly node_count: number|null;
-  readonly software_config: Google_composer_environment_config_875_software_config_877[]|null;
+  readonly software_config: Google_composer_environment_config_19_software_config_21[]|null;
 
   constructor({
     airflow_uri = null,
@@ -1878,9 +1878,9 @@ export class Google_composer_environment_config_875 implements PcoreValue {
     airflow_uri?: string|null,
     dag_gcs_prefix?: string|null,
     gke_cluster?: string|null,
-    node_config?: Google_composer_environment_config_875_node_config_876[]|null,
+    node_config?: Google_composer_environment_config_19_node_config_20[]|null,
     node_count?: number|null,
-    software_config?: Google_composer_environment_config_875_software_config_877[]|null
+    software_config?: Google_composer_environment_config_19_software_config_21[]|null
   }) {
     this.airflow_uri = airflow_uri;
     this.dag_gcs_prefix = dag_gcs_prefix;
@@ -1914,11 +1914,11 @@ export class Google_composer_environment_config_875 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_composer_environment_config_875';
+    return 'TerraformGoogle::Google_composer_environment_config_19';
   }
 }
 
-export class Google_composer_environment_config_875_node_config_876 implements PcoreValue {
+export class Google_composer_environment_config_19_node_config_20 implements PcoreValue {
   readonly disk_size_gb: number|null;
   readonly machine_type: string|null;
   readonly network: string|null;
@@ -1987,11 +1987,11 @@ export class Google_composer_environment_config_875_node_config_876 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_composer_environment_config_875_node_config_876';
+    return 'TerraformGoogle::Google_composer_environment_config_19_node_config_20';
   }
 }
 
-export class Google_composer_environment_config_875_software_config_877 implements PcoreValue {
+export class Google_composer_environment_config_19_software_config_21 implements PcoreValue {
   readonly airflow_config_overrides: {[s: string]: string}|null;
   readonly env_variables: {[s: string]: string}|null;
   readonly image_version: string|null;
@@ -2032,7 +2032,7 @@ export class Google_composer_environment_config_875_software_config_877 implemen
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_composer_environment_config_875_software_config_877';
+    return 'TerraformGoogle::Google_composer_environment_config_19_software_config_21';
   }
 }
 
@@ -2232,7 +2232,7 @@ export class Google_compute_attached_diskHandler implements PcoreValue {
 }
 
 export class Google_compute_autoscaler implements PcoreValue {
-  readonly autoscaling_policy: Google_compute_autoscaler_autoscaling_policy_878[];
+  readonly autoscaling_policy: Google_compute_autoscaler_autoscaling_policy_22[];
   readonly name: string;
   readonly target: string;
   readonly google_compute_autoscaler_id: string|null;
@@ -2253,7 +2253,7 @@ export class Google_compute_autoscaler implements PcoreValue {
     self_link = null,
     zone = null
   }: {
-    autoscaling_policy: Google_compute_autoscaler_autoscaling_policy_878[],
+    autoscaling_policy: Google_compute_autoscaler_autoscaling_policy_22[],
     name: string,
     target: string,
     google_compute_autoscaler_id?: string|null,
@@ -2315,13 +2315,13 @@ export class Google_compute_autoscalerHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_autoscaler_autoscaling_policy_878 implements PcoreValue {
+export class Google_compute_autoscaler_autoscaling_policy_22 implements PcoreValue {
   readonly max_replicas: number;
   readonly min_replicas: number;
   readonly cooldown_period: number|null;
-  readonly cpu_utilization: Google_compute_autoscaler_autoscaling_policy_878_cpu_utilization_879[]|null;
-  readonly load_balancing_utilization: Google_compute_autoscaler_autoscaling_policy_878_load_balancing_utilization_880[]|null;
-  readonly metric: Google_compute_autoscaler_autoscaling_policy_878_metric_881[]|null;
+  readonly cpu_utilization: Google_compute_autoscaler_autoscaling_policy_22_cpu_utilization_23[]|null;
+  readonly load_balancing_utilization: Google_compute_autoscaler_autoscaling_policy_22_load_balancing_utilization_24[]|null;
+  readonly metric: Google_compute_autoscaler_autoscaling_policy_22_metric_25[]|null;
 
   constructor({
     max_replicas,
@@ -2334,9 +2334,9 @@ export class Google_compute_autoscaler_autoscaling_policy_878 implements PcoreVa
     max_replicas: number,
     min_replicas: number,
     cooldown_period?: number|null,
-    cpu_utilization?: Google_compute_autoscaler_autoscaling_policy_878_cpu_utilization_879[]|null,
-    load_balancing_utilization?: Google_compute_autoscaler_autoscaling_policy_878_load_balancing_utilization_880[]|null,
-    metric?: Google_compute_autoscaler_autoscaling_policy_878_metric_881[]|null
+    cpu_utilization?: Google_compute_autoscaler_autoscaling_policy_22_cpu_utilization_23[]|null,
+    load_balancing_utilization?: Google_compute_autoscaler_autoscaling_policy_22_load_balancing_utilization_24[]|null,
+    metric?: Google_compute_autoscaler_autoscaling_policy_22_metric_25[]|null
   }) {
     this.max_replicas = max_replicas;
     this.min_replicas = min_replicas;
@@ -2366,11 +2366,11 @@ export class Google_compute_autoscaler_autoscaling_policy_878 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_878';
+    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_22';
   }
 }
 
-export class Google_compute_autoscaler_autoscaling_policy_878_cpu_utilization_879 implements PcoreValue {
+export class Google_compute_autoscaler_autoscaling_policy_22_cpu_utilization_23 implements PcoreValue {
   readonly target: number;
 
   constructor({
@@ -2388,11 +2388,11 @@ export class Google_compute_autoscaler_autoscaling_policy_878_cpu_utilization_87
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_878_cpu_utilization_879';
+    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_22_cpu_utilization_23';
   }
 }
 
-export class Google_compute_autoscaler_autoscaling_policy_878_load_balancing_utilization_880 implements PcoreValue {
+export class Google_compute_autoscaler_autoscaling_policy_22_load_balancing_utilization_24 implements PcoreValue {
   readonly target: number;
 
   constructor({
@@ -2410,11 +2410,11 @@ export class Google_compute_autoscaler_autoscaling_policy_878_load_balancing_uti
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_878_load_balancing_utilization_880';
+    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_22_load_balancing_utilization_24';
   }
 }
 
-export class Google_compute_autoscaler_autoscaling_policy_878_metric_881 implements PcoreValue {
+export class Google_compute_autoscaler_autoscaling_policy_22_metric_25 implements PcoreValue {
   readonly name: string;
   readonly target: number;
   readonly type: string;
@@ -2442,7 +2442,7 @@ export class Google_compute_autoscaler_autoscaling_policy_878_metric_881 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_878_metric_881';
+    return 'TerraformGoogle::Google_compute_autoscaler_autoscaling_policy_22_metric_25';
   }
 }
 
@@ -2529,14 +2529,14 @@ export class Google_compute_backend_service implements PcoreValue {
   readonly health_checks: string[];
   readonly name: string;
   readonly google_compute_backend_service_id: string|null;
-  readonly backend: Google_compute_backend_service_backend_882[]|null;
-  readonly cdn_policy: Google_compute_backend_service_cdn_policy_883[]|null;
+  readonly backend: Google_compute_backend_service_backend_26[]|null;
+  readonly cdn_policy: Google_compute_backend_service_cdn_policy_27[]|null;
   readonly connection_draining_timeout_sec: number|null;
   readonly custom_request_headers: string[]|null;
   readonly description: string|null;
   readonly enable_cdn: boolean|null;
   readonly fingerprint: string|null;
-  readonly iap: Google_compute_backend_service_iap_885[]|null;
+  readonly iap: Google_compute_backend_service_iap_29[]|null;
   readonly port_name: string|null;
   readonly project: string|null;
   readonly protocol: string|null;
@@ -2570,14 +2570,14 @@ export class Google_compute_backend_service implements PcoreValue {
     health_checks: string[],
     name: string,
     google_compute_backend_service_id?: string|null,
-    backend?: Google_compute_backend_service_backend_882[]|null,
-    cdn_policy?: Google_compute_backend_service_cdn_policy_883[]|null,
+    backend?: Google_compute_backend_service_backend_26[]|null,
+    cdn_policy?: Google_compute_backend_service_cdn_policy_27[]|null,
     connection_draining_timeout_sec?: number|null,
     custom_request_headers?: string[]|null,
     description?: string|null,
     enable_cdn?: boolean|null,
     fingerprint?: string|null,
-    iap?: Google_compute_backend_service_iap_885[]|null,
+    iap?: Google_compute_backend_service_iap_29[]|null,
     port_name?: string|null,
     project?: string|null,
     protocol?: string|null,
@@ -2681,7 +2681,7 @@ export class Google_compute_backend_serviceHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_backend_service_backend_882 implements PcoreValue {
+export class Google_compute_backend_service_backend_26 implements PcoreValue {
   readonly balancing_mode: string|null;
   readonly capacity_scaler: number|null;
   readonly description: string|null;
@@ -2757,17 +2757,17 @@ export class Google_compute_backend_service_backend_882 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_backend_service_backend_882';
+    return 'TerraformGoogle::Google_compute_backend_service_backend_26';
   }
 }
 
-export class Google_compute_backend_service_cdn_policy_883 implements PcoreValue {
-  readonly cache_key_policy: Google_compute_backend_service_cdn_policy_883_cache_key_policy_884[]|null;
+export class Google_compute_backend_service_cdn_policy_27 implements PcoreValue {
+  readonly cache_key_policy: Google_compute_backend_service_cdn_policy_27_cache_key_policy_28[]|null;
 
   constructor({
     cache_key_policy = null
   }: {
-    cache_key_policy?: Google_compute_backend_service_cdn_policy_883_cache_key_policy_884[]|null
+    cache_key_policy?: Google_compute_backend_service_cdn_policy_27_cache_key_policy_28[]|null
   }) {
     this.cache_key_policy = cache_key_policy;
   }
@@ -2781,11 +2781,11 @@ export class Google_compute_backend_service_cdn_policy_883 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_backend_service_cdn_policy_883';
+    return 'TerraformGoogle::Google_compute_backend_service_cdn_policy_27';
   }
 }
 
-export class Google_compute_backend_service_cdn_policy_883_cache_key_policy_884 implements PcoreValue {
+export class Google_compute_backend_service_cdn_policy_27_cache_key_policy_28 implements PcoreValue {
   readonly include_host: boolean|null;
   readonly include_protocol: boolean|null;
   readonly include_query_string: boolean|null;
@@ -2833,11 +2833,11 @@ export class Google_compute_backend_service_cdn_policy_883_cache_key_policy_884 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_backend_service_cdn_policy_883_cache_key_policy_884';
+    return 'TerraformGoogle::Google_compute_backend_service_cdn_policy_27_cache_key_policy_28';
   }
 }
 
-export class Google_compute_backend_service_iap_885 implements PcoreValue {
+export class Google_compute_backend_service_iap_29 implements PcoreValue {
   readonly oauth2_client_id: string;
   readonly oauth2_client_secret: string;
 
@@ -2860,7 +2860,7 @@ export class Google_compute_backend_service_iap_885 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_backend_service_iap_885';
+    return 'TerraformGoogle::Google_compute_backend_service_iap_29';
   }
 }
 
@@ -2869,7 +2869,7 @@ export class Google_compute_disk implements PcoreValue {
   readonly google_compute_disk_id: string|null;
   readonly creation_timestamp: string|null;
   readonly description: string|null;
-  readonly disk_encryption_key: Google_compute_disk_disk_encryption_key_886[]|null;
+  readonly disk_encryption_key: Google_compute_disk_disk_encryption_key_30[]|null;
   readonly disk_encryption_key_raw: string|null;
   readonly disk_encryption_key_sha256: string|null;
   readonly image: string|null;
@@ -2881,9 +2881,9 @@ export class Google_compute_disk implements PcoreValue {
   readonly self_link: string|null;
   readonly size: number|null;
   readonly snapshot: string|null;
-  readonly source_image_encryption_key: Google_compute_disk_source_image_encryption_key_887[]|null;
+  readonly source_image_encryption_key: Google_compute_disk_source_image_encryption_key_31[]|null;
   readonly source_image_id: string|null;
-  readonly source_snapshot_encryption_key: Google_compute_disk_source_snapshot_encryption_key_888[]|null;
+  readonly source_snapshot_encryption_key: Google_compute_disk_source_snapshot_encryption_key_32[]|null;
   readonly source_snapshot_id: string|null;
   readonly type: string|null;
   readonly users: string[]|null;
@@ -2918,7 +2918,7 @@ export class Google_compute_disk implements PcoreValue {
     google_compute_disk_id?: string|null,
     creation_timestamp?: string|null,
     description?: string|null,
-    disk_encryption_key?: Google_compute_disk_disk_encryption_key_886[]|null,
+    disk_encryption_key?: Google_compute_disk_disk_encryption_key_30[]|null,
     disk_encryption_key_raw?: string|null,
     disk_encryption_key_sha256?: string|null,
     image?: string|null,
@@ -2930,9 +2930,9 @@ export class Google_compute_disk implements PcoreValue {
     self_link?: string|null,
     size?: number|null,
     snapshot?: string|null,
-    source_image_encryption_key?: Google_compute_disk_source_image_encryption_key_887[]|null,
+    source_image_encryption_key?: Google_compute_disk_source_image_encryption_key_31[]|null,
     source_image_id?: string|null,
-    source_snapshot_encryption_key?: Google_compute_disk_source_snapshot_encryption_key_888[]|null,
+    source_snapshot_encryption_key?: Google_compute_disk_source_snapshot_encryption_key_32[]|null,
     source_snapshot_id?: string|null,
     type?: string|null,
     users?: string[]|null,
@@ -3050,7 +3050,7 @@ export class Google_compute_diskHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_disk_disk_encryption_key_886 implements PcoreValue {
+export class Google_compute_disk_disk_encryption_key_30 implements PcoreValue {
   readonly raw_key: string|null;
   readonly sha256: string|null;
 
@@ -3077,11 +3077,11 @@ export class Google_compute_disk_disk_encryption_key_886 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_disk_disk_encryption_key_886';
+    return 'TerraformGoogle::Google_compute_disk_disk_encryption_key_30';
   }
 }
 
-export class Google_compute_disk_source_image_encryption_key_887 implements PcoreValue {
+export class Google_compute_disk_source_image_encryption_key_31 implements PcoreValue {
   readonly raw_key: string|null;
   readonly sha256: string|null;
 
@@ -3108,11 +3108,11 @@ export class Google_compute_disk_source_image_encryption_key_887 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_disk_source_image_encryption_key_887';
+    return 'TerraformGoogle::Google_compute_disk_source_image_encryption_key_31';
   }
 }
 
-export class Google_compute_disk_source_snapshot_encryption_key_888 implements PcoreValue {
+export class Google_compute_disk_source_snapshot_encryption_key_32 implements PcoreValue {
   readonly raw_key: string|null;
   readonly sha256: string|null;
 
@@ -3139,7 +3139,7 @@ export class Google_compute_disk_source_snapshot_encryption_key_888 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_disk_source_snapshot_encryption_key_888';
+    return 'TerraformGoogle::Google_compute_disk_source_snapshot_encryption_key_32';
   }
 }
 
@@ -3147,9 +3147,9 @@ export class Google_compute_firewall implements PcoreValue {
   readonly name: string;
   readonly network: string;
   readonly google_compute_firewall_id: string|null;
-  readonly allow: Google_compute_firewall_allow_889[]|null;
+  readonly allow: Google_compute_firewall_allow_33[]|null;
   readonly creation_timestamp: string|null;
-  readonly deny: Google_compute_firewall_deny_890[]|null;
+  readonly deny: Google_compute_firewall_deny_34[]|null;
   readonly description: string|null;
   readonly destination_ranges: string[]|null;
   readonly direction: string|null;
@@ -3188,9 +3188,9 @@ export class Google_compute_firewall implements PcoreValue {
     name: string,
     network: string,
     google_compute_firewall_id?: string|null,
-    allow?: Google_compute_firewall_allow_889[]|null,
+    allow?: Google_compute_firewall_allow_33[]|null,
     creation_timestamp?: string|null,
-    deny?: Google_compute_firewall_deny_890[]|null,
+    deny?: Google_compute_firewall_deny_34[]|null,
     description?: string|null,
     destination_ranges?: string[]|null,
     direction?: string|null,
@@ -3299,7 +3299,7 @@ export class Google_compute_firewallHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_firewall_allow_889 implements PcoreValue {
+export class Google_compute_firewall_allow_33 implements PcoreValue {
   readonly protocol: string;
   readonly ports: string[]|null;
 
@@ -3324,11 +3324,11 @@ export class Google_compute_firewall_allow_889 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_firewall_allow_889';
+    return 'TerraformGoogle::Google_compute_firewall_allow_33';
   }
 }
 
-export class Google_compute_firewall_deny_890 implements PcoreValue {
+export class Google_compute_firewall_deny_34 implements PcoreValue {
   readonly protocol: string;
   readonly ports: string[]|null;
 
@@ -3353,7 +3353,7 @@ export class Google_compute_firewall_deny_890 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_firewall_deny_890';
+    return 'TerraformGoogle::Google_compute_firewall_deny_34';
   }
 }
 
@@ -3780,12 +3780,12 @@ export class Google_compute_health_check implements PcoreValue {
   readonly creation_timestamp: string|null;
   readonly description: string|null;
   readonly healthy_threshold: number|null;
-  readonly http_health_check: Google_compute_health_check_http_health_check_891[]|null;
-  readonly https_health_check: Google_compute_health_check_https_health_check_892[]|null;
+  readonly http_health_check: Google_compute_health_check_http_health_check_35[]|null;
+  readonly https_health_check: Google_compute_health_check_https_health_check_36[]|null;
   readonly project: string|null;
   readonly self_link: string|null;
-  readonly ssl_health_check: Google_compute_health_check_ssl_health_check_893[]|null;
-  readonly tcp_health_check: Google_compute_health_check_tcp_health_check_894[]|null;
+  readonly ssl_health_check: Google_compute_health_check_ssl_health_check_37[]|null;
+  readonly tcp_health_check: Google_compute_health_check_tcp_health_check_38[]|null;
   readonly timeout_sec: number|null;
   readonly type: string|null;
   readonly unhealthy_threshold: number|null;
@@ -3813,12 +3813,12 @@ export class Google_compute_health_check implements PcoreValue {
     creation_timestamp?: string|null,
     description?: string|null,
     healthy_threshold?: number|null,
-    http_health_check?: Google_compute_health_check_http_health_check_891[]|null,
-    https_health_check?: Google_compute_health_check_https_health_check_892[]|null,
+    http_health_check?: Google_compute_health_check_http_health_check_35[]|null,
+    https_health_check?: Google_compute_health_check_https_health_check_36[]|null,
     project?: string|null,
     self_link?: string|null,
-    ssl_health_check?: Google_compute_health_check_ssl_health_check_893[]|null,
-    tcp_health_check?: Google_compute_health_check_tcp_health_check_894[]|null,
+    ssl_health_check?: Google_compute_health_check_ssl_health_check_37[]|null,
+    tcp_health_check?: Google_compute_health_check_tcp_health_check_38[]|null,
     timeout_sec?: number|null,
     type?: string|null,
     unhealthy_threshold?: number|null
@@ -3903,7 +3903,7 @@ export class Google_compute_health_checkHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_health_check_http_health_check_891 implements PcoreValue {
+export class Google_compute_health_check_http_health_check_35 implements PcoreValue {
   readonly host: string|null;
   readonly port: number|null;
   readonly proxy_header: string|null;
@@ -3951,11 +3951,11 @@ export class Google_compute_health_check_http_health_check_891 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_health_check_http_health_check_891';
+    return 'TerraformGoogle::Google_compute_health_check_http_health_check_35';
   }
 }
 
-export class Google_compute_health_check_https_health_check_892 implements PcoreValue {
+export class Google_compute_health_check_https_health_check_36 implements PcoreValue {
   readonly host: string|null;
   readonly port: number|null;
   readonly proxy_header: string|null;
@@ -4003,11 +4003,11 @@ export class Google_compute_health_check_https_health_check_892 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_health_check_https_health_check_892';
+    return 'TerraformGoogle::Google_compute_health_check_https_health_check_36';
   }
 }
 
-export class Google_compute_health_check_ssl_health_check_893 implements PcoreValue {
+export class Google_compute_health_check_ssl_health_check_37 implements PcoreValue {
   readonly port: number|null;
   readonly proxy_header: string|null;
   readonly request: string|null;
@@ -4048,11 +4048,11 @@ export class Google_compute_health_check_ssl_health_check_893 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_health_check_ssl_health_check_893';
+    return 'TerraformGoogle::Google_compute_health_check_ssl_health_check_37';
   }
 }
 
-export class Google_compute_health_check_tcp_health_check_894 implements PcoreValue {
+export class Google_compute_health_check_tcp_health_check_38 implements PcoreValue {
   readonly port: number|null;
   readonly proxy_header: string|null;
   readonly request: string|null;
@@ -4093,7 +4093,7 @@ export class Google_compute_health_check_tcp_health_check_894 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_health_check_tcp_health_check_894';
+    return 'TerraformGoogle::Google_compute_health_check_tcp_health_check_38';
   }
 }
 
@@ -4339,7 +4339,7 @@ export class Google_compute_image implements PcoreValue {
   readonly labels: {[s: string]: string}|null;
   readonly licenses: string[]|null;
   readonly project: string|null;
-  readonly raw_disk: Google_compute_image_raw_disk_895[]|null;
+  readonly raw_disk: Google_compute_image_raw_disk_39[]|null;
   readonly self_link: string|null;
   readonly source_disk: string|null;
 
@@ -4366,7 +4366,7 @@ export class Google_compute_image implements PcoreValue {
     labels?: {[s: string]: string}|null,
     licenses?: string[]|null,
     project?: string|null,
-    raw_disk?: Google_compute_image_raw_disk_895[]|null,
+    raw_disk?: Google_compute_image_raw_disk_39[]|null,
     self_link?: string|null,
     source_disk?: string|null
   }) {
@@ -4438,7 +4438,7 @@ export class Google_compute_imageHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_image_raw_disk_895 implements PcoreValue {
+export class Google_compute_image_raw_disk_39 implements PcoreValue {
   readonly source: string;
   readonly container_type: string|null;
   readonly sha1: string|null;
@@ -4470,25 +4470,25 @@ export class Google_compute_image_raw_disk_895 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_image_raw_disk_895';
+    return 'TerraformGoogle::Google_compute_image_raw_disk_39';
   }
 }
 
 export class Google_compute_instance implements PcoreValue {
-  readonly boot_disk: Google_compute_instance_boot_disk_897[];
+  readonly boot_disk: Google_compute_instance_boot_disk_41[];
   readonly machine_type: string;
   readonly name: string;
-  readonly network_interface: Google_compute_instance_network_interface_902[];
+  readonly network_interface: Google_compute_instance_network_interface_46[];
   readonly google_compute_instance_id: string|null;
   readonly allow_stopping_for_update: boolean|null;
-  readonly attached_disk: Google_compute_instance_attached_disk_896[]|null;
+  readonly attached_disk: Google_compute_instance_attached_disk_40[]|null;
   readonly can_ip_forward: boolean|null;
   readonly cpu_platform: string|null;
   readonly create_timeout: number|null;
   readonly deletion_protection: boolean|null;
   readonly description: string|null;
-  readonly disk: Google_compute_instance_disk_899[]|null;
-  readonly guest_accelerator: Google_compute_instance_guest_accelerator_900[]|null;
+  readonly disk: Google_compute_instance_disk_43[]|null;
+  readonly guest_accelerator: Google_compute_instance_guest_accelerator_44[]|null;
   readonly instance_id: string|null;
   readonly label_fingerprint: string|null;
   readonly labels: {[s: string]: string}|null;
@@ -4496,12 +4496,12 @@ export class Google_compute_instance implements PcoreValue {
   readonly metadata_fingerprint: string|null;
   readonly metadata_startup_script: string|null;
   readonly min_cpu_platform: string|null;
-  readonly network: Google_compute_instance_network_901[]|null;
+  readonly network: Google_compute_instance_network_45[]|null;
   readonly project: string|null;
-  readonly scheduling: Google_compute_instance_scheduling_905[]|null;
-  readonly scratch_disk: Google_compute_instance_scratch_disk_906[]|null;
+  readonly scheduling: Google_compute_instance_scheduling_49[]|null;
+  readonly scratch_disk: Google_compute_instance_scratch_disk_50[]|null;
   readonly self_link: string|null;
-  readonly service_account: Google_compute_instance_service_account_907[]|null;
+  readonly service_account: Google_compute_instance_service_account_51[]|null;
   readonly tags: string[]|null;
   readonly tags_fingerprint: string|null;
   readonly zone: string|null;
@@ -4538,20 +4538,20 @@ export class Google_compute_instance implements PcoreValue {
     tags_fingerprint = null,
     zone = null
   }: {
-    boot_disk: Google_compute_instance_boot_disk_897[],
+    boot_disk: Google_compute_instance_boot_disk_41[],
     machine_type: string,
     name: string,
-    network_interface: Google_compute_instance_network_interface_902[],
+    network_interface: Google_compute_instance_network_interface_46[],
     google_compute_instance_id?: string|null,
     allow_stopping_for_update?: boolean|null,
-    attached_disk?: Google_compute_instance_attached_disk_896[]|null,
+    attached_disk?: Google_compute_instance_attached_disk_40[]|null,
     can_ip_forward?: boolean|null,
     cpu_platform?: string|null,
     create_timeout?: number|null,
     deletion_protection?: boolean|null,
     description?: string|null,
-    disk?: Google_compute_instance_disk_899[]|null,
-    guest_accelerator?: Google_compute_instance_guest_accelerator_900[]|null,
+    disk?: Google_compute_instance_disk_43[]|null,
+    guest_accelerator?: Google_compute_instance_guest_accelerator_44[]|null,
     instance_id?: string|null,
     label_fingerprint?: string|null,
     labels?: {[s: string]: string}|null,
@@ -4559,12 +4559,12 @@ export class Google_compute_instance implements PcoreValue {
     metadata_fingerprint?: string|null,
     metadata_startup_script?: string|null,
     min_cpu_platform?: string|null,
-    network?: Google_compute_instance_network_901[]|null,
+    network?: Google_compute_instance_network_45[]|null,
     project?: string|null,
-    scheduling?: Google_compute_instance_scheduling_905[]|null,
-    scratch_disk?: Google_compute_instance_scratch_disk_906[]|null,
+    scheduling?: Google_compute_instance_scheduling_49[]|null,
+    scratch_disk?: Google_compute_instance_scratch_disk_50[]|null,
     self_link?: string|null,
-    service_account?: Google_compute_instance_service_account_907[]|null,
+    service_account?: Google_compute_instance_service_account_51[]|null,
     tags?: string[]|null,
     tags_fingerprint?: string|null,
     zone?: string|null
@@ -4703,7 +4703,7 @@ export class Google_compute_instanceHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_instance_attached_disk_896 implements PcoreValue {
+export class Google_compute_instance_attached_disk_40 implements PcoreValue {
   readonly source: string;
   readonly device_name: string|null;
   readonly disk_encryption_key_raw: string|null;
@@ -4749,16 +4749,16 @@ export class Google_compute_instance_attached_disk_896 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_attached_disk_896';
+    return 'TerraformGoogle::Google_compute_instance_attached_disk_40';
   }
 }
 
-export class Google_compute_instance_boot_disk_897 implements PcoreValue {
+export class Google_compute_instance_boot_disk_41 implements PcoreValue {
   readonly auto_delete: boolean|null;
   readonly device_name: string|null;
   readonly disk_encryption_key_raw: string|null;
   readonly disk_encryption_key_sha256: string|null;
-  readonly initialize_params: Google_compute_instance_boot_disk_897_initialize_params_898[]|null;
+  readonly initialize_params: Google_compute_instance_boot_disk_41_initialize_params_42[]|null;
   readonly source: string|null;
 
   constructor({
@@ -4773,7 +4773,7 @@ export class Google_compute_instance_boot_disk_897 implements PcoreValue {
     device_name?: string|null,
     disk_encryption_key_raw?: string|null,
     disk_encryption_key_sha256?: string|null,
-    initialize_params?: Google_compute_instance_boot_disk_897_initialize_params_898[]|null,
+    initialize_params?: Google_compute_instance_boot_disk_41_initialize_params_42[]|null,
     source?: string|null
   }) {
     this.auto_delete = auto_delete;
@@ -4808,11 +4808,11 @@ export class Google_compute_instance_boot_disk_897 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_boot_disk_897';
+    return 'TerraformGoogle::Google_compute_instance_boot_disk_41';
   }
 }
 
-export class Google_compute_instance_boot_disk_897_initialize_params_898 implements PcoreValue {
+export class Google_compute_instance_boot_disk_41_initialize_params_42 implements PcoreValue {
   readonly image: string|null;
   readonly size: number|null;
   readonly type: string|null;
@@ -4846,11 +4846,11 @@ export class Google_compute_instance_boot_disk_897_initialize_params_898 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_boot_disk_897_initialize_params_898';
+    return 'TerraformGoogle::Google_compute_instance_boot_disk_41_initialize_params_42';
   }
 }
 
-export class Google_compute_instance_disk_899 implements PcoreValue {
+export class Google_compute_instance_disk_43 implements PcoreValue {
   readonly auto_delete: boolean|null;
   readonly device_name: string|null;
   readonly disk: string|null;
@@ -4926,7 +4926,7 @@ export class Google_compute_instance_disk_899 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_disk_899';
+    return 'TerraformGoogle::Google_compute_instance_disk_43';
   }
 }
 
@@ -4935,13 +4935,13 @@ export class Google_compute_instance_from_template implements PcoreValue {
   readonly source_instance_template: string;
   readonly google_compute_instance_from_template_id: string|null;
   readonly allow_stopping_for_update: boolean|null;
-  readonly attached_disk: Google_compute_instance_from_template_attached_disk_908[]|null;
-  readonly boot_disk: Google_compute_instance_from_template_boot_disk_909[]|null;
+  readonly attached_disk: Google_compute_instance_from_template_attached_disk_52[]|null;
+  readonly boot_disk: Google_compute_instance_from_template_boot_disk_53[]|null;
   readonly can_ip_forward: boolean|null;
   readonly cpu_platform: string|null;
   readonly deletion_protection: boolean|null;
   readonly description: string|null;
-  readonly guest_accelerator: Google_compute_instance_from_template_guest_accelerator_911[]|null;
+  readonly guest_accelerator: Google_compute_instance_from_template_guest_accelerator_55[]|null;
   readonly instance_id: string|null;
   readonly label_fingerprint: string|null;
   readonly labels: {[s: string]: string}|null;
@@ -4950,12 +4950,12 @@ export class Google_compute_instance_from_template implements PcoreValue {
   readonly metadata_fingerprint: string|null;
   readonly metadata_startup_script: string|null;
   readonly min_cpu_platform: string|null;
-  readonly network_interface: Google_compute_instance_from_template_network_interface_912[]|null;
+  readonly network_interface: Google_compute_instance_from_template_network_interface_56[]|null;
   readonly project: string|null;
-  readonly scheduling: Google_compute_instance_from_template_scheduling_915[]|null;
-  readonly scratch_disk: Google_compute_instance_from_template_scratch_disk_916[]|null;
+  readonly scheduling: Google_compute_instance_from_template_scheduling_59[]|null;
+  readonly scratch_disk: Google_compute_instance_from_template_scratch_disk_60[]|null;
   readonly self_link: string|null;
-  readonly service_account: Google_compute_instance_from_template_service_account_917[]|null;
+  readonly service_account: Google_compute_instance_from_template_service_account_61[]|null;
   readonly tags: string[]|null;
   readonly tags_fingerprint: string|null;
   readonly zone: string|null;
@@ -4994,13 +4994,13 @@ export class Google_compute_instance_from_template implements PcoreValue {
     source_instance_template: string,
     google_compute_instance_from_template_id?: string|null,
     allow_stopping_for_update?: boolean|null,
-    attached_disk?: Google_compute_instance_from_template_attached_disk_908[]|null,
-    boot_disk?: Google_compute_instance_from_template_boot_disk_909[]|null,
+    attached_disk?: Google_compute_instance_from_template_attached_disk_52[]|null,
+    boot_disk?: Google_compute_instance_from_template_boot_disk_53[]|null,
     can_ip_forward?: boolean|null,
     cpu_platform?: string|null,
     deletion_protection?: boolean|null,
     description?: string|null,
-    guest_accelerator?: Google_compute_instance_from_template_guest_accelerator_911[]|null,
+    guest_accelerator?: Google_compute_instance_from_template_guest_accelerator_55[]|null,
     instance_id?: string|null,
     label_fingerprint?: string|null,
     labels?: {[s: string]: string}|null,
@@ -5009,12 +5009,12 @@ export class Google_compute_instance_from_template implements PcoreValue {
     metadata_fingerprint?: string|null,
     metadata_startup_script?: string|null,
     min_cpu_platform?: string|null,
-    network_interface?: Google_compute_instance_from_template_network_interface_912[]|null,
+    network_interface?: Google_compute_instance_from_template_network_interface_56[]|null,
     project?: string|null,
-    scheduling?: Google_compute_instance_from_template_scheduling_915[]|null,
-    scratch_disk?: Google_compute_instance_from_template_scratch_disk_916[]|null,
+    scheduling?: Google_compute_instance_from_template_scheduling_59[]|null,
+    scratch_disk?: Google_compute_instance_from_template_scratch_disk_60[]|null,
     self_link?: string|null,
-    service_account?: Google_compute_instance_from_template_service_account_917[]|null,
+    service_account?: Google_compute_instance_from_template_service_account_61[]|null,
     tags?: string[]|null,
     tags_fingerprint?: string|null,
     zone?: string|null
@@ -5149,7 +5149,7 @@ export class Google_compute_instance_from_templateHandler implements PcoreValue 
   }
 }
 
-export class Google_compute_instance_from_template_attached_disk_908 implements PcoreValue {
+export class Google_compute_instance_from_template_attached_disk_52 implements PcoreValue {
   readonly source: string;
   readonly device_name: string|null;
   readonly disk_encryption_key_raw: string|null;
@@ -5195,16 +5195,16 @@ export class Google_compute_instance_from_template_attached_disk_908 implements 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_attached_disk_908';
+    return 'TerraformGoogle::Google_compute_instance_from_template_attached_disk_52';
   }
 }
 
-export class Google_compute_instance_from_template_boot_disk_909 implements PcoreValue {
+export class Google_compute_instance_from_template_boot_disk_53 implements PcoreValue {
   readonly auto_delete: boolean|null;
   readonly device_name: string|null;
   readonly disk_encryption_key_raw: string|null;
   readonly disk_encryption_key_sha256: string|null;
-  readonly initialize_params: Google_compute_instance_from_template_boot_disk_909_initialize_params_910[]|null;
+  readonly initialize_params: Google_compute_instance_from_template_boot_disk_53_initialize_params_54[]|null;
   readonly source: string|null;
 
   constructor({
@@ -5219,7 +5219,7 @@ export class Google_compute_instance_from_template_boot_disk_909 implements Pcor
     device_name?: string|null,
     disk_encryption_key_raw?: string|null,
     disk_encryption_key_sha256?: string|null,
-    initialize_params?: Google_compute_instance_from_template_boot_disk_909_initialize_params_910[]|null,
+    initialize_params?: Google_compute_instance_from_template_boot_disk_53_initialize_params_54[]|null,
     source?: string|null
   }) {
     this.auto_delete = auto_delete;
@@ -5254,11 +5254,11 @@ export class Google_compute_instance_from_template_boot_disk_909 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_boot_disk_909';
+    return 'TerraformGoogle::Google_compute_instance_from_template_boot_disk_53';
   }
 }
 
-export class Google_compute_instance_from_template_boot_disk_909_initialize_params_910 implements PcoreValue {
+export class Google_compute_instance_from_template_boot_disk_53_initialize_params_54 implements PcoreValue {
   readonly image: string|null;
   readonly size: number|null;
   readonly type: string|null;
@@ -5292,11 +5292,11 @@ export class Google_compute_instance_from_template_boot_disk_909_initialize_para
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_boot_disk_909_initialize_params_910';
+    return 'TerraformGoogle::Google_compute_instance_from_template_boot_disk_53_initialize_params_54';
   }
 }
 
-export class Google_compute_instance_from_template_guest_accelerator_911 implements PcoreValue {
+export class Google_compute_instance_from_template_guest_accelerator_55 implements PcoreValue {
   readonly count: number;
   readonly type: string;
 
@@ -5319,14 +5319,14 @@ export class Google_compute_instance_from_template_guest_accelerator_911 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_guest_accelerator_911';
+    return 'TerraformGoogle::Google_compute_instance_from_template_guest_accelerator_55';
   }
 }
 
-export class Google_compute_instance_from_template_network_interface_912 implements PcoreValue {
-  readonly access_config: Google_compute_instance_from_template_network_interface_912_access_config_913[]|null;
+export class Google_compute_instance_from_template_network_interface_56 implements PcoreValue {
+  readonly access_config: Google_compute_instance_from_template_network_interface_56_access_config_57[]|null;
   readonly address: string|null;
-  readonly alias_ip_range: Google_compute_instance_from_template_network_interface_912_alias_ip_range_914[]|null;
+  readonly alias_ip_range: Google_compute_instance_from_template_network_interface_56_alias_ip_range_58[]|null;
   readonly name: string|null;
   readonly network: string|null;
   readonly network_ip: string|null;
@@ -5343,9 +5343,9 @@ export class Google_compute_instance_from_template_network_interface_912 impleme
     subnetwork = null,
     subnetwork_project = null
   }: {
-    access_config?: Google_compute_instance_from_template_network_interface_912_access_config_913[]|null,
+    access_config?: Google_compute_instance_from_template_network_interface_56_access_config_57[]|null,
     address?: string|null,
-    alias_ip_range?: Google_compute_instance_from_template_network_interface_912_alias_ip_range_914[]|null,
+    alias_ip_range?: Google_compute_instance_from_template_network_interface_56_alias_ip_range_58[]|null,
     name?: string|null,
     network?: string|null,
     network_ip?: string|null,
@@ -5392,11 +5392,11 @@ export class Google_compute_instance_from_template_network_interface_912 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_network_interface_912';
+    return 'TerraformGoogle::Google_compute_instance_from_template_network_interface_56';
   }
 }
 
-export class Google_compute_instance_from_template_network_interface_912_access_config_913 implements PcoreValue {
+export class Google_compute_instance_from_template_network_interface_56_access_config_57 implements PcoreValue {
   readonly assigned_nat_ip: string|null;
   readonly nat_ip: string|null;
   readonly network_tier: string|null;
@@ -5437,11 +5437,11 @@ export class Google_compute_instance_from_template_network_interface_912_access_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_network_interface_912_access_config_913';
+    return 'TerraformGoogle::Google_compute_instance_from_template_network_interface_56_access_config_57';
   }
 }
 
-export class Google_compute_instance_from_template_network_interface_912_alias_ip_range_914 implements PcoreValue {
+export class Google_compute_instance_from_template_network_interface_56_alias_ip_range_58 implements PcoreValue {
   readonly ip_cidr_range: string;
   readonly subnetwork_range_name: string|null;
 
@@ -5466,11 +5466,11 @@ export class Google_compute_instance_from_template_network_interface_912_alias_i
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_network_interface_912_alias_ip_range_914';
+    return 'TerraformGoogle::Google_compute_instance_from_template_network_interface_56_alias_ip_range_58';
   }
 }
 
-export class Google_compute_instance_from_template_scheduling_915 implements PcoreValue {
+export class Google_compute_instance_from_template_scheduling_59 implements PcoreValue {
   readonly automatic_restart: boolean|null;
   readonly on_host_maintenance: string|null;
   readonly preemptible: boolean|null;
@@ -5504,11 +5504,11 @@ export class Google_compute_instance_from_template_scheduling_915 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_scheduling_915';
+    return 'TerraformGoogle::Google_compute_instance_from_template_scheduling_59';
   }
 }
 
-export class Google_compute_instance_from_template_scratch_disk_916 implements PcoreValue {
+export class Google_compute_instance_from_template_scratch_disk_60 implements PcoreValue {
   readonly interface_: string|null;
 
   constructor({
@@ -5528,11 +5528,11 @@ export class Google_compute_instance_from_template_scratch_disk_916 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_scratch_disk_916';
+    return 'TerraformGoogle::Google_compute_instance_from_template_scratch_disk_60';
   }
 }
 
-export class Google_compute_instance_from_template_service_account_917 implements PcoreValue {
+export class Google_compute_instance_from_template_service_account_61 implements PcoreValue {
   readonly scopes: string[];
   readonly email: string|null;
 
@@ -5557,7 +5557,7 @@ export class Google_compute_instance_from_template_service_account_917 implement
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_from_template_service_account_917';
+    return 'TerraformGoogle::Google_compute_instance_from_template_service_account_61';
   }
 }
 
@@ -5566,7 +5566,7 @@ export class Google_compute_instance_group implements PcoreValue {
   readonly google_compute_instance_group_id: string|null;
   readonly description: string|null;
   readonly instances: string[]|null;
-  readonly named_port: Google_compute_instance_group_named_port_918[]|null;
+  readonly named_port: Google_compute_instance_group_named_port_62[]|null;
   readonly network: string|null;
   readonly project: string|null;
   readonly self_link: string|null;
@@ -5589,7 +5589,7 @@ export class Google_compute_instance_group implements PcoreValue {
     google_compute_instance_group_id?: string|null,
     description?: string|null,
     instances?: string[]|null,
-    named_port?: Google_compute_instance_group_named_port_918[]|null,
+    named_port?: Google_compute_instance_group_named_port_62[]|null,
     network?: string|null,
     project?: string|null,
     self_link?: string|null,
@@ -5660,19 +5660,19 @@ export class Google_compute_instance_group_manager implements PcoreValue {
   readonly base_instance_name: string;
   readonly name: string;
   readonly google_compute_instance_group_manager_id: string|null;
-  readonly auto_healing_policies: Google_compute_instance_group_manager_auto_healing_policies_919[]|null;
+  readonly auto_healing_policies: Google_compute_instance_group_manager_auto_healing_policies_63[]|null;
   readonly description: string|null;
   readonly fingerprint: string|null;
   readonly instance_group: string|null;
   readonly instance_template: string|null;
-  readonly named_port: Google_compute_instance_group_manager_named_port_920[]|null;
+  readonly named_port: Google_compute_instance_group_manager_named_port_64[]|null;
   readonly project: string|null;
-  readonly rolling_update_policy: Google_compute_instance_group_manager_rolling_update_policy_921[]|null;
+  readonly rolling_update_policy: Google_compute_instance_group_manager_rolling_update_policy_65[]|null;
   readonly self_link: string|null;
   readonly target_pools: string[]|null;
   readonly target_size: number|null;
   readonly update_strategy: string|null;
-  readonly version: Google_compute_instance_group_manager_version_922[]|null;
+  readonly version: Google_compute_instance_group_manager_version_66[]|null;
   readonly wait_for_instances: boolean|null;
   readonly zone: string|null;
 
@@ -5699,19 +5699,19 @@ export class Google_compute_instance_group_manager implements PcoreValue {
     base_instance_name: string,
     name: string,
     google_compute_instance_group_manager_id?: string|null,
-    auto_healing_policies?: Google_compute_instance_group_manager_auto_healing_policies_919[]|null,
+    auto_healing_policies?: Google_compute_instance_group_manager_auto_healing_policies_63[]|null,
     description?: string|null,
     fingerprint?: string|null,
     instance_group?: string|null,
     instance_template?: string|null,
-    named_port?: Google_compute_instance_group_manager_named_port_920[]|null,
+    named_port?: Google_compute_instance_group_manager_named_port_64[]|null,
     project?: string|null,
-    rolling_update_policy?: Google_compute_instance_group_manager_rolling_update_policy_921[]|null,
+    rolling_update_policy?: Google_compute_instance_group_manager_rolling_update_policy_65[]|null,
     self_link?: string|null,
     target_pools?: string[]|null,
     target_size?: number|null,
     update_strategy?: string|null,
-    version?: Google_compute_instance_group_manager_version_922[]|null,
+    version?: Google_compute_instance_group_manager_version_66[]|null,
     wait_for_instances?: boolean|null,
     zone?: string|null
   }) {
@@ -5805,7 +5805,7 @@ export class Google_compute_instance_group_managerHandler implements PcoreValue 
   }
 }
 
-export class Google_compute_instance_group_manager_auto_healing_policies_919 implements PcoreValue {
+export class Google_compute_instance_group_manager_auto_healing_policies_63 implements PcoreValue {
   readonly health_check: string;
   readonly initial_delay_sec: number;
 
@@ -5828,11 +5828,11 @@ export class Google_compute_instance_group_manager_auto_healing_policies_919 imp
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_group_manager_auto_healing_policies_919';
+    return 'TerraformGoogle::Google_compute_instance_group_manager_auto_healing_policies_63';
   }
 }
 
-export class Google_compute_instance_group_manager_named_port_920 implements PcoreValue {
+export class Google_compute_instance_group_manager_named_port_64 implements PcoreValue {
   readonly name: string;
   readonly port: number;
 
@@ -5855,11 +5855,11 @@ export class Google_compute_instance_group_manager_named_port_920 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_group_manager_named_port_920';
+    return 'TerraformGoogle::Google_compute_instance_group_manager_named_port_64';
   }
 }
 
-export class Google_compute_instance_group_manager_rolling_update_policy_921 implements PcoreValue {
+export class Google_compute_instance_group_manager_rolling_update_policy_65 implements PcoreValue {
   readonly minimal_action: string;
   readonly type: string;
   readonly max_surge_fixed: number|null;
@@ -5917,14 +5917,14 @@ export class Google_compute_instance_group_manager_rolling_update_policy_921 imp
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_group_manager_rolling_update_policy_921';
+    return 'TerraformGoogle::Google_compute_instance_group_manager_rolling_update_policy_65';
   }
 }
 
-export class Google_compute_instance_group_manager_version_922 implements PcoreValue {
+export class Google_compute_instance_group_manager_version_66 implements PcoreValue {
   readonly instance_template: string;
   readonly name: string;
-  readonly target_size: Google_compute_instance_group_manager_version_922_target_size_923[]|null;
+  readonly target_size: Google_compute_instance_group_manager_version_66_target_size_67[]|null;
 
   constructor({
     instance_template,
@@ -5933,7 +5933,7 @@ export class Google_compute_instance_group_manager_version_922 implements PcoreV
   }: {
     instance_template: string,
     name: string,
-    target_size?: Google_compute_instance_group_manager_version_922_target_size_923[]|null
+    target_size?: Google_compute_instance_group_manager_version_66_target_size_67[]|null
   }) {
     this.instance_template = instance_template;
     this.name = name;
@@ -5951,11 +5951,11 @@ export class Google_compute_instance_group_manager_version_922 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_group_manager_version_922';
+    return 'TerraformGoogle::Google_compute_instance_group_manager_version_66';
   }
 }
 
-export class Google_compute_instance_group_manager_version_922_target_size_923 implements PcoreValue {
+export class Google_compute_instance_group_manager_version_66_target_size_67 implements PcoreValue {
   readonly fixed: number|null;
   readonly percent: number|null;
 
@@ -5982,11 +5982,11 @@ export class Google_compute_instance_group_manager_version_922_target_size_923 i
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_group_manager_version_922_target_size_923';
+    return 'TerraformGoogle::Google_compute_instance_group_manager_version_66_target_size_67';
   }
 }
 
-export class Google_compute_instance_group_named_port_918 implements PcoreValue {
+export class Google_compute_instance_group_named_port_62 implements PcoreValue {
   readonly name: string;
   readonly port: number;
 
@@ -6009,11 +6009,11 @@ export class Google_compute_instance_group_named_port_918 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_group_named_port_918';
+    return 'TerraformGoogle::Google_compute_instance_group_named_port_62';
   }
 }
 
-export class Google_compute_instance_guest_accelerator_900 implements PcoreValue {
+export class Google_compute_instance_guest_accelerator_44 implements PcoreValue {
   readonly count: number;
   readonly type: string;
 
@@ -6036,11 +6036,11 @@ export class Google_compute_instance_guest_accelerator_900 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_guest_accelerator_900';
+    return 'TerraformGoogle::Google_compute_instance_guest_accelerator_44';
   }
 }
 
-export class Google_compute_instance_network_901 implements PcoreValue {
+export class Google_compute_instance_network_45 implements PcoreValue {
   readonly source: string;
   readonly address: string|null;
   readonly external_address: string|null;
@@ -6086,14 +6086,14 @@ export class Google_compute_instance_network_901 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_network_901';
+    return 'TerraformGoogle::Google_compute_instance_network_45';
   }
 }
 
-export class Google_compute_instance_network_interface_902 implements PcoreValue {
-  readonly access_config: Google_compute_instance_network_interface_902_access_config_903[]|null;
+export class Google_compute_instance_network_interface_46 implements PcoreValue {
+  readonly access_config: Google_compute_instance_network_interface_46_access_config_47[]|null;
   readonly address: string|null;
-  readonly alias_ip_range: Google_compute_instance_network_interface_902_alias_ip_range_904[]|null;
+  readonly alias_ip_range: Google_compute_instance_network_interface_46_alias_ip_range_48[]|null;
   readonly name: string|null;
   readonly network: string|null;
   readonly network_ip: string|null;
@@ -6110,9 +6110,9 @@ export class Google_compute_instance_network_interface_902 implements PcoreValue
     subnetwork = null,
     subnetwork_project = null
   }: {
-    access_config?: Google_compute_instance_network_interface_902_access_config_903[]|null,
+    access_config?: Google_compute_instance_network_interface_46_access_config_47[]|null,
     address?: string|null,
-    alias_ip_range?: Google_compute_instance_network_interface_902_alias_ip_range_904[]|null,
+    alias_ip_range?: Google_compute_instance_network_interface_46_alias_ip_range_48[]|null,
     name?: string|null,
     network?: string|null,
     network_ip?: string|null,
@@ -6159,11 +6159,11 @@ export class Google_compute_instance_network_interface_902 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_network_interface_902';
+    return 'TerraformGoogle::Google_compute_instance_network_interface_46';
   }
 }
 
-export class Google_compute_instance_network_interface_902_access_config_903 implements PcoreValue {
+export class Google_compute_instance_network_interface_46_access_config_47 implements PcoreValue {
   readonly assigned_nat_ip: string|null;
   readonly nat_ip: string|null;
   readonly network_tier: string|null;
@@ -6204,11 +6204,11 @@ export class Google_compute_instance_network_interface_902_access_config_903 imp
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_network_interface_902_access_config_903';
+    return 'TerraformGoogle::Google_compute_instance_network_interface_46_access_config_47';
   }
 }
 
-export class Google_compute_instance_network_interface_902_alias_ip_range_904 implements PcoreValue {
+export class Google_compute_instance_network_interface_46_alias_ip_range_48 implements PcoreValue {
   readonly ip_cidr_range: string;
   readonly subnetwork_range_name: string|null;
 
@@ -6233,11 +6233,11 @@ export class Google_compute_instance_network_interface_902_alias_ip_range_904 im
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_network_interface_902_alias_ip_range_904';
+    return 'TerraformGoogle::Google_compute_instance_network_interface_46_alias_ip_range_48';
   }
 }
 
-export class Google_compute_instance_scheduling_905 implements PcoreValue {
+export class Google_compute_instance_scheduling_49 implements PcoreValue {
   readonly automatic_restart: boolean|null;
   readonly on_host_maintenance: string|null;
   readonly preemptible: boolean|null;
@@ -6271,11 +6271,11 @@ export class Google_compute_instance_scheduling_905 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_scheduling_905';
+    return 'TerraformGoogle::Google_compute_instance_scheduling_49';
   }
 }
 
-export class Google_compute_instance_scratch_disk_906 implements PcoreValue {
+export class Google_compute_instance_scratch_disk_50 implements PcoreValue {
   readonly interface_: string|null;
 
   constructor({
@@ -6295,11 +6295,11 @@ export class Google_compute_instance_scratch_disk_906 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_scratch_disk_906';
+    return 'TerraformGoogle::Google_compute_instance_scratch_disk_50';
   }
 }
 
-export class Google_compute_instance_service_account_907 implements PcoreValue {
+export class Google_compute_instance_service_account_51 implements PcoreValue {
   readonly scopes: string[];
   readonly email: string|null;
 
@@ -6324,18 +6324,18 @@ export class Google_compute_instance_service_account_907 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_service_account_907';
+    return 'TerraformGoogle::Google_compute_instance_service_account_51';
   }
 }
 
 export class Google_compute_instance_template implements PcoreValue {
-  readonly disk: Google_compute_instance_template_disk_924[];
+  readonly disk: Google_compute_instance_template_disk_68[];
   readonly machine_type: string;
   readonly google_compute_instance_template_id: string|null;
   readonly automatic_restart: boolean|null;
   readonly can_ip_forward: boolean|null;
   readonly description: string|null;
-  readonly guest_accelerator: Google_compute_instance_template_guest_accelerator_926[]|null;
+  readonly guest_accelerator: Google_compute_instance_template_guest_accelerator_70[]|null;
   readonly instance_description: string|null;
   readonly labels: {[s: string]: string}|null;
   readonly metadata: {[s: string]: string}|null;
@@ -6344,13 +6344,13 @@ export class Google_compute_instance_template implements PcoreValue {
   readonly min_cpu_platform: string|null;
   readonly name: string|null;
   readonly name_prefix: string|null;
-  readonly network_interface: Google_compute_instance_template_network_interface_927[]|null;
+  readonly network_interface: Google_compute_instance_template_network_interface_71[]|null;
   readonly on_host_maintenance: string|null;
   readonly project: string|null;
   readonly region: string|null;
-  readonly scheduling: Google_compute_instance_template_scheduling_930[]|null;
+  readonly scheduling: Google_compute_instance_template_scheduling_74[]|null;
   readonly self_link: string|null;
-  readonly service_account: Google_compute_instance_template_service_account_931[]|null;
+  readonly service_account: Google_compute_instance_template_service_account_75[]|null;
   readonly tags: string[]|null;
   readonly tags_fingerprint: string|null;
 
@@ -6380,13 +6380,13 @@ export class Google_compute_instance_template implements PcoreValue {
     tags = null,
     tags_fingerprint = null
   }: {
-    disk: Google_compute_instance_template_disk_924[],
+    disk: Google_compute_instance_template_disk_68[],
     machine_type: string,
     google_compute_instance_template_id?: string|null,
     automatic_restart?: boolean|null,
     can_ip_forward?: boolean|null,
     description?: string|null,
-    guest_accelerator?: Google_compute_instance_template_guest_accelerator_926[]|null,
+    guest_accelerator?: Google_compute_instance_template_guest_accelerator_70[]|null,
     instance_description?: string|null,
     labels?: {[s: string]: string}|null,
     metadata?: {[s: string]: string}|null,
@@ -6395,13 +6395,13 @@ export class Google_compute_instance_template implements PcoreValue {
     min_cpu_platform?: string|null,
     name?: string|null,
     name_prefix?: string|null,
-    network_interface?: Google_compute_instance_template_network_interface_927[]|null,
+    network_interface?: Google_compute_instance_template_network_interface_71[]|null,
     on_host_maintenance?: string|null,
     project?: string|null,
     region?: string|null,
-    scheduling?: Google_compute_instance_template_scheduling_930[]|null,
+    scheduling?: Google_compute_instance_template_scheduling_74[]|null,
     self_link?: string|null,
-    service_account?: Google_compute_instance_template_service_account_931[]|null,
+    service_account?: Google_compute_instance_template_service_account_75[]|null,
     tags?: string[]|null,
     tags_fingerprint?: string|null
   }) {
@@ -6519,11 +6519,11 @@ export class Google_compute_instance_templateHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_instance_template_disk_924 implements PcoreValue {
+export class Google_compute_instance_template_disk_68 implements PcoreValue {
   readonly auto_delete: boolean|null;
   readonly boot: boolean|null;
   readonly device_name: string|null;
-  readonly disk_encryption_key: Google_compute_instance_template_disk_924_disk_encryption_key_925[]|null;
+  readonly disk_encryption_key: Google_compute_instance_template_disk_68_disk_encryption_key_69[]|null;
   readonly disk_name: string|null;
   readonly disk_size_gb: number|null;
   readonly disk_type: string|null;
@@ -6550,7 +6550,7 @@ export class Google_compute_instance_template_disk_924 implements PcoreValue {
     auto_delete?: boolean|null,
     boot?: boolean|null,
     device_name?: string|null,
-    disk_encryption_key?: Google_compute_instance_template_disk_924_disk_encryption_key_925[]|null,
+    disk_encryption_key?: Google_compute_instance_template_disk_68_disk_encryption_key_69[]|null,
     disk_name?: string|null,
     disk_size_gb?: number|null,
     disk_type?: string|null,
@@ -6616,11 +6616,11 @@ export class Google_compute_instance_template_disk_924 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_disk_924';
+    return 'TerraformGoogle::Google_compute_instance_template_disk_68';
   }
 }
 
-export class Google_compute_instance_template_disk_924_disk_encryption_key_925 implements PcoreValue {
+export class Google_compute_instance_template_disk_68_disk_encryption_key_69 implements PcoreValue {
   readonly kms_key_self_link: string|null;
 
   constructor({
@@ -6640,11 +6640,11 @@ export class Google_compute_instance_template_disk_924_disk_encryption_key_925 i
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_disk_924_disk_encryption_key_925';
+    return 'TerraformGoogle::Google_compute_instance_template_disk_68_disk_encryption_key_69';
   }
 }
 
-export class Google_compute_instance_template_guest_accelerator_926 implements PcoreValue {
+export class Google_compute_instance_template_guest_accelerator_70 implements PcoreValue {
   readonly count: number;
   readonly type: string;
 
@@ -6667,14 +6667,14 @@ export class Google_compute_instance_template_guest_accelerator_926 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_guest_accelerator_926';
+    return 'TerraformGoogle::Google_compute_instance_template_guest_accelerator_70';
   }
 }
 
-export class Google_compute_instance_template_network_interface_927 implements PcoreValue {
-  readonly access_config: Google_compute_instance_template_network_interface_927_access_config_928[]|null;
+export class Google_compute_instance_template_network_interface_71 implements PcoreValue {
+  readonly access_config: Google_compute_instance_template_network_interface_71_access_config_72[]|null;
   readonly address: string|null;
-  readonly alias_ip_range: Google_compute_instance_template_network_interface_927_alias_ip_range_929[]|null;
+  readonly alias_ip_range: Google_compute_instance_template_network_interface_71_alias_ip_range_73[]|null;
   readonly network: string|null;
   readonly network_ip: string|null;
   readonly subnetwork: string|null;
@@ -6689,9 +6689,9 @@ export class Google_compute_instance_template_network_interface_927 implements P
     subnetwork = null,
     subnetwork_project = null
   }: {
-    access_config?: Google_compute_instance_template_network_interface_927_access_config_928[]|null,
+    access_config?: Google_compute_instance_template_network_interface_71_access_config_72[]|null,
     address?: string|null,
-    alias_ip_range?: Google_compute_instance_template_network_interface_927_alias_ip_range_929[]|null,
+    alias_ip_range?: Google_compute_instance_template_network_interface_71_alias_ip_range_73[]|null,
     network?: string|null,
     network_ip?: string|null,
     subnetwork?: string|null,
@@ -6733,11 +6733,11 @@ export class Google_compute_instance_template_network_interface_927 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_network_interface_927';
+    return 'TerraformGoogle::Google_compute_instance_template_network_interface_71';
   }
 }
 
-export class Google_compute_instance_template_network_interface_927_access_config_928 implements PcoreValue {
+export class Google_compute_instance_template_network_interface_71_access_config_72 implements PcoreValue {
   readonly assigned_nat_ip: string|null;
   readonly nat_ip: string|null;
   readonly network_tier: string|null;
@@ -6771,11 +6771,11 @@ export class Google_compute_instance_template_network_interface_927_access_confi
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_network_interface_927_access_config_928';
+    return 'TerraformGoogle::Google_compute_instance_template_network_interface_71_access_config_72';
   }
 }
 
-export class Google_compute_instance_template_network_interface_927_alias_ip_range_929 implements PcoreValue {
+export class Google_compute_instance_template_network_interface_71_alias_ip_range_73 implements PcoreValue {
   readonly ip_cidr_range: string;
   readonly subnetwork_range_name: string|null;
 
@@ -6800,11 +6800,11 @@ export class Google_compute_instance_template_network_interface_927_alias_ip_ran
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_network_interface_927_alias_ip_range_929';
+    return 'TerraformGoogle::Google_compute_instance_template_network_interface_71_alias_ip_range_73';
   }
 }
 
-export class Google_compute_instance_template_scheduling_930 implements PcoreValue {
+export class Google_compute_instance_template_scheduling_74 implements PcoreValue {
   readonly automatic_restart: boolean|null;
   readonly on_host_maintenance: string|null;
   readonly preemptible: boolean|null;
@@ -6838,11 +6838,11 @@ export class Google_compute_instance_template_scheduling_930 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_scheduling_930';
+    return 'TerraformGoogle::Google_compute_instance_template_scheduling_74';
   }
 }
 
-export class Google_compute_instance_template_service_account_931 implements PcoreValue {
+export class Google_compute_instance_template_service_account_75 implements PcoreValue {
   readonly scopes: string[];
   readonly email: string|null;
 
@@ -6867,7 +6867,7 @@ export class Google_compute_instance_template_service_account_931 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_instance_template_service_account_931';
+    return 'TerraformGoogle::Google_compute_instance_template_service_account_75';
   }
 }
 
@@ -6881,7 +6881,7 @@ export class Google_compute_interconnect_attachment implements PcoreValue {
   readonly customer_router_ip_address: string|null;
   readonly description: string|null;
   readonly google_reference_id: string|null;
-  readonly private_interconnect_info: Google_compute_interconnect_attachment_private_interconnect_info_932[]|null;
+  readonly private_interconnect_info: Google_compute_interconnect_attachment_private_interconnect_info_76[]|null;
   readonly project: string|null;
   readonly region: string|null;
   readonly self_link: string|null;
@@ -6910,7 +6910,7 @@ export class Google_compute_interconnect_attachment implements PcoreValue {
     customer_router_ip_address?: string|null,
     description?: string|null,
     google_reference_id?: string|null,
-    private_interconnect_info?: Google_compute_interconnect_attachment_private_interconnect_info_932[]|null,
+    private_interconnect_info?: Google_compute_interconnect_attachment_private_interconnect_info_76[]|null,
     project?: string|null,
     region?: string|null,
     self_link?: string|null
@@ -6983,7 +6983,7 @@ export class Google_compute_interconnect_attachmentHandler implements PcoreValue
   }
 }
 
-export class Google_compute_interconnect_attachment_private_interconnect_info_932 implements PcoreValue {
+export class Google_compute_interconnect_attachment_private_interconnect_info_76 implements PcoreValue {
   readonly tag8021q: number|null;
 
   constructor({
@@ -7003,7 +7003,7 @@ export class Google_compute_interconnect_attachment_private_interconnect_info_93
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_interconnect_attachment_private_interconnect_info_932';
+    return 'TerraformGoogle::Google_compute_interconnect_attachment_private_interconnect_info_76';
   }
 }
 
@@ -7263,7 +7263,7 @@ export class Google_compute_project_metadata_itemHandler implements PcoreValue {
 }
 
 export class Google_compute_region_autoscaler implements PcoreValue {
-  readonly autoscaling_policy: Google_compute_region_autoscaler_autoscaling_policy_933[];
+  readonly autoscaling_policy: Google_compute_region_autoscaler_autoscaling_policy_77[];
   readonly name: string;
   readonly target: string;
   readonly google_compute_region_autoscaler_id: string|null;
@@ -7284,7 +7284,7 @@ export class Google_compute_region_autoscaler implements PcoreValue {
     region = null,
     self_link = null
   }: {
-    autoscaling_policy: Google_compute_region_autoscaler_autoscaling_policy_933[],
+    autoscaling_policy: Google_compute_region_autoscaler_autoscaling_policy_77[],
     name: string,
     target: string,
     google_compute_region_autoscaler_id?: string|null,
@@ -7346,13 +7346,13 @@ export class Google_compute_region_autoscalerHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_region_autoscaler_autoscaling_policy_933 implements PcoreValue {
+export class Google_compute_region_autoscaler_autoscaling_policy_77 implements PcoreValue {
   readonly max_replicas: number;
   readonly min_replicas: number;
   readonly cooldown_period: number|null;
-  readonly cpu_utilization: Google_compute_region_autoscaler_autoscaling_policy_933_cpu_utilization_934[]|null;
-  readonly load_balancing_utilization: Google_compute_region_autoscaler_autoscaling_policy_933_load_balancing_utilization_935[]|null;
-  readonly metric: Google_compute_region_autoscaler_autoscaling_policy_933_metric_936[]|null;
+  readonly cpu_utilization: Google_compute_region_autoscaler_autoscaling_policy_77_cpu_utilization_78[]|null;
+  readonly load_balancing_utilization: Google_compute_region_autoscaler_autoscaling_policy_77_load_balancing_utilization_79[]|null;
+  readonly metric: Google_compute_region_autoscaler_autoscaling_policy_77_metric_80[]|null;
 
   constructor({
     max_replicas,
@@ -7365,9 +7365,9 @@ export class Google_compute_region_autoscaler_autoscaling_policy_933 implements 
     max_replicas: number,
     min_replicas: number,
     cooldown_period?: number|null,
-    cpu_utilization?: Google_compute_region_autoscaler_autoscaling_policy_933_cpu_utilization_934[]|null,
-    load_balancing_utilization?: Google_compute_region_autoscaler_autoscaling_policy_933_load_balancing_utilization_935[]|null,
-    metric?: Google_compute_region_autoscaler_autoscaling_policy_933_metric_936[]|null
+    cpu_utilization?: Google_compute_region_autoscaler_autoscaling_policy_77_cpu_utilization_78[]|null,
+    load_balancing_utilization?: Google_compute_region_autoscaler_autoscaling_policy_77_load_balancing_utilization_79[]|null,
+    metric?: Google_compute_region_autoscaler_autoscaling_policy_77_metric_80[]|null
   }) {
     this.max_replicas = max_replicas;
     this.min_replicas = min_replicas;
@@ -7397,11 +7397,11 @@ export class Google_compute_region_autoscaler_autoscaling_policy_933 implements 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_933';
+    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_77';
   }
 }
 
-export class Google_compute_region_autoscaler_autoscaling_policy_933_cpu_utilization_934 implements PcoreValue {
+export class Google_compute_region_autoscaler_autoscaling_policy_77_cpu_utilization_78 implements PcoreValue {
   readonly target: number;
 
   constructor({
@@ -7419,11 +7419,11 @@ export class Google_compute_region_autoscaler_autoscaling_policy_933_cpu_utiliza
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_933_cpu_utilization_934';
+    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_77_cpu_utilization_78';
   }
 }
 
-export class Google_compute_region_autoscaler_autoscaling_policy_933_load_balancing_utilization_935 implements PcoreValue {
+export class Google_compute_region_autoscaler_autoscaling_policy_77_load_balancing_utilization_79 implements PcoreValue {
   readonly target: number;
 
   constructor({
@@ -7441,11 +7441,11 @@ export class Google_compute_region_autoscaler_autoscaling_policy_933_load_balanc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_933_load_balancing_utilization_935';
+    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_77_load_balancing_utilization_79';
   }
 }
 
-export class Google_compute_region_autoscaler_autoscaling_policy_933_metric_936 implements PcoreValue {
+export class Google_compute_region_autoscaler_autoscaling_policy_77_metric_80 implements PcoreValue {
   readonly name: string;
   readonly target: number;
   readonly type: string;
@@ -7473,7 +7473,7 @@ export class Google_compute_region_autoscaler_autoscaling_policy_933_metric_936 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_933_metric_936';
+    return 'TerraformGoogle::Google_compute_region_autoscaler_autoscaling_policy_77_metric_80';
   }
 }
 
@@ -7481,7 +7481,7 @@ export class Google_compute_region_backend_service implements PcoreValue {
   readonly health_checks: string[];
   readonly name: string;
   readonly google_compute_region_backend_service_id: string|null;
-  readonly backend: Google_compute_region_backend_service_backend_937[]|null;
+  readonly backend: Google_compute_region_backend_service_backend_81[]|null;
   readonly connection_draining_timeout_sec: number|null;
   readonly description: string|null;
   readonly fingerprint: string|null;
@@ -7510,7 +7510,7 @@ export class Google_compute_region_backend_service implements PcoreValue {
     health_checks: string[],
     name: string,
     google_compute_region_backend_service_id?: string|null,
-    backend?: Google_compute_region_backend_service_backend_937[]|null,
+    backend?: Google_compute_region_backend_service_backend_81[]|null,
     connection_draining_timeout_sec?: number|null,
     description?: string|null,
     fingerprint?: string|null,
@@ -7591,7 +7591,7 @@ export class Google_compute_region_backend_serviceHandler implements PcoreValue 
   }
 }
 
-export class Google_compute_region_backend_service_backend_937 implements PcoreValue {
+export class Google_compute_region_backend_service_backend_81 implements PcoreValue {
   readonly description: string|null;
   readonly group: string|null;
 
@@ -7618,7 +7618,7 @@ export class Google_compute_region_backend_service_backend_937 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_backend_service_backend_937';
+    return 'TerraformGoogle::Google_compute_region_backend_service_backend_81';
   }
 }
 
@@ -7628,7 +7628,7 @@ export class Google_compute_region_disk implements PcoreValue {
   readonly google_compute_region_disk_id: string|null;
   readonly creation_timestamp: string|null;
   readonly description: string|null;
-  readonly disk_encryption_key: Google_compute_region_disk_disk_encryption_key_938[]|null;
+  readonly disk_encryption_key: Google_compute_region_disk_disk_encryption_key_82[]|null;
   readonly label_fingerprint: string|null;
   readonly labels: {[s: string]: string}|null;
   readonly last_attach_timestamp: string|null;
@@ -7638,7 +7638,7 @@ export class Google_compute_region_disk implements PcoreValue {
   readonly self_link: string|null;
   readonly size: number|null;
   readonly snapshot: string|null;
-  readonly source_snapshot_encryption_key: Google_compute_region_disk_source_snapshot_encryption_key_939[]|null;
+  readonly source_snapshot_encryption_key: Google_compute_region_disk_source_snapshot_encryption_key_83[]|null;
   readonly source_snapshot_id: string|null;
   readonly type: string|null;
   readonly users: string[]|null;
@@ -7669,7 +7669,7 @@ export class Google_compute_region_disk implements PcoreValue {
     google_compute_region_disk_id?: string|null,
     creation_timestamp?: string|null,
     description?: string|null,
-    disk_encryption_key?: Google_compute_region_disk_disk_encryption_key_938[]|null,
+    disk_encryption_key?: Google_compute_region_disk_disk_encryption_key_82[]|null,
     label_fingerprint?: string|null,
     labels?: {[s: string]: string}|null,
     last_attach_timestamp?: string|null,
@@ -7679,7 +7679,7 @@ export class Google_compute_region_disk implements PcoreValue {
     self_link?: string|null,
     size?: number|null,
     snapshot?: string|null,
-    source_snapshot_encryption_key?: Google_compute_region_disk_source_snapshot_encryption_key_939[]|null,
+    source_snapshot_encryption_key?: Google_compute_region_disk_source_snapshot_encryption_key_83[]|null,
     source_snapshot_id?: string|null,
     type?: string|null,
     users?: string[]|null
@@ -7778,7 +7778,7 @@ export class Google_compute_region_diskHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_region_disk_disk_encryption_key_938 implements PcoreValue {
+export class Google_compute_region_disk_disk_encryption_key_82 implements PcoreValue {
   readonly raw_key: string|null;
   readonly sha256: string|null;
 
@@ -7805,11 +7805,11 @@ export class Google_compute_region_disk_disk_encryption_key_938 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_disk_disk_encryption_key_938';
+    return 'TerraformGoogle::Google_compute_region_disk_disk_encryption_key_82';
   }
 }
 
-export class Google_compute_region_disk_source_snapshot_encryption_key_939 implements PcoreValue {
+export class Google_compute_region_disk_source_snapshot_encryption_key_83 implements PcoreValue {
   readonly raw_key: string|null;
   readonly sha256: string|null;
 
@@ -7836,7 +7836,7 @@ export class Google_compute_region_disk_source_snapshot_encryption_key_939 imple
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_disk_source_snapshot_encryption_key_939';
+    return 'TerraformGoogle::Google_compute_region_disk_source_snapshot_encryption_key_83';
   }
 }
 
@@ -7845,20 +7845,20 @@ export class Google_compute_region_instance_group_manager implements PcoreValue 
   readonly name: string;
   readonly region: string;
   readonly google_compute_region_instance_group_manager_id: string|null;
-  readonly auto_healing_policies: Google_compute_region_instance_group_manager_auto_healing_policies_940[]|null;
+  readonly auto_healing_policies: Google_compute_region_instance_group_manager_auto_healing_policies_84[]|null;
   readonly description: string|null;
   readonly distribution_policy_zones: string[]|null;
   readonly fingerprint: string|null;
   readonly instance_group: string|null;
   readonly instance_template: string|null;
-  readonly named_port: Google_compute_region_instance_group_manager_named_port_941[]|null;
+  readonly named_port: Google_compute_region_instance_group_manager_named_port_85[]|null;
   readonly project: string|null;
-  readonly rolling_update_policy: Google_compute_region_instance_group_manager_rolling_update_policy_942[]|null;
+  readonly rolling_update_policy: Google_compute_region_instance_group_manager_rolling_update_policy_86[]|null;
   readonly self_link: string|null;
   readonly target_pools: string[]|null;
   readonly target_size: number|null;
   readonly update_strategy: string|null;
-  readonly version: Google_compute_region_instance_group_manager_version_943[]|null;
+  readonly version: Google_compute_region_instance_group_manager_version_87[]|null;
   readonly wait_for_instances: boolean|null;
 
   constructor({
@@ -7886,20 +7886,20 @@ export class Google_compute_region_instance_group_manager implements PcoreValue 
     name: string,
     region: string,
     google_compute_region_instance_group_manager_id?: string|null,
-    auto_healing_policies?: Google_compute_region_instance_group_manager_auto_healing_policies_940[]|null,
+    auto_healing_policies?: Google_compute_region_instance_group_manager_auto_healing_policies_84[]|null,
     description?: string|null,
     distribution_policy_zones?: string[]|null,
     fingerprint?: string|null,
     instance_group?: string|null,
     instance_template?: string|null,
-    named_port?: Google_compute_region_instance_group_manager_named_port_941[]|null,
+    named_port?: Google_compute_region_instance_group_manager_named_port_85[]|null,
     project?: string|null,
-    rolling_update_policy?: Google_compute_region_instance_group_manager_rolling_update_policy_942[]|null,
+    rolling_update_policy?: Google_compute_region_instance_group_manager_rolling_update_policy_86[]|null,
     self_link?: string|null,
     target_pools?: string[]|null,
     target_size?: number|null,
     update_strategy?: string|null,
-    version?: Google_compute_region_instance_group_manager_version_943[]|null,
+    version?: Google_compute_region_instance_group_manager_version_87[]|null,
     wait_for_instances?: boolean|null
   }) {
     this.base_instance_name = base_instance_name;
@@ -7994,7 +7994,7 @@ export class Google_compute_region_instance_group_managerHandler implements Pcor
   }
 }
 
-export class Google_compute_region_instance_group_manager_auto_healing_policies_940 implements PcoreValue {
+export class Google_compute_region_instance_group_manager_auto_healing_policies_84 implements PcoreValue {
   readonly health_check: string;
   readonly initial_delay_sec: number;
 
@@ -8017,11 +8017,11 @@ export class Google_compute_region_instance_group_manager_auto_healing_policies_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_instance_group_manager_auto_healing_policies_940';
+    return 'TerraformGoogle::Google_compute_region_instance_group_manager_auto_healing_policies_84';
   }
 }
 
-export class Google_compute_region_instance_group_manager_named_port_941 implements PcoreValue {
+export class Google_compute_region_instance_group_manager_named_port_85 implements PcoreValue {
   readonly name: string;
   readonly port: number;
 
@@ -8044,11 +8044,11 @@ export class Google_compute_region_instance_group_manager_named_port_941 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_instance_group_manager_named_port_941';
+    return 'TerraformGoogle::Google_compute_region_instance_group_manager_named_port_85';
   }
 }
 
-export class Google_compute_region_instance_group_manager_rolling_update_policy_942 implements PcoreValue {
+export class Google_compute_region_instance_group_manager_rolling_update_policy_86 implements PcoreValue {
   readonly minimal_action: string;
   readonly type: string;
   readonly max_surge_fixed: number|null;
@@ -8106,14 +8106,14 @@ export class Google_compute_region_instance_group_manager_rolling_update_policy_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_instance_group_manager_rolling_update_policy_942';
+    return 'TerraformGoogle::Google_compute_region_instance_group_manager_rolling_update_policy_86';
   }
 }
 
-export class Google_compute_region_instance_group_manager_version_943 implements PcoreValue {
+export class Google_compute_region_instance_group_manager_version_87 implements PcoreValue {
   readonly instance_template: string;
   readonly name: string;
-  readonly target_size: Google_compute_region_instance_group_manager_version_943_target_size_944[]|null;
+  readonly target_size: Google_compute_region_instance_group_manager_version_87_target_size_88[]|null;
 
   constructor({
     instance_template,
@@ -8122,7 +8122,7 @@ export class Google_compute_region_instance_group_manager_version_943 implements
   }: {
     instance_template: string,
     name: string,
-    target_size?: Google_compute_region_instance_group_manager_version_943_target_size_944[]|null
+    target_size?: Google_compute_region_instance_group_manager_version_87_target_size_88[]|null
   }) {
     this.instance_template = instance_template;
     this.name = name;
@@ -8140,11 +8140,11 @@ export class Google_compute_region_instance_group_manager_version_943 implements
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_instance_group_manager_version_943';
+    return 'TerraformGoogle::Google_compute_region_instance_group_manager_version_87';
   }
 }
 
-export class Google_compute_region_instance_group_manager_version_943_target_size_944 implements PcoreValue {
+export class Google_compute_region_instance_group_manager_version_87_target_size_88 implements PcoreValue {
   readonly fixed: number|null;
   readonly percent: number|null;
 
@@ -8171,7 +8171,7 @@ export class Google_compute_region_instance_group_manager_version_943_target_siz
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_region_instance_group_manager_version_943_target_size_944';
+    return 'TerraformGoogle::Google_compute_region_instance_group_manager_version_87_target_size_88';
   }
 }
 
@@ -8305,7 +8305,7 @@ export class Google_compute_router implements PcoreValue {
   readonly name: string;
   readonly network: string;
   readonly google_compute_router_id: string|null;
-  readonly bgp: Google_compute_router_bgp_945[]|null;
+  readonly bgp: Google_compute_router_bgp_89[]|null;
   readonly creation_timestamp: string|null;
   readonly description: string|null;
   readonly project: string|null;
@@ -8326,7 +8326,7 @@ export class Google_compute_router implements PcoreValue {
     name: string,
     network: string,
     google_compute_router_id?: string|null,
-    bgp?: Google_compute_router_bgp_945[]|null,
+    bgp?: Google_compute_router_bgp_89[]|null,
     creation_timestamp?: string|null,
     description?: string|null,
     project?: string|null,
@@ -8387,11 +8387,11 @@ export class Google_compute_routerHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_router_bgp_945 implements PcoreValue {
+export class Google_compute_router_bgp_89 implements PcoreValue {
   readonly asn: number;
   readonly advertise_mode: string|null;
   readonly advertised_groups: string[]|null;
-  readonly advertised_ip_ranges: Google_compute_router_bgp_945_advertised_ip_ranges_946[]|null;
+  readonly advertised_ip_ranges: Google_compute_router_bgp_89_advertised_ip_ranges_90[]|null;
 
   constructor({
     asn,
@@ -8402,7 +8402,7 @@ export class Google_compute_router_bgp_945 implements PcoreValue {
     asn: number,
     advertise_mode?: string|null,
     advertised_groups?: string[]|null,
-    advertised_ip_ranges?: Google_compute_router_bgp_945_advertised_ip_ranges_946[]|null
+    advertised_ip_ranges?: Google_compute_router_bgp_89_advertised_ip_ranges_90[]|null
   }) {
     this.asn = asn;
     this.advertise_mode = advertise_mode;
@@ -8426,11 +8426,11 @@ export class Google_compute_router_bgp_945 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_router_bgp_945';
+    return 'TerraformGoogle::Google_compute_router_bgp_89';
   }
 }
 
-export class Google_compute_router_bgp_945_advertised_ip_ranges_946 implements PcoreValue {
+export class Google_compute_router_bgp_89_advertised_ip_ranges_90 implements PcoreValue {
   readonly description: string|null;
   readonly range: string|null;
 
@@ -8457,7 +8457,7 @@ export class Google_compute_router_bgp_945_advertised_ip_ranges_946 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_router_bgp_945_advertised_ip_ranges_946';
+    return 'TerraformGoogle::Google_compute_router_bgp_89_advertised_ip_ranges_90';
   }
 }
 
@@ -8542,7 +8542,7 @@ export class Google_compute_router_nat implements PcoreValue {
   readonly project: string|null;
   readonly region: string|null;
   readonly source_subnetwork_ip_ranges_to_nat: string|null;
-  readonly subnetwork: Google_compute_router_nat_subnetwork_947[]|null;
+  readonly subnetwork: Google_compute_router_nat_subnetwork_91[]|null;
   readonly tcp_established_idle_timeout_sec: number|null;
   readonly tcp_transitory_idle_timeout_sec: number|null;
   readonly udp_idle_timeout_sec: number|null;
@@ -8573,7 +8573,7 @@ export class Google_compute_router_nat implements PcoreValue {
     project?: string|null,
     region?: string|null,
     source_subnetwork_ip_ranges_to_nat?: string|null,
-    subnetwork?: Google_compute_router_nat_subnetwork_947[]|null,
+    subnetwork?: Google_compute_router_nat_subnetwork_91[]|null,
     tcp_established_idle_timeout_sec?: number|null,
     tcp_transitory_idle_timeout_sec?: number|null,
     udp_idle_timeout_sec?: number|null
@@ -8650,7 +8650,7 @@ export class Google_compute_router_natHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_router_nat_subnetwork_947 implements PcoreValue {
+export class Google_compute_router_nat_subnetwork_91 implements PcoreValue {
   readonly name: string;
   readonly secondary_ip_range_names: string[]|null;
   readonly source_ip_ranges_to_nat: string[]|null;
@@ -8682,7 +8682,7 @@ export class Google_compute_router_nat_subnetwork_947 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_router_nat_subnetwork_947';
+    return 'TerraformGoogle::Google_compute_router_nat_subnetwork_91';
   }
 }
 
@@ -8781,7 +8781,7 @@ export class Google_compute_security_policy implements PcoreValue {
   readonly description: string|null;
   readonly fingerprint: string|null;
   readonly project: string|null;
-  readonly rule: Google_compute_security_policy_rule_948[]|null;
+  readonly rule: Google_compute_security_policy_rule_92[]|null;
   readonly self_link: string|null;
 
   constructor({
@@ -8798,7 +8798,7 @@ export class Google_compute_security_policy implements PcoreValue {
     description?: string|null,
     fingerprint?: string|null,
     project?: string|null,
-    rule?: Google_compute_security_policy_rule_948[]|null,
+    rule?: Google_compute_security_policy_rule_92[]|null,
     self_link?: string|null
   }) {
     this.name = name;
@@ -8849,9 +8849,9 @@ export class Google_compute_security_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_security_policy_rule_948 implements PcoreValue {
+export class Google_compute_security_policy_rule_92 implements PcoreValue {
   readonly action: string;
-  readonly match: Google_compute_security_policy_rule_948_match_949[];
+  readonly match: Google_compute_security_policy_rule_92_match_93[];
   readonly priority: number;
   readonly description: string|null;
   readonly preview: boolean|null;
@@ -8864,7 +8864,7 @@ export class Google_compute_security_policy_rule_948 implements PcoreValue {
     preview = null
   }: {
     action: string,
-    match: Google_compute_security_policy_rule_948_match_949[],
+    match: Google_compute_security_policy_rule_92_match_93[],
     priority: number,
     description?: string|null,
     preview?: boolean|null
@@ -8891,19 +8891,19 @@ export class Google_compute_security_policy_rule_948 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_security_policy_rule_948';
+    return 'TerraformGoogle::Google_compute_security_policy_rule_92';
   }
 }
 
-export class Google_compute_security_policy_rule_948_match_949 implements PcoreValue {
-  readonly config: Google_compute_security_policy_rule_948_match_949_config_950[];
+export class Google_compute_security_policy_rule_92_match_93 implements PcoreValue {
+  readonly config: Google_compute_security_policy_rule_92_match_93_config_94[];
   readonly versioned_expr: string;
 
   constructor({
     config,
     versioned_expr
   }: {
-    config: Google_compute_security_policy_rule_948_match_949_config_950[],
+    config: Google_compute_security_policy_rule_92_match_93_config_94[],
     versioned_expr: string
   }) {
     this.config = config;
@@ -8918,11 +8918,11 @@ export class Google_compute_security_policy_rule_948_match_949 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_security_policy_rule_948_match_949';
+    return 'TerraformGoogle::Google_compute_security_policy_rule_92_match_93';
   }
 }
 
-export class Google_compute_security_policy_rule_948_match_949_config_950 implements PcoreValue {
+export class Google_compute_security_policy_rule_92_match_93_config_94 implements PcoreValue {
   readonly src_ip_ranges: string[];
 
   constructor({
@@ -8940,7 +8940,7 @@ export class Google_compute_security_policy_rule_948_match_949_config_950 implem
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_security_policy_rule_948_match_949_config_950';
+    return 'TerraformGoogle::Google_compute_security_policy_rule_92_match_93_config_94';
   }
 }
 
@@ -9039,11 +9039,11 @@ export class Google_compute_snapshot implements PcoreValue {
   readonly licenses: string[]|null;
   readonly project: string|null;
   readonly self_link: string|null;
-  readonly snapshot_encryption_key: Google_compute_snapshot_snapshot_encryption_key_951[]|null;
+  readonly snapshot_encryption_key: Google_compute_snapshot_snapshot_encryption_key_95[]|null;
   readonly snapshot_encryption_key_raw: string|null;
   readonly snapshot_encryption_key_sha256: string|null;
   readonly snapshot_id: number|null;
-  readonly source_disk_encryption_key: Google_compute_snapshot_source_disk_encryption_key_952[]|null;
+  readonly source_disk_encryption_key: Google_compute_snapshot_source_disk_encryption_key_96[]|null;
   readonly source_disk_encryption_key_raw: string|null;
   readonly source_disk_encryption_key_sha256: string|null;
   readonly source_disk_link: string|null;
@@ -9084,11 +9084,11 @@ export class Google_compute_snapshot implements PcoreValue {
     licenses?: string[]|null,
     project?: string|null,
     self_link?: string|null,
-    snapshot_encryption_key?: Google_compute_snapshot_snapshot_encryption_key_951[]|null,
+    snapshot_encryption_key?: Google_compute_snapshot_snapshot_encryption_key_95[]|null,
     snapshot_encryption_key_raw?: string|null,
     snapshot_encryption_key_sha256?: string|null,
     snapshot_id?: number|null,
-    source_disk_encryption_key?: Google_compute_snapshot_source_disk_encryption_key_952[]|null,
+    source_disk_encryption_key?: Google_compute_snapshot_source_disk_encryption_key_96[]|null,
     source_disk_encryption_key_raw?: string|null,
     source_disk_encryption_key_sha256?: string|null,
     source_disk_link?: string|null,
@@ -9197,7 +9197,7 @@ export class Google_compute_snapshotHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_snapshot_snapshot_encryption_key_951 implements PcoreValue {
+export class Google_compute_snapshot_snapshot_encryption_key_95 implements PcoreValue {
   readonly raw_key: string|null;
   readonly sha256: string|null;
 
@@ -9224,11 +9224,11 @@ export class Google_compute_snapshot_snapshot_encryption_key_951 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_snapshot_snapshot_encryption_key_951';
+    return 'TerraformGoogle::Google_compute_snapshot_snapshot_encryption_key_95';
   }
 }
 
-export class Google_compute_snapshot_source_disk_encryption_key_952 implements PcoreValue {
+export class Google_compute_snapshot_source_disk_encryption_key_96 implements PcoreValue {
   readonly raw_key: string|null;
 
   constructor({
@@ -9248,7 +9248,7 @@ export class Google_compute_snapshot_source_disk_encryption_key_952 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_snapshot_source_disk_encryption_key_952';
+    return 'TerraformGoogle::Google_compute_snapshot_source_disk_encryption_key_96';
   }
 }
 
@@ -9460,7 +9460,7 @@ export class Google_compute_subnetwork implements PcoreValue {
   readonly private_ip_google_access: boolean|null;
   readonly project: string|null;
   readonly region: string|null;
-  readonly secondary_ip_range: Google_compute_subnetwork_secondary_ip_range_953[]|null;
+  readonly secondary_ip_range: Google_compute_subnetwork_secondary_ip_range_97[]|null;
   readonly self_link: string|null;
 
   constructor({
@@ -9491,7 +9491,7 @@ export class Google_compute_subnetwork implements PcoreValue {
     private_ip_google_access?: boolean|null,
     project?: string|null,
     region?: string|null,
-    secondary_ip_range?: Google_compute_subnetwork_secondary_ip_range_953[]|null,
+    secondary_ip_range?: Google_compute_subnetwork_secondary_ip_range_97[]|null,
     self_link?: string|null
   }) {
     this.ip_cidr_range = ip_cidr_range;
@@ -9771,7 +9771,7 @@ export class Google_compute_subnetwork_iam_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_subnetwork_secondary_ip_range_953 implements PcoreValue {
+export class Google_compute_subnetwork_secondary_ip_range_97 implements PcoreValue {
   readonly ip_cidr_range: string;
   readonly range_name: string;
 
@@ -9794,7 +9794,7 @@ export class Google_compute_subnetwork_secondary_ip_range_953 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_subnetwork_secondary_ip_range_953';
+    return 'TerraformGoogle::Google_compute_subnetwork_secondary_ip_range_97';
   }
 }
 
@@ -10267,12 +10267,12 @@ export class Google_compute_url_map implements PcoreValue {
   readonly google_compute_url_map_id: string|null;
   readonly description: string|null;
   readonly fingerprint: string|null;
-  readonly host_rule: Google_compute_url_map_host_rule_954[]|null;
+  readonly host_rule: Google_compute_url_map_host_rule_98[]|null;
   readonly map_id: string|null;
-  readonly path_matcher: Google_compute_url_map_path_matcher_955[]|null;
+  readonly path_matcher: Google_compute_url_map_path_matcher_99[]|null;
   readonly project: string|null;
   readonly self_link: string|null;
-  readonly test: Google_compute_url_map_test_957[]|null;
+  readonly test: Google_compute_url_map_test_101[]|null;
 
   constructor({
     default_service,
@@ -10292,12 +10292,12 @@ export class Google_compute_url_map implements PcoreValue {
     google_compute_url_map_id?: string|null,
     description?: string|null,
     fingerprint?: string|null,
-    host_rule?: Google_compute_url_map_host_rule_954[]|null,
+    host_rule?: Google_compute_url_map_host_rule_98[]|null,
     map_id?: string|null,
-    path_matcher?: Google_compute_url_map_path_matcher_955[]|null,
+    path_matcher?: Google_compute_url_map_path_matcher_99[]|null,
     project?: string|null,
     self_link?: string|null,
-    test?: Google_compute_url_map_test_957[]|null
+    test?: Google_compute_url_map_test_101[]|null
   }) {
     this.default_service = default_service;
     this.name = name;
@@ -10361,7 +10361,7 @@ export class Google_compute_url_mapHandler implements PcoreValue {
   }
 }
 
-export class Google_compute_url_map_host_rule_954 implements PcoreValue {
+export class Google_compute_url_map_host_rule_98 implements PcoreValue {
   readonly hosts: string[];
   readonly path_matcher: string;
   readonly description: string|null;
@@ -10391,15 +10391,15 @@ export class Google_compute_url_map_host_rule_954 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_url_map_host_rule_954';
+    return 'TerraformGoogle::Google_compute_url_map_host_rule_98';
   }
 }
 
-export class Google_compute_url_map_path_matcher_955 implements PcoreValue {
+export class Google_compute_url_map_path_matcher_99 implements PcoreValue {
   readonly default_service: string;
   readonly name: string;
   readonly description: string|null;
-  readonly path_rule: Google_compute_url_map_path_matcher_955_path_rule_956[]|null;
+  readonly path_rule: Google_compute_url_map_path_matcher_99_path_rule_100[]|null;
 
   constructor({
     default_service,
@@ -10410,7 +10410,7 @@ export class Google_compute_url_map_path_matcher_955 implements PcoreValue {
     default_service: string,
     name: string,
     description?: string|null,
-    path_rule?: Google_compute_url_map_path_matcher_955_path_rule_956[]|null
+    path_rule?: Google_compute_url_map_path_matcher_99_path_rule_100[]|null
   }) {
     this.default_service = default_service;
     this.name = name;
@@ -10432,11 +10432,11 @@ export class Google_compute_url_map_path_matcher_955 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_url_map_path_matcher_955';
+    return 'TerraformGoogle::Google_compute_url_map_path_matcher_99';
   }
 }
 
-export class Google_compute_url_map_path_matcher_955_path_rule_956 implements PcoreValue {
+export class Google_compute_url_map_path_matcher_99_path_rule_100 implements PcoreValue {
   readonly paths: string[];
   readonly service: string;
 
@@ -10459,11 +10459,11 @@ export class Google_compute_url_map_path_matcher_955_path_rule_956 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_url_map_path_matcher_955_path_rule_956';
+    return 'TerraformGoogle::Google_compute_url_map_path_matcher_99_path_rule_100';
   }
 }
 
-export class Google_compute_url_map_test_957 implements PcoreValue {
+export class Google_compute_url_map_test_101 implements PcoreValue {
   readonly host: string;
   readonly path: string;
   readonly service: string;
@@ -10498,7 +10498,7 @@ export class Google_compute_url_map_test_957 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_compute_url_map_test_957';
+    return 'TerraformGoogle::Google_compute_url_map_test_101';
   }
 }
 
@@ -10727,7 +10727,7 @@ export class Google_compute_vpn_tunnelHandler implements PcoreValue {
 }
 
 export class Google_container_analysis_note implements PcoreValue {
-  readonly attestation_authority: Google_container_analysis_note_attestation_authority_958[];
+  readonly attestation_authority: Google_container_analysis_note_attestation_authority_102[];
   readonly name: string;
   readonly google_container_analysis_note_id: string|null;
   readonly project: string|null;
@@ -10738,7 +10738,7 @@ export class Google_container_analysis_note implements PcoreValue {
     google_container_analysis_note_id = null,
     project = null
   }: {
-    attestation_authority: Google_container_analysis_note_attestation_authority_958[],
+    attestation_authority: Google_container_analysis_note_attestation_authority_102[],
     name: string,
     google_container_analysis_note_id?: string|null,
     project?: string|null
@@ -10777,13 +10777,13 @@ export class Google_container_analysis_noteHandler implements PcoreValue {
   }
 }
 
-export class Google_container_analysis_note_attestation_authority_958 implements PcoreValue {
-  readonly hint: Google_container_analysis_note_attestation_authority_958_hint_959[];
+export class Google_container_analysis_note_attestation_authority_102 implements PcoreValue {
+  readonly hint: Google_container_analysis_note_attestation_authority_102_hint_103[];
 
   constructor({
     hint
   }: {
-    hint: Google_container_analysis_note_attestation_authority_958_hint_959[]
+    hint: Google_container_analysis_note_attestation_authority_102_hint_103[]
   }) {
     this.hint = hint;
   }
@@ -10795,11 +10795,11 @@ export class Google_container_analysis_note_attestation_authority_958 implements
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_analysis_note_attestation_authority_958';
+    return 'TerraformGoogle::Google_container_analysis_note_attestation_authority_102';
   }
 }
 
-export class Google_container_analysis_note_attestation_authority_958_hint_959 implements PcoreValue {
+export class Google_container_analysis_note_attestation_authority_102_hint_103 implements PcoreValue {
   readonly human_readable_name: string;
 
   constructor({
@@ -10817,7 +10817,7 @@ export class Google_container_analysis_note_attestation_authority_958_hint_959 i
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_analysis_note_attestation_authority_958_hint_959';
+    return 'TerraformGoogle::Google_container_analysis_note_attestation_authority_102_hint_103';
   }
 }
 
@@ -10825,8 +10825,8 @@ export class Google_container_cluster implements PcoreValue {
   readonly name: string;
   readonly google_container_cluster_id: string|null;
   readonly additional_zones: string[]|null;
-  readonly addons_config: Google_container_cluster_addons_config_960[]|null;
-  readonly cluster_autoscaling: Google_container_cluster_cluster_autoscaling_965[]|null;
+  readonly addons_config: Google_container_cluster_addons_config_104[]|null;
+  readonly cluster_autoscaling: Google_container_cluster_cluster_autoscaling_109[]|null;
   readonly cluster_ipv4_cidr: string|null;
   readonly description: string|null;
   readonly enable_binary_authorization: boolean|null;
@@ -10836,23 +10836,23 @@ export class Google_container_cluster implements PcoreValue {
   readonly endpoint: string|null;
   readonly initial_node_count: number|null;
   readonly instance_group_urls: string[]|null;
-  readonly ip_allocation_policy: Google_container_cluster_ip_allocation_policy_967[]|null;
+  readonly ip_allocation_policy: Google_container_cluster_ip_allocation_policy_111[]|null;
   readonly logging_service: string|null;
-  readonly maintenance_policy: Google_container_cluster_maintenance_policy_968[]|null;
-  readonly master_auth: Google_container_cluster_master_auth_970[]|null;
-  readonly master_authorized_networks_config: Google_container_cluster_master_authorized_networks_config_972[]|null;
+  readonly maintenance_policy: Google_container_cluster_maintenance_policy_112[]|null;
+  readonly master_auth: Google_container_cluster_master_auth_114[]|null;
+  readonly master_authorized_networks_config: Google_container_cluster_master_authorized_networks_config_116[]|null;
   readonly master_ipv4_cidr_block: string|null;
   readonly master_version: string|null;
   readonly min_master_version: string|null;
   readonly monitoring_service: string|null;
   readonly network: string|null;
-  readonly network_policy: Google_container_cluster_network_policy_974[]|null;
-  readonly node_config: Google_container_cluster_node_config_975[]|null;
-  readonly node_pool: Google_container_cluster_node_pool_979[]|null;
+  readonly network_policy: Google_container_cluster_network_policy_118[]|null;
+  readonly node_config: Google_container_cluster_node_config_119[]|null;
+  readonly node_pool: Google_container_cluster_node_pool_123[]|null;
   readonly node_version: string|null;
-  readonly pod_security_policy_config: Google_container_cluster_pod_security_policy_config_986[]|null;
+  readonly pod_security_policy_config: Google_container_cluster_pod_security_policy_config_130[]|null;
   readonly private_cluster: boolean|null;
-  readonly private_cluster_config: Google_container_cluster_private_cluster_config_987[]|null;
+  readonly private_cluster_config: Google_container_cluster_private_cluster_config_131[]|null;
   readonly project: string|null;
   readonly region: string|null;
   readonly remove_default_node_pool: boolean|null;
@@ -10902,8 +10902,8 @@ export class Google_container_cluster implements PcoreValue {
     name: string,
     google_container_cluster_id?: string|null,
     additional_zones?: string[]|null,
-    addons_config?: Google_container_cluster_addons_config_960[]|null,
-    cluster_autoscaling?: Google_container_cluster_cluster_autoscaling_965[]|null,
+    addons_config?: Google_container_cluster_addons_config_104[]|null,
+    cluster_autoscaling?: Google_container_cluster_cluster_autoscaling_109[]|null,
     cluster_ipv4_cidr?: string|null,
     description?: string|null,
     enable_binary_authorization?: boolean|null,
@@ -10913,23 +10913,23 @@ export class Google_container_cluster implements PcoreValue {
     endpoint?: string|null,
     initial_node_count?: number|null,
     instance_group_urls?: string[]|null,
-    ip_allocation_policy?: Google_container_cluster_ip_allocation_policy_967[]|null,
+    ip_allocation_policy?: Google_container_cluster_ip_allocation_policy_111[]|null,
     logging_service?: string|null,
-    maintenance_policy?: Google_container_cluster_maintenance_policy_968[]|null,
-    master_auth?: Google_container_cluster_master_auth_970[]|null,
-    master_authorized_networks_config?: Google_container_cluster_master_authorized_networks_config_972[]|null,
+    maintenance_policy?: Google_container_cluster_maintenance_policy_112[]|null,
+    master_auth?: Google_container_cluster_master_auth_114[]|null,
+    master_authorized_networks_config?: Google_container_cluster_master_authorized_networks_config_116[]|null,
     master_ipv4_cidr_block?: string|null,
     master_version?: string|null,
     min_master_version?: string|null,
     monitoring_service?: string|null,
     network?: string|null,
-    network_policy?: Google_container_cluster_network_policy_974[]|null,
-    node_config?: Google_container_cluster_node_config_975[]|null,
-    node_pool?: Google_container_cluster_node_pool_979[]|null,
+    network_policy?: Google_container_cluster_network_policy_118[]|null,
+    node_config?: Google_container_cluster_node_config_119[]|null,
+    node_pool?: Google_container_cluster_node_pool_123[]|null,
     node_version?: string|null,
-    pod_security_policy_config?: Google_container_cluster_pod_security_policy_config_986[]|null,
+    pod_security_policy_config?: Google_container_cluster_pod_security_policy_config_130[]|null,
     private_cluster?: boolean|null,
-    private_cluster_config?: Google_container_cluster_private_cluster_config_987[]|null,
+    private_cluster_config?: Google_container_cluster_private_cluster_config_131[]|null,
     project?: string|null,
     region?: string|null,
     remove_default_node_pool?: boolean|null,
@@ -11105,11 +11105,11 @@ export class Google_container_clusterHandler implements PcoreValue {
   }
 }
 
-export class Google_container_cluster_addons_config_960 implements PcoreValue {
-  readonly horizontal_pod_autoscaling: Google_container_cluster_addons_config_960_horizontal_pod_autoscaling_961[]|null;
-  readonly http_load_balancing: Google_container_cluster_addons_config_960_http_load_balancing_962[]|null;
-  readonly kubernetes_dashboard: Google_container_cluster_addons_config_960_kubernetes_dashboard_963[]|null;
-  readonly network_policy_config: Google_container_cluster_addons_config_960_network_policy_config_964[]|null;
+export class Google_container_cluster_addons_config_104 implements PcoreValue {
+  readonly horizontal_pod_autoscaling: Google_container_cluster_addons_config_104_horizontal_pod_autoscaling_105[]|null;
+  readonly http_load_balancing: Google_container_cluster_addons_config_104_http_load_balancing_106[]|null;
+  readonly kubernetes_dashboard: Google_container_cluster_addons_config_104_kubernetes_dashboard_107[]|null;
+  readonly network_policy_config: Google_container_cluster_addons_config_104_network_policy_config_108[]|null;
 
   constructor({
     horizontal_pod_autoscaling = null,
@@ -11117,10 +11117,10 @@ export class Google_container_cluster_addons_config_960 implements PcoreValue {
     kubernetes_dashboard = null,
     network_policy_config = null
   }: {
-    horizontal_pod_autoscaling?: Google_container_cluster_addons_config_960_horizontal_pod_autoscaling_961[]|null,
-    http_load_balancing?: Google_container_cluster_addons_config_960_http_load_balancing_962[]|null,
-    kubernetes_dashboard?: Google_container_cluster_addons_config_960_kubernetes_dashboard_963[]|null,
-    network_policy_config?: Google_container_cluster_addons_config_960_network_policy_config_964[]|null
+    horizontal_pod_autoscaling?: Google_container_cluster_addons_config_104_horizontal_pod_autoscaling_105[]|null,
+    http_load_balancing?: Google_container_cluster_addons_config_104_http_load_balancing_106[]|null,
+    kubernetes_dashboard?: Google_container_cluster_addons_config_104_kubernetes_dashboard_107[]|null,
+    network_policy_config?: Google_container_cluster_addons_config_104_network_policy_config_108[]|null
   }) {
     this.horizontal_pod_autoscaling = horizontal_pod_autoscaling;
     this.http_load_balancing = http_load_balancing;
@@ -11146,11 +11146,11 @@ export class Google_container_cluster_addons_config_960 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_addons_config_960';
+    return 'TerraformGoogle::Google_container_cluster_addons_config_104';
   }
 }
 
-export class Google_container_cluster_addons_config_960_horizontal_pod_autoscaling_961 implements PcoreValue {
+export class Google_container_cluster_addons_config_104_horizontal_pod_autoscaling_105 implements PcoreValue {
   readonly disabled: boolean|null;
 
   constructor({
@@ -11170,11 +11170,11 @@ export class Google_container_cluster_addons_config_960_horizontal_pod_autoscali
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_addons_config_960_horizontal_pod_autoscaling_961';
+    return 'TerraformGoogle::Google_container_cluster_addons_config_104_horizontal_pod_autoscaling_105';
   }
 }
 
-export class Google_container_cluster_addons_config_960_http_load_balancing_962 implements PcoreValue {
+export class Google_container_cluster_addons_config_104_http_load_balancing_106 implements PcoreValue {
   readonly disabled: boolean|null;
 
   constructor({
@@ -11194,11 +11194,11 @@ export class Google_container_cluster_addons_config_960_http_load_balancing_962 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_addons_config_960_http_load_balancing_962';
+    return 'TerraformGoogle::Google_container_cluster_addons_config_104_http_load_balancing_106';
   }
 }
 
-export class Google_container_cluster_addons_config_960_kubernetes_dashboard_963 implements PcoreValue {
+export class Google_container_cluster_addons_config_104_kubernetes_dashboard_107 implements PcoreValue {
   readonly disabled: boolean|null;
 
   constructor({
@@ -11218,11 +11218,11 @@ export class Google_container_cluster_addons_config_960_kubernetes_dashboard_963
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_addons_config_960_kubernetes_dashboard_963';
+    return 'TerraformGoogle::Google_container_cluster_addons_config_104_kubernetes_dashboard_107';
   }
 }
 
-export class Google_container_cluster_addons_config_960_network_policy_config_964 implements PcoreValue {
+export class Google_container_cluster_addons_config_104_network_policy_config_108 implements PcoreValue {
   readonly disabled: boolean|null;
 
   constructor({
@@ -11242,20 +11242,20 @@ export class Google_container_cluster_addons_config_960_network_policy_config_96
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_addons_config_960_network_policy_config_964';
+    return 'TerraformGoogle::Google_container_cluster_addons_config_104_network_policy_config_108';
   }
 }
 
-export class Google_container_cluster_cluster_autoscaling_965 implements PcoreValue {
+export class Google_container_cluster_cluster_autoscaling_109 implements PcoreValue {
   readonly enabled: boolean;
-  readonly resource_limits: Google_container_cluster_cluster_autoscaling_965_resource_limits_966[]|null;
+  readonly resource_limits: Google_container_cluster_cluster_autoscaling_109_resource_limits_110[]|null;
 
   constructor({
     enabled,
     resource_limits = null
   }: {
     enabled: boolean,
-    resource_limits?: Google_container_cluster_cluster_autoscaling_965_resource_limits_966[]|null
+    resource_limits?: Google_container_cluster_cluster_autoscaling_109_resource_limits_110[]|null
   }) {
     this.enabled = enabled;
     this.resource_limits = resource_limits;
@@ -11271,11 +11271,11 @@ export class Google_container_cluster_cluster_autoscaling_965 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_cluster_autoscaling_965';
+    return 'TerraformGoogle::Google_container_cluster_cluster_autoscaling_109';
   }
 }
 
-export class Google_container_cluster_cluster_autoscaling_965_resource_limits_966 implements PcoreValue {
+export class Google_container_cluster_cluster_autoscaling_109_resource_limits_110 implements PcoreValue {
   readonly resource_type: string;
   readonly maximum: number|null;
   readonly minimum: number|null;
@@ -11307,11 +11307,11 @@ export class Google_container_cluster_cluster_autoscaling_965_resource_limits_96
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_cluster_autoscaling_965_resource_limits_966';
+    return 'TerraformGoogle::Google_container_cluster_cluster_autoscaling_109_resource_limits_110';
   }
 }
 
-export class Google_container_cluster_ip_allocation_policy_967 implements PcoreValue {
+export class Google_container_cluster_ip_allocation_policy_111 implements PcoreValue {
   readonly cluster_ipv4_cidr_block: string|null;
   readonly cluster_secondary_range_name: string|null;
   readonly create_subnetwork: boolean|null;
@@ -11366,17 +11366,17 @@ export class Google_container_cluster_ip_allocation_policy_967 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_ip_allocation_policy_967';
+    return 'TerraformGoogle::Google_container_cluster_ip_allocation_policy_111';
   }
 }
 
-export class Google_container_cluster_maintenance_policy_968 implements PcoreValue {
-  readonly daily_maintenance_window: Google_container_cluster_maintenance_policy_968_daily_maintenance_window_969[];
+export class Google_container_cluster_maintenance_policy_112 implements PcoreValue {
+  readonly daily_maintenance_window: Google_container_cluster_maintenance_policy_112_daily_maintenance_window_113[];
 
   constructor({
     daily_maintenance_window
   }: {
-    daily_maintenance_window: Google_container_cluster_maintenance_policy_968_daily_maintenance_window_969[]
+    daily_maintenance_window: Google_container_cluster_maintenance_policy_112_daily_maintenance_window_113[]
   }) {
     this.daily_maintenance_window = daily_maintenance_window;
   }
@@ -11388,11 +11388,11 @@ export class Google_container_cluster_maintenance_policy_968 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_maintenance_policy_968';
+    return 'TerraformGoogle::Google_container_cluster_maintenance_policy_112';
   }
 }
 
-export class Google_container_cluster_maintenance_policy_968_daily_maintenance_window_969 implements PcoreValue {
+export class Google_container_cluster_maintenance_policy_112_daily_maintenance_window_113 implements PcoreValue {
   readonly start_time: string;
   readonly duration: string|null;
 
@@ -11417,15 +11417,15 @@ export class Google_container_cluster_maintenance_policy_968_daily_maintenance_w
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_maintenance_policy_968_daily_maintenance_window_969';
+    return 'TerraformGoogle::Google_container_cluster_maintenance_policy_112_daily_maintenance_window_113';
   }
 }
 
-export class Google_container_cluster_master_auth_970 implements PcoreValue {
+export class Google_container_cluster_master_auth_114 implements PcoreValue {
   readonly password: string;
   readonly username: string;
   readonly client_certificate: string|null;
-  readonly client_certificate_config: Google_container_cluster_master_auth_970_client_certificate_config_971[]|null;
+  readonly client_certificate_config: Google_container_cluster_master_auth_114_client_certificate_config_115[]|null;
   readonly client_key: string|null;
   readonly cluster_ca_certificate: string|null;
 
@@ -11440,7 +11440,7 @@ export class Google_container_cluster_master_auth_970 implements PcoreValue {
     password: string,
     username: string,
     client_certificate?: string|null,
-    client_certificate_config?: Google_container_cluster_master_auth_970_client_certificate_config_971[]|null,
+    client_certificate_config?: Google_container_cluster_master_auth_114_client_certificate_config_115[]|null,
     client_key?: string|null,
     cluster_ca_certificate?: string|null
   }) {
@@ -11472,11 +11472,11 @@ export class Google_container_cluster_master_auth_970 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_master_auth_970';
+    return 'TerraformGoogle::Google_container_cluster_master_auth_114';
   }
 }
 
-export class Google_container_cluster_master_auth_970_client_certificate_config_971 implements PcoreValue {
+export class Google_container_cluster_master_auth_114_client_certificate_config_115 implements PcoreValue {
   readonly issue_client_certificate: boolean;
 
   constructor({
@@ -11494,17 +11494,17 @@ export class Google_container_cluster_master_auth_970_client_certificate_config_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_master_auth_970_client_certificate_config_971';
+    return 'TerraformGoogle::Google_container_cluster_master_auth_114_client_certificate_config_115';
   }
 }
 
-export class Google_container_cluster_master_authorized_networks_config_972 implements PcoreValue {
-  readonly cidr_blocks: Google_container_cluster_master_authorized_networks_config_972_cidr_blocks_973[]|null;
+export class Google_container_cluster_master_authorized_networks_config_116 implements PcoreValue {
+  readonly cidr_blocks: Google_container_cluster_master_authorized_networks_config_116_cidr_blocks_117[]|null;
 
   constructor({
     cidr_blocks = null
   }: {
-    cidr_blocks?: Google_container_cluster_master_authorized_networks_config_972_cidr_blocks_973[]|null
+    cidr_blocks?: Google_container_cluster_master_authorized_networks_config_116_cidr_blocks_117[]|null
   }) {
     this.cidr_blocks = cidr_blocks;
   }
@@ -11518,11 +11518,11 @@ export class Google_container_cluster_master_authorized_networks_config_972 impl
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_master_authorized_networks_config_972';
+    return 'TerraformGoogle::Google_container_cluster_master_authorized_networks_config_116';
   }
 }
 
-export class Google_container_cluster_master_authorized_networks_config_972_cidr_blocks_973 implements PcoreValue {
+export class Google_container_cluster_master_authorized_networks_config_116_cidr_blocks_117 implements PcoreValue {
   readonly cidr_block: string;
   readonly display_name: string|null;
 
@@ -11547,11 +11547,11 @@ export class Google_container_cluster_master_authorized_networks_config_972_cidr
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_master_authorized_networks_config_972_cidr_blocks_973';
+    return 'TerraformGoogle::Google_container_cluster_master_authorized_networks_config_116_cidr_blocks_117';
   }
 }
 
-export class Google_container_cluster_network_policy_974 implements PcoreValue {
+export class Google_container_cluster_network_policy_118 implements PcoreValue {
   readonly enabled: boolean|null;
   readonly provider: string|null;
 
@@ -11578,14 +11578,14 @@ export class Google_container_cluster_network_policy_974 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_network_policy_974';
+    return 'TerraformGoogle::Google_container_cluster_network_policy_118';
   }
 }
 
-export class Google_container_cluster_node_config_975 implements PcoreValue {
+export class Google_container_cluster_node_config_119 implements PcoreValue {
   readonly disk_size_gb: number|null;
   readonly disk_type: string|null;
-  readonly guest_accelerator: Google_container_cluster_node_config_975_guest_accelerator_976[]|null;
+  readonly guest_accelerator: Google_container_cluster_node_config_119_guest_accelerator_120[]|null;
   readonly image_type: string|null;
   readonly labels: {[s: string]: string}|null;
   readonly local_ssd_count: number|null;
@@ -11596,8 +11596,8 @@ export class Google_container_cluster_node_config_975 implements PcoreValue {
   readonly preemptible: boolean|null;
   readonly service_account: string|null;
   readonly tags: string[]|null;
-  readonly taint: Google_container_cluster_node_config_975_taint_977[]|null;
-  readonly workload_metadata_config: Google_container_cluster_node_config_975_workload_metadata_config_978[]|null;
+  readonly taint: Google_container_cluster_node_config_119_taint_121[]|null;
+  readonly workload_metadata_config: Google_container_cluster_node_config_119_workload_metadata_config_122[]|null;
 
   constructor({
     disk_size_gb = null,
@@ -11618,7 +11618,7 @@ export class Google_container_cluster_node_config_975 implements PcoreValue {
   }: {
     disk_size_gb?: number|null,
     disk_type?: string|null,
-    guest_accelerator?: Google_container_cluster_node_config_975_guest_accelerator_976[]|null,
+    guest_accelerator?: Google_container_cluster_node_config_119_guest_accelerator_120[]|null,
     image_type?: string|null,
     labels?: {[s: string]: string}|null,
     local_ssd_count?: number|null,
@@ -11629,8 +11629,8 @@ export class Google_container_cluster_node_config_975 implements PcoreValue {
     preemptible?: boolean|null,
     service_account?: string|null,
     tags?: string[]|null,
-    taint?: Google_container_cluster_node_config_975_taint_977[]|null,
-    workload_metadata_config?: Google_container_cluster_node_config_975_workload_metadata_config_978[]|null
+    taint?: Google_container_cluster_node_config_119_taint_121[]|null,
+    workload_metadata_config?: Google_container_cluster_node_config_119_workload_metadata_config_122[]|null
   }) {
     this.disk_size_gb = disk_size_gb;
     this.disk_type = disk_type;
@@ -11700,11 +11700,11 @@ export class Google_container_cluster_node_config_975 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_config_975';
+    return 'TerraformGoogle::Google_container_cluster_node_config_119';
   }
 }
 
-export class Google_container_cluster_node_config_975_guest_accelerator_976 implements PcoreValue {
+export class Google_container_cluster_node_config_119_guest_accelerator_120 implements PcoreValue {
   readonly count: number;
   readonly type: string;
 
@@ -11727,11 +11727,11 @@ export class Google_container_cluster_node_config_975_guest_accelerator_976 impl
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_config_975_guest_accelerator_976';
+    return 'TerraformGoogle::Google_container_cluster_node_config_119_guest_accelerator_120';
   }
 }
 
-export class Google_container_cluster_node_config_975_taint_977 implements PcoreValue {
+export class Google_container_cluster_node_config_119_taint_121 implements PcoreValue {
   readonly effect: string;
   readonly key: string;
   readonly value: string;
@@ -11759,11 +11759,11 @@ export class Google_container_cluster_node_config_975_taint_977 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_config_975_taint_977';
+    return 'TerraformGoogle::Google_container_cluster_node_config_119_taint_121';
   }
 }
 
-export class Google_container_cluster_node_config_975_workload_metadata_config_978 implements PcoreValue {
+export class Google_container_cluster_node_config_119_workload_metadata_config_122 implements PcoreValue {
   readonly node_metadata: string;
 
   constructor({
@@ -11781,19 +11781,19 @@ export class Google_container_cluster_node_config_975_workload_metadata_config_9
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_config_975_workload_metadata_config_978';
+    return 'TerraformGoogle::Google_container_cluster_node_config_119_workload_metadata_config_122';
   }
 }
 
-export class Google_container_cluster_node_pool_979 implements PcoreValue {
-  readonly autoscaling: Google_container_cluster_node_pool_979_autoscaling_980[]|null;
+export class Google_container_cluster_node_pool_123 implements PcoreValue {
+  readonly autoscaling: Google_container_cluster_node_pool_123_autoscaling_124[]|null;
   readonly initial_node_count: number|null;
   readonly instance_group_urls: string[]|null;
-  readonly management: Google_container_cluster_node_pool_979_management_981[]|null;
+  readonly management: Google_container_cluster_node_pool_123_management_125[]|null;
   readonly max_pods_per_node: number|null;
   readonly name: string|null;
   readonly name_prefix: string|null;
-  readonly node_config: Google_container_cluster_node_pool_979_node_config_982[]|null;
+  readonly node_config: Google_container_cluster_node_pool_123_node_config_126[]|null;
   readonly node_count: number|null;
   readonly version: string|null;
 
@@ -11809,14 +11809,14 @@ export class Google_container_cluster_node_pool_979 implements PcoreValue {
     node_count = null,
     version = null
   }: {
-    autoscaling?: Google_container_cluster_node_pool_979_autoscaling_980[]|null,
+    autoscaling?: Google_container_cluster_node_pool_123_autoscaling_124[]|null,
     initial_node_count?: number|null,
     instance_group_urls?: string[]|null,
-    management?: Google_container_cluster_node_pool_979_management_981[]|null,
+    management?: Google_container_cluster_node_pool_123_management_125[]|null,
     max_pods_per_node?: number|null,
     name?: string|null,
     name_prefix?: string|null,
-    node_config?: Google_container_cluster_node_pool_979_node_config_982[]|null,
+    node_config?: Google_container_cluster_node_pool_123_node_config_126[]|null,
     node_count?: number|null,
     version?: string|null
   }) {
@@ -11868,11 +11868,11 @@ export class Google_container_cluster_node_pool_979 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123';
   }
 }
 
-export class Google_container_cluster_node_pool_979_autoscaling_980 implements PcoreValue {
+export class Google_container_cluster_node_pool_123_autoscaling_124 implements PcoreValue {
   readonly max_node_count: number;
   readonly min_node_count: number;
 
@@ -11895,11 +11895,11 @@ export class Google_container_cluster_node_pool_979_autoscaling_980 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979_autoscaling_980';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123_autoscaling_124';
   }
 }
 
-export class Google_container_cluster_node_pool_979_management_981 implements PcoreValue {
+export class Google_container_cluster_node_pool_123_management_125 implements PcoreValue {
   readonly auto_repair: boolean|null;
   readonly auto_upgrade: boolean|null;
 
@@ -11926,14 +11926,14 @@ export class Google_container_cluster_node_pool_979_management_981 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979_management_981';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123_management_125';
   }
 }
 
-export class Google_container_cluster_node_pool_979_node_config_982 implements PcoreValue {
+export class Google_container_cluster_node_pool_123_node_config_126 implements PcoreValue {
   readonly disk_size_gb: number|null;
   readonly disk_type: string|null;
-  readonly guest_accelerator: Google_container_cluster_node_pool_979_node_config_982_guest_accelerator_983[]|null;
+  readonly guest_accelerator: Google_container_cluster_node_pool_123_node_config_126_guest_accelerator_127[]|null;
   readonly image_type: string|null;
   readonly labels: {[s: string]: string}|null;
   readonly local_ssd_count: number|null;
@@ -11944,8 +11944,8 @@ export class Google_container_cluster_node_pool_979_node_config_982 implements P
   readonly preemptible: boolean|null;
   readonly service_account: string|null;
   readonly tags: string[]|null;
-  readonly taint: Google_container_cluster_node_pool_979_node_config_982_taint_984[]|null;
-  readonly workload_metadata_config: Google_container_cluster_node_pool_979_node_config_982_workload_metadata_config_985[]|null;
+  readonly taint: Google_container_cluster_node_pool_123_node_config_126_taint_128[]|null;
+  readonly workload_metadata_config: Google_container_cluster_node_pool_123_node_config_126_workload_metadata_config_129[]|null;
 
   constructor({
     disk_size_gb = null,
@@ -11966,7 +11966,7 @@ export class Google_container_cluster_node_pool_979_node_config_982 implements P
   }: {
     disk_size_gb?: number|null,
     disk_type?: string|null,
-    guest_accelerator?: Google_container_cluster_node_pool_979_node_config_982_guest_accelerator_983[]|null,
+    guest_accelerator?: Google_container_cluster_node_pool_123_node_config_126_guest_accelerator_127[]|null,
     image_type?: string|null,
     labels?: {[s: string]: string}|null,
     local_ssd_count?: number|null,
@@ -11977,8 +11977,8 @@ export class Google_container_cluster_node_pool_979_node_config_982 implements P
     preemptible?: boolean|null,
     service_account?: string|null,
     tags?: string[]|null,
-    taint?: Google_container_cluster_node_pool_979_node_config_982_taint_984[]|null,
-    workload_metadata_config?: Google_container_cluster_node_pool_979_node_config_982_workload_metadata_config_985[]|null
+    taint?: Google_container_cluster_node_pool_123_node_config_126_taint_128[]|null,
+    workload_metadata_config?: Google_container_cluster_node_pool_123_node_config_126_workload_metadata_config_129[]|null
   }) {
     this.disk_size_gb = disk_size_gb;
     this.disk_type = disk_type;
@@ -12048,11 +12048,11 @@ export class Google_container_cluster_node_pool_979_node_config_982 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979_node_config_982';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123_node_config_126';
   }
 }
 
-export class Google_container_cluster_node_pool_979_node_config_982_guest_accelerator_983 implements PcoreValue {
+export class Google_container_cluster_node_pool_123_node_config_126_guest_accelerator_127 implements PcoreValue {
   readonly count: number;
   readonly type: string;
 
@@ -12075,11 +12075,11 @@ export class Google_container_cluster_node_pool_979_node_config_982_guest_accele
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979_node_config_982_guest_accelerator_983';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123_node_config_126_guest_accelerator_127';
   }
 }
 
-export class Google_container_cluster_node_pool_979_node_config_982_taint_984 implements PcoreValue {
+export class Google_container_cluster_node_pool_123_node_config_126_taint_128 implements PcoreValue {
   readonly effect: string;
   readonly key: string;
   readonly value: string;
@@ -12107,11 +12107,11 @@ export class Google_container_cluster_node_pool_979_node_config_982_taint_984 im
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979_node_config_982_taint_984';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123_node_config_126_taint_128';
   }
 }
 
-export class Google_container_cluster_node_pool_979_node_config_982_workload_metadata_config_985 implements PcoreValue {
+export class Google_container_cluster_node_pool_123_node_config_126_workload_metadata_config_129 implements PcoreValue {
   readonly node_metadata: string;
 
   constructor({
@@ -12129,11 +12129,11 @@ export class Google_container_cluster_node_pool_979_node_config_982_workload_met
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_node_pool_979_node_config_982_workload_metadata_config_985';
+    return 'TerraformGoogle::Google_container_cluster_node_pool_123_node_config_126_workload_metadata_config_129';
   }
 }
 
-export class Google_container_cluster_pod_security_policy_config_986 implements PcoreValue {
+export class Google_container_cluster_pod_security_policy_config_130 implements PcoreValue {
   readonly enabled: boolean;
 
   constructor({
@@ -12151,11 +12151,11 @@ export class Google_container_cluster_pod_security_policy_config_986 implements 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_pod_security_policy_config_986';
+    return 'TerraformGoogle::Google_container_cluster_pod_security_policy_config_130';
   }
 }
 
-export class Google_container_cluster_private_cluster_config_987 implements PcoreValue {
+export class Google_container_cluster_private_cluster_config_131 implements PcoreValue {
   readonly enable_private_endpoint: boolean|null;
   readonly enable_private_nodes: boolean|null;
   readonly master_ipv4_cidr_block: string|null;
@@ -12203,21 +12203,21 @@ export class Google_container_cluster_private_cluster_config_987 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_cluster_private_cluster_config_987';
+    return 'TerraformGoogle::Google_container_cluster_private_cluster_config_131';
   }
 }
 
 export class Google_container_node_pool implements PcoreValue {
   readonly cluster: string;
   readonly google_container_node_pool_id: string|null;
-  readonly autoscaling: Google_container_node_pool_autoscaling_988[]|null;
+  readonly autoscaling: Google_container_node_pool_autoscaling_132[]|null;
   readonly initial_node_count: number|null;
   readonly instance_group_urls: string[]|null;
-  readonly management: Google_container_node_pool_management_989[]|null;
+  readonly management: Google_container_node_pool_management_133[]|null;
   readonly max_pods_per_node: number|null;
   readonly name: string|null;
   readonly name_prefix: string|null;
-  readonly node_config: Google_container_node_pool_node_config_990[]|null;
+  readonly node_config: Google_container_node_pool_node_config_134[]|null;
   readonly node_count: number|null;
   readonly project: string|null;
   readonly region: string|null;
@@ -12243,14 +12243,14 @@ export class Google_container_node_pool implements PcoreValue {
   }: {
     cluster: string,
     google_container_node_pool_id?: string|null,
-    autoscaling?: Google_container_node_pool_autoscaling_988[]|null,
+    autoscaling?: Google_container_node_pool_autoscaling_132[]|null,
     initial_node_count?: number|null,
     instance_group_urls?: string[]|null,
-    management?: Google_container_node_pool_management_989[]|null,
+    management?: Google_container_node_pool_management_133[]|null,
     max_pods_per_node?: number|null,
     name?: string|null,
     name_prefix?: string|null,
-    node_config?: Google_container_node_pool_node_config_990[]|null,
+    node_config?: Google_container_node_pool_node_config_134[]|null,
     node_count?: number|null,
     project?: string|null,
     region?: string|null,
@@ -12337,7 +12337,7 @@ export class Google_container_node_poolHandler implements PcoreValue {
   }
 }
 
-export class Google_container_node_pool_autoscaling_988 implements PcoreValue {
+export class Google_container_node_pool_autoscaling_132 implements PcoreValue {
   readonly max_node_count: number;
   readonly min_node_count: number;
 
@@ -12360,11 +12360,11 @@ export class Google_container_node_pool_autoscaling_988 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_node_pool_autoscaling_988';
+    return 'TerraformGoogle::Google_container_node_pool_autoscaling_132';
   }
 }
 
-export class Google_container_node_pool_management_989 implements PcoreValue {
+export class Google_container_node_pool_management_133 implements PcoreValue {
   readonly auto_repair: boolean|null;
   readonly auto_upgrade: boolean|null;
 
@@ -12391,14 +12391,14 @@ export class Google_container_node_pool_management_989 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_node_pool_management_989';
+    return 'TerraformGoogle::Google_container_node_pool_management_133';
   }
 }
 
-export class Google_container_node_pool_node_config_990 implements PcoreValue {
+export class Google_container_node_pool_node_config_134 implements PcoreValue {
   readonly disk_size_gb: number|null;
   readonly disk_type: string|null;
-  readonly guest_accelerator: Google_container_node_pool_node_config_990_guest_accelerator_991[]|null;
+  readonly guest_accelerator: Google_container_node_pool_node_config_134_guest_accelerator_135[]|null;
   readonly image_type: string|null;
   readonly labels: {[s: string]: string}|null;
   readonly local_ssd_count: number|null;
@@ -12409,8 +12409,8 @@ export class Google_container_node_pool_node_config_990 implements PcoreValue {
   readonly preemptible: boolean|null;
   readonly service_account: string|null;
   readonly tags: string[]|null;
-  readonly taint: Google_container_node_pool_node_config_990_taint_992[]|null;
-  readonly workload_metadata_config: Google_container_node_pool_node_config_990_workload_metadata_config_993[]|null;
+  readonly taint: Google_container_node_pool_node_config_134_taint_136[]|null;
+  readonly workload_metadata_config: Google_container_node_pool_node_config_134_workload_metadata_config_137[]|null;
 
   constructor({
     disk_size_gb = null,
@@ -12431,7 +12431,7 @@ export class Google_container_node_pool_node_config_990 implements PcoreValue {
   }: {
     disk_size_gb?: number|null,
     disk_type?: string|null,
-    guest_accelerator?: Google_container_node_pool_node_config_990_guest_accelerator_991[]|null,
+    guest_accelerator?: Google_container_node_pool_node_config_134_guest_accelerator_135[]|null,
     image_type?: string|null,
     labels?: {[s: string]: string}|null,
     local_ssd_count?: number|null,
@@ -12442,8 +12442,8 @@ export class Google_container_node_pool_node_config_990 implements PcoreValue {
     preemptible?: boolean|null,
     service_account?: string|null,
     tags?: string[]|null,
-    taint?: Google_container_node_pool_node_config_990_taint_992[]|null,
-    workload_metadata_config?: Google_container_node_pool_node_config_990_workload_metadata_config_993[]|null
+    taint?: Google_container_node_pool_node_config_134_taint_136[]|null,
+    workload_metadata_config?: Google_container_node_pool_node_config_134_workload_metadata_config_137[]|null
   }) {
     this.disk_size_gb = disk_size_gb;
     this.disk_type = disk_type;
@@ -12513,11 +12513,11 @@ export class Google_container_node_pool_node_config_990 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_node_pool_node_config_990';
+    return 'TerraformGoogle::Google_container_node_pool_node_config_134';
   }
 }
 
-export class Google_container_node_pool_node_config_990_guest_accelerator_991 implements PcoreValue {
+export class Google_container_node_pool_node_config_134_guest_accelerator_135 implements PcoreValue {
   readonly count: number;
   readonly type: string;
 
@@ -12540,11 +12540,11 @@ export class Google_container_node_pool_node_config_990_guest_accelerator_991 im
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_node_pool_node_config_990_guest_accelerator_991';
+    return 'TerraformGoogle::Google_container_node_pool_node_config_134_guest_accelerator_135';
   }
 }
 
-export class Google_container_node_pool_node_config_990_taint_992 implements PcoreValue {
+export class Google_container_node_pool_node_config_134_taint_136 implements PcoreValue {
   readonly effect: string;
   readonly key: string;
   readonly value: string;
@@ -12572,11 +12572,11 @@ export class Google_container_node_pool_node_config_990_taint_992 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_node_pool_node_config_990_taint_992';
+    return 'TerraformGoogle::Google_container_node_pool_node_config_134_taint_136';
   }
 }
 
-export class Google_container_node_pool_node_config_990_workload_metadata_config_993 implements PcoreValue {
+export class Google_container_node_pool_node_config_134_workload_metadata_config_137 implements PcoreValue {
   readonly node_metadata: string;
 
   constructor({
@@ -12594,7 +12594,7 @@ export class Google_container_node_pool_node_config_990_workload_metadata_config
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_container_node_pool_node_config_990_workload_metadata_config_993';
+    return 'TerraformGoogle::Google_container_node_pool_node_config_134_workload_metadata_config_137';
   }
 }
 
@@ -12699,7 +12699,7 @@ export class Google_dataflow_jobHandler implements PcoreValue {
 export class Google_dataproc_cluster implements PcoreValue {
   readonly name: string;
   readonly google_dataproc_cluster_id: string|null;
-  readonly cluster_config: Google_dataproc_cluster_cluster_config_994[]|null;
+  readonly cluster_config: Google_dataproc_cluster_cluster_config_138[]|null;
   readonly labels: {[s: string]: string}|null;
   readonly project: string|null;
   readonly region: string|null;
@@ -12714,7 +12714,7 @@ export class Google_dataproc_cluster implements PcoreValue {
   }: {
     name: string,
     google_dataproc_cluster_id?: string|null,
-    cluster_config?: Google_dataproc_cluster_cluster_config_994[]|null,
+    cluster_config?: Google_dataproc_cluster_cluster_config_138[]|null,
     labels?: {[s: string]: string}|null,
     project?: string|null,
     region?: string|null
@@ -12763,16 +12763,16 @@ export class Google_dataproc_clusterHandler implements PcoreValue {
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138 implements PcoreValue {
   readonly bucket: string|null;
   readonly delete_autogen_bucket: boolean|null;
-  readonly gce_cluster_config: Google_dataproc_cluster_cluster_config_994_gce_cluster_config_995[]|null;
-  readonly initialization_action: Google_dataproc_cluster_cluster_config_994_initialization_action_996[]|null;
-  readonly master_config: Google_dataproc_cluster_cluster_config_994_master_config_997[]|null;
-  readonly preemptible_worker_config: Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999[]|null;
-  readonly software_config: Google_dataproc_cluster_cluster_config_994_software_config_1001[]|null;
+  readonly gce_cluster_config: Google_dataproc_cluster_cluster_config_138_gce_cluster_config_139[]|null;
+  readonly initialization_action: Google_dataproc_cluster_cluster_config_138_initialization_action_140[]|null;
+  readonly master_config: Google_dataproc_cluster_cluster_config_138_master_config_141[]|null;
+  readonly preemptible_worker_config: Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143[]|null;
+  readonly software_config: Google_dataproc_cluster_cluster_config_138_software_config_145[]|null;
   readonly staging_bucket: string|null;
-  readonly worker_config: Google_dataproc_cluster_cluster_config_994_worker_config_1002[]|null;
+  readonly worker_config: Google_dataproc_cluster_cluster_config_138_worker_config_146[]|null;
 
   constructor({
     bucket = null,
@@ -12787,13 +12787,13 @@ export class Google_dataproc_cluster_cluster_config_994 implements PcoreValue {
   }: {
     bucket?: string|null,
     delete_autogen_bucket?: boolean|null,
-    gce_cluster_config?: Google_dataproc_cluster_cluster_config_994_gce_cluster_config_995[]|null,
-    initialization_action?: Google_dataproc_cluster_cluster_config_994_initialization_action_996[]|null,
-    master_config?: Google_dataproc_cluster_cluster_config_994_master_config_997[]|null,
-    preemptible_worker_config?: Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999[]|null,
-    software_config?: Google_dataproc_cluster_cluster_config_994_software_config_1001[]|null,
+    gce_cluster_config?: Google_dataproc_cluster_cluster_config_138_gce_cluster_config_139[]|null,
+    initialization_action?: Google_dataproc_cluster_cluster_config_138_initialization_action_140[]|null,
+    master_config?: Google_dataproc_cluster_cluster_config_138_master_config_141[]|null,
+    preemptible_worker_config?: Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143[]|null,
+    software_config?: Google_dataproc_cluster_cluster_config_138_software_config_145[]|null,
     staging_bucket?: string|null,
-    worker_config?: Google_dataproc_cluster_cluster_config_994_worker_config_1002[]|null
+    worker_config?: Google_dataproc_cluster_cluster_config_138_worker_config_146[]|null
   }) {
     this.bucket = bucket;
     this.delete_autogen_bucket = delete_autogen_bucket;
@@ -12839,11 +12839,11 @@ export class Google_dataproc_cluster_cluster_config_994 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_gce_cluster_config_995 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138_gce_cluster_config_139 implements PcoreValue {
   readonly internal_ip_only: boolean|null;
   readonly metadata: {[s: string]: string}|null;
   readonly network: string|null;
@@ -12912,11 +12912,11 @@ export class Google_dataproc_cluster_cluster_config_994_gce_cluster_config_995 i
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_gce_cluster_config_995';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_gce_cluster_config_139';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_initialization_action_996 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138_initialization_action_140 implements PcoreValue {
   readonly script: string;
   readonly timeout_sec: number|null;
 
@@ -12941,12 +12941,12 @@ export class Google_dataproc_cluster_cluster_config_994_initialization_action_99
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_initialization_action_996';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_initialization_action_140';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_master_config_997 implements PcoreValue {
-  readonly disk_config: Google_dataproc_cluster_cluster_config_994_master_config_997_disk_config_998[]|null;
+export class Google_dataproc_cluster_cluster_config_138_master_config_141 implements PcoreValue {
+  readonly disk_config: Google_dataproc_cluster_cluster_config_138_master_config_141_disk_config_142[]|null;
   readonly instance_names: string[]|null;
   readonly machine_type: string|null;
   readonly num_instances: number|null;
@@ -12957,7 +12957,7 @@ export class Google_dataproc_cluster_cluster_config_994_master_config_997 implem
     machine_type = null,
     num_instances = null
   }: {
-    disk_config?: Google_dataproc_cluster_cluster_config_994_master_config_997_disk_config_998[]|null,
+    disk_config?: Google_dataproc_cluster_cluster_config_138_master_config_141_disk_config_142[]|null,
     instance_names?: string[]|null,
     machine_type?: string|null,
     num_instances?: number|null
@@ -12986,11 +12986,11 @@ export class Google_dataproc_cluster_cluster_config_994_master_config_997 implem
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_master_config_997';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_master_config_141';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_master_config_997_disk_config_998 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138_master_config_141_disk_config_142 implements PcoreValue {
   readonly boot_disk_size_gb: number|null;
   readonly boot_disk_type: string|null;
   readonly num_local_ssds: number|null;
@@ -13024,12 +13024,12 @@ export class Google_dataproc_cluster_cluster_config_994_master_config_997_disk_c
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_master_config_997_disk_config_998';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_master_config_141_disk_config_142';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999 implements PcoreValue {
-  readonly disk_config: Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999_disk_config_1000[]|null;
+export class Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143 implements PcoreValue {
+  readonly disk_config: Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143_disk_config_144[]|null;
   readonly instance_names: string[]|null;
   readonly num_instances: number|null;
 
@@ -13038,7 +13038,7 @@ export class Google_dataproc_cluster_cluster_config_994_preemptible_worker_confi
     instance_names = null,
     num_instances = null
   }: {
-    disk_config?: Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999_disk_config_1000[]|null,
+    disk_config?: Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143_disk_config_144[]|null,
     instance_names?: string[]|null,
     num_instances?: number|null
   }) {
@@ -13062,11 +13062,11 @@ export class Google_dataproc_cluster_cluster_config_994_preemptible_worker_confi
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999_disk_config_1000 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143_disk_config_144 implements PcoreValue {
   readonly boot_disk_size_gb: number|null;
 
   constructor({
@@ -13086,11 +13086,11 @@ export class Google_dataproc_cluster_cluster_config_994_preemptible_worker_confi
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_preemptible_worker_config_999_disk_config_1000';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_preemptible_worker_config_143_disk_config_144';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_software_config_1001 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138_software_config_145 implements PcoreValue {
   readonly image_version: string|null;
   readonly override_properties: {[s: string]: string}|null;
   readonly properties: {[s: string]: string}|null;
@@ -13124,12 +13124,12 @@ export class Google_dataproc_cluster_cluster_config_994_software_config_1001 imp
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_software_config_1001';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_software_config_145';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_worker_config_1002 implements PcoreValue {
-  readonly disk_config: Google_dataproc_cluster_cluster_config_994_worker_config_1002_disk_config_1003[]|null;
+export class Google_dataproc_cluster_cluster_config_138_worker_config_146 implements PcoreValue {
+  readonly disk_config: Google_dataproc_cluster_cluster_config_138_worker_config_146_disk_config_147[]|null;
   readonly instance_names: string[]|null;
   readonly machine_type: string|null;
   readonly num_instances: number|null;
@@ -13140,7 +13140,7 @@ export class Google_dataproc_cluster_cluster_config_994_worker_config_1002 imple
     machine_type = null,
     num_instances = null
   }: {
-    disk_config?: Google_dataproc_cluster_cluster_config_994_worker_config_1002_disk_config_1003[]|null,
+    disk_config?: Google_dataproc_cluster_cluster_config_138_worker_config_146_disk_config_147[]|null,
     instance_names?: string[]|null,
     machine_type?: string|null,
     num_instances?: number|null
@@ -13169,11 +13169,11 @@ export class Google_dataproc_cluster_cluster_config_994_worker_config_1002 imple
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_worker_config_1002';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_worker_config_146';
   }
 }
 
-export class Google_dataproc_cluster_cluster_config_994_worker_config_1002_disk_config_1003 implements PcoreValue {
+export class Google_dataproc_cluster_cluster_config_138_worker_config_146_disk_config_147 implements PcoreValue {
   readonly boot_disk_size_gb: number|null;
   readonly boot_disk_type: string|null;
   readonly num_local_ssds: number|null;
@@ -13207,28 +13207,28 @@ export class Google_dataproc_cluster_cluster_config_994_worker_config_1002_disk_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_994_worker_config_1002_disk_config_1003';
+    return 'TerraformGoogle::Google_dataproc_cluster_cluster_config_138_worker_config_146_disk_config_147';
   }
 }
 
 export class Google_dataproc_job implements PcoreValue {
-  readonly placement: Google_dataproc_job_placement_1009[];
+  readonly placement: Google_dataproc_job_placement_153[];
   readonly google_dataproc_job_id: string|null;
   readonly driver_controls_files_uri: string|null;
   readonly driver_output_resource_uri: string|null;
   readonly force_delete: boolean|null;
-  readonly hadoop_config: Google_dataproc_job_hadoop_config_1004[]|null;
-  readonly hive_config: Google_dataproc_job_hive_config_1006[]|null;
+  readonly hadoop_config: Google_dataproc_job_hadoop_config_148[]|null;
+  readonly hive_config: Google_dataproc_job_hive_config_150[]|null;
   readonly labels: {[s: string]: string}|null;
-  readonly pig_config: Google_dataproc_job_pig_config_1007[]|null;
+  readonly pig_config: Google_dataproc_job_pig_config_151[]|null;
   readonly project: string|null;
-  readonly pyspark_config: Google_dataproc_job_pyspark_config_1010[]|null;
-  readonly reference: Google_dataproc_job_reference_1012[]|null;
+  readonly pyspark_config: Google_dataproc_job_pyspark_config_154[]|null;
+  readonly reference: Google_dataproc_job_reference_156[]|null;
   readonly region: string|null;
-  readonly scheduling: Google_dataproc_job_scheduling_1013[]|null;
-  readonly spark_config: Google_dataproc_job_spark_config_1014[]|null;
-  readonly sparksql_config: Google_dataproc_job_sparksql_config_1016[]|null;
-  readonly status: Google_dataproc_job_status_1018[]|null;
+  readonly scheduling: Google_dataproc_job_scheduling_157[]|null;
+  readonly spark_config: Google_dataproc_job_spark_config_158[]|null;
+  readonly sparksql_config: Google_dataproc_job_sparksql_config_160[]|null;
+  readonly status: Google_dataproc_job_status_162[]|null;
 
   constructor({
     placement,
@@ -13249,23 +13249,23 @@ export class Google_dataproc_job implements PcoreValue {
     sparksql_config = null,
     status = null
   }: {
-    placement: Google_dataproc_job_placement_1009[],
+    placement: Google_dataproc_job_placement_153[],
     google_dataproc_job_id?: string|null,
     driver_controls_files_uri?: string|null,
     driver_output_resource_uri?: string|null,
     force_delete?: boolean|null,
-    hadoop_config?: Google_dataproc_job_hadoop_config_1004[]|null,
-    hive_config?: Google_dataproc_job_hive_config_1006[]|null,
+    hadoop_config?: Google_dataproc_job_hadoop_config_148[]|null,
+    hive_config?: Google_dataproc_job_hive_config_150[]|null,
     labels?: {[s: string]: string}|null,
-    pig_config?: Google_dataproc_job_pig_config_1007[]|null,
+    pig_config?: Google_dataproc_job_pig_config_151[]|null,
     project?: string|null,
-    pyspark_config?: Google_dataproc_job_pyspark_config_1010[]|null,
-    reference?: Google_dataproc_job_reference_1012[]|null,
+    pyspark_config?: Google_dataproc_job_pyspark_config_154[]|null,
+    reference?: Google_dataproc_job_reference_156[]|null,
     region?: string|null,
-    scheduling?: Google_dataproc_job_scheduling_1013[]|null,
-    spark_config?: Google_dataproc_job_spark_config_1014[]|null,
-    sparksql_config?: Google_dataproc_job_sparksql_config_1016[]|null,
-    status?: Google_dataproc_job_status_1018[]|null
+    scheduling?: Google_dataproc_job_scheduling_157[]|null,
+    spark_config?: Google_dataproc_job_spark_config_158[]|null,
+    sparksql_config?: Google_dataproc_job_sparksql_config_160[]|null,
+    status?: Google_dataproc_job_status_162[]|null
   }) {
     this.placement = placement;
     this.google_dataproc_job_id = google_dataproc_job_id;
@@ -13355,12 +13355,12 @@ export class Google_dataproc_jobHandler implements PcoreValue {
   }
 }
 
-export class Google_dataproc_job_hadoop_config_1004 implements PcoreValue {
+export class Google_dataproc_job_hadoop_config_148 implements PcoreValue {
   readonly archive_uris: string[]|null;
   readonly args: string[]|null;
   readonly file_uris: string[]|null;
   readonly jar_file_uris: string[]|null;
-  readonly logging_config: Google_dataproc_job_hadoop_config_1004_logging_config_1005[]|null;
+  readonly logging_config: Google_dataproc_job_hadoop_config_148_logging_config_149[]|null;
   readonly main_class: string|null;
   readonly main_jar_file_uri: string|null;
   readonly properties: {[s: string]: string}|null;
@@ -13379,7 +13379,7 @@ export class Google_dataproc_job_hadoop_config_1004 implements PcoreValue {
     args?: string[]|null,
     file_uris?: string[]|null,
     jar_file_uris?: string[]|null,
-    logging_config?: Google_dataproc_job_hadoop_config_1004_logging_config_1005[]|null,
+    logging_config?: Google_dataproc_job_hadoop_config_148_logging_config_149[]|null,
     main_class?: string|null,
     main_jar_file_uri?: string|null,
     properties?: {[s: string]: string}|null
@@ -13424,11 +13424,11 @@ export class Google_dataproc_job_hadoop_config_1004 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_hadoop_config_1004';
+    return 'TerraformGoogle::Google_dataproc_job_hadoop_config_148';
   }
 }
 
-export class Google_dataproc_job_hadoop_config_1004_logging_config_1005 implements PcoreValue {
+export class Google_dataproc_job_hadoop_config_148_logging_config_149 implements PcoreValue {
   readonly driver_log_levels: {[s: string]: string}|null;
 
   constructor({
@@ -13448,11 +13448,11 @@ export class Google_dataproc_job_hadoop_config_1004_logging_config_1005 implemen
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_hadoop_config_1004_logging_config_1005';
+    return 'TerraformGoogle::Google_dataproc_job_hadoop_config_148_logging_config_149';
   }
 }
 
-export class Google_dataproc_job_hive_config_1006 implements PcoreValue {
+export class Google_dataproc_job_hive_config_150 implements PcoreValue {
   readonly continue_on_failure: boolean|null;
   readonly jar_file_uris: string[]|null;
   readonly properties: {[s: string]: string}|null;
@@ -13507,14 +13507,14 @@ export class Google_dataproc_job_hive_config_1006 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_hive_config_1006';
+    return 'TerraformGoogle::Google_dataproc_job_hive_config_150';
   }
 }
 
-export class Google_dataproc_job_pig_config_1007 implements PcoreValue {
+export class Google_dataproc_job_pig_config_151 implements PcoreValue {
   readonly continue_on_failure: boolean|null;
   readonly jar_file_uris: string[]|null;
-  readonly logging_config: Google_dataproc_job_pig_config_1007_logging_config_1008[]|null;
+  readonly logging_config: Google_dataproc_job_pig_config_151_logging_config_152[]|null;
   readonly properties: {[s: string]: string}|null;
   readonly query_file_uri: string|null;
   readonly query_list: string[]|null;
@@ -13531,7 +13531,7 @@ export class Google_dataproc_job_pig_config_1007 implements PcoreValue {
   }: {
     continue_on_failure?: boolean|null,
     jar_file_uris?: string[]|null,
-    logging_config?: Google_dataproc_job_pig_config_1007_logging_config_1008[]|null,
+    logging_config?: Google_dataproc_job_pig_config_151_logging_config_152[]|null,
     properties?: {[s: string]: string}|null,
     query_file_uri?: string|null,
     query_list?: string[]|null,
@@ -13573,11 +13573,11 @@ export class Google_dataproc_job_pig_config_1007 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_pig_config_1007';
+    return 'TerraformGoogle::Google_dataproc_job_pig_config_151';
   }
 }
 
-export class Google_dataproc_job_pig_config_1007_logging_config_1008 implements PcoreValue {
+export class Google_dataproc_job_pig_config_151_logging_config_152 implements PcoreValue {
   readonly driver_log_levels: {[s: string]: string}|null;
 
   constructor({
@@ -13597,11 +13597,11 @@ export class Google_dataproc_job_pig_config_1007_logging_config_1008 implements 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_pig_config_1007_logging_config_1008';
+    return 'TerraformGoogle::Google_dataproc_job_pig_config_151_logging_config_152';
   }
 }
 
-export class Google_dataproc_job_placement_1009 implements PcoreValue {
+export class Google_dataproc_job_placement_153 implements PcoreValue {
   readonly cluster_name: string;
   readonly cluster_uuid: string|null;
 
@@ -13626,17 +13626,17 @@ export class Google_dataproc_job_placement_1009 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_placement_1009';
+    return 'TerraformGoogle::Google_dataproc_job_placement_153';
   }
 }
 
-export class Google_dataproc_job_pyspark_config_1010 implements PcoreValue {
+export class Google_dataproc_job_pyspark_config_154 implements PcoreValue {
   readonly main_python_file_uri: string;
   readonly archive_uris: string[]|null;
   readonly args: string[]|null;
   readonly file_uris: string[]|null;
   readonly jar_file_uris: string[]|null;
-  readonly logging_config: Google_dataproc_job_pyspark_config_1010_logging_config_1011[]|null;
+  readonly logging_config: Google_dataproc_job_pyspark_config_154_logging_config_155[]|null;
   readonly properties: {[s: string]: string}|null;
   readonly python_file_uris: string[]|null;
 
@@ -13655,7 +13655,7 @@ export class Google_dataproc_job_pyspark_config_1010 implements PcoreValue {
     args?: string[]|null,
     file_uris?: string[]|null,
     jar_file_uris?: string[]|null,
-    logging_config?: Google_dataproc_job_pyspark_config_1010_logging_config_1011[]|null,
+    logging_config?: Google_dataproc_job_pyspark_config_154_logging_config_155[]|null,
     properties?: {[s: string]: string}|null,
     python_file_uris?: string[]|null
   }) {
@@ -13697,11 +13697,11 @@ export class Google_dataproc_job_pyspark_config_1010 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_pyspark_config_1010';
+    return 'TerraformGoogle::Google_dataproc_job_pyspark_config_154';
   }
 }
 
-export class Google_dataproc_job_pyspark_config_1010_logging_config_1011 implements PcoreValue {
+export class Google_dataproc_job_pyspark_config_154_logging_config_155 implements PcoreValue {
   readonly driver_log_levels: {[s: string]: string}|null;
 
   constructor({
@@ -13721,11 +13721,11 @@ export class Google_dataproc_job_pyspark_config_1010_logging_config_1011 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_pyspark_config_1010_logging_config_1011';
+    return 'TerraformGoogle::Google_dataproc_job_pyspark_config_154_logging_config_155';
   }
 }
 
-export class Google_dataproc_job_reference_1012 implements PcoreValue {
+export class Google_dataproc_job_reference_156 implements PcoreValue {
   readonly job_id: string|null;
 
   constructor({
@@ -13745,11 +13745,11 @@ export class Google_dataproc_job_reference_1012 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_reference_1012';
+    return 'TerraformGoogle::Google_dataproc_job_reference_156';
   }
 }
 
-export class Google_dataproc_job_scheduling_1013 implements PcoreValue {
+export class Google_dataproc_job_scheduling_157 implements PcoreValue {
   readonly max_failures_per_hour: number|null;
 
   constructor({
@@ -13769,16 +13769,16 @@ export class Google_dataproc_job_scheduling_1013 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_scheduling_1013';
+    return 'TerraformGoogle::Google_dataproc_job_scheduling_157';
   }
 }
 
-export class Google_dataproc_job_spark_config_1014 implements PcoreValue {
+export class Google_dataproc_job_spark_config_158 implements PcoreValue {
   readonly archive_uris: string[]|null;
   readonly args: string[]|null;
   readonly file_uris: string[]|null;
   readonly jar_file_uris: string[]|null;
-  readonly logging_config: Google_dataproc_job_spark_config_1014_logging_config_1015[]|null;
+  readonly logging_config: Google_dataproc_job_spark_config_158_logging_config_159[]|null;
   readonly main_class: string|null;
   readonly main_jar_file_uri: string|null;
   readonly properties: {[s: string]: string}|null;
@@ -13797,7 +13797,7 @@ export class Google_dataproc_job_spark_config_1014 implements PcoreValue {
     args?: string[]|null,
     file_uris?: string[]|null,
     jar_file_uris?: string[]|null,
-    logging_config?: Google_dataproc_job_spark_config_1014_logging_config_1015[]|null,
+    logging_config?: Google_dataproc_job_spark_config_158_logging_config_159[]|null,
     main_class?: string|null,
     main_jar_file_uri?: string|null,
     properties?: {[s: string]: string}|null
@@ -13842,11 +13842,11 @@ export class Google_dataproc_job_spark_config_1014 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_spark_config_1014';
+    return 'TerraformGoogle::Google_dataproc_job_spark_config_158';
   }
 }
 
-export class Google_dataproc_job_spark_config_1014_logging_config_1015 implements PcoreValue {
+export class Google_dataproc_job_spark_config_158_logging_config_159 implements PcoreValue {
   readonly driver_log_levels: {[s: string]: string}|null;
 
   constructor({
@@ -13866,13 +13866,13 @@ export class Google_dataproc_job_spark_config_1014_logging_config_1015 implement
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_spark_config_1014_logging_config_1015';
+    return 'TerraformGoogle::Google_dataproc_job_spark_config_158_logging_config_159';
   }
 }
 
-export class Google_dataproc_job_sparksql_config_1016 implements PcoreValue {
+export class Google_dataproc_job_sparksql_config_160 implements PcoreValue {
   readonly jar_file_uris: string[]|null;
-  readonly logging_config: Google_dataproc_job_sparksql_config_1016_logging_config_1017[]|null;
+  readonly logging_config: Google_dataproc_job_sparksql_config_160_logging_config_161[]|null;
   readonly properties: {[s: string]: string}|null;
   readonly query_file_uri: string|null;
   readonly query_list: string[]|null;
@@ -13887,7 +13887,7 @@ export class Google_dataproc_job_sparksql_config_1016 implements PcoreValue {
     script_variables = null
   }: {
     jar_file_uris?: string[]|null,
-    logging_config?: Google_dataproc_job_sparksql_config_1016_logging_config_1017[]|null,
+    logging_config?: Google_dataproc_job_sparksql_config_160_logging_config_161[]|null,
     properties?: {[s: string]: string}|null,
     query_file_uri?: string|null,
     query_list?: string[]|null,
@@ -13925,11 +13925,11 @@ export class Google_dataproc_job_sparksql_config_1016 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_sparksql_config_1016';
+    return 'TerraformGoogle::Google_dataproc_job_sparksql_config_160';
   }
 }
 
-export class Google_dataproc_job_sparksql_config_1016_logging_config_1017 implements PcoreValue {
+export class Google_dataproc_job_sparksql_config_160_logging_config_161 implements PcoreValue {
   readonly driver_log_levels: {[s: string]: string}|null;
 
   constructor({
@@ -13949,11 +13949,11 @@ export class Google_dataproc_job_sparksql_config_1016_logging_config_1017 implem
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_sparksql_config_1016_logging_config_1017';
+    return 'TerraformGoogle::Google_dataproc_job_sparksql_config_160_logging_config_161';
   }
 }
 
-export class Google_dataproc_job_status_1018 implements PcoreValue {
+export class Google_dataproc_job_status_162 implements PcoreValue {
   readonly details: string|null;
   readonly state: string|null;
   readonly state_start_time: string|null;
@@ -13994,7 +13994,7 @@ export class Google_dataproc_job_status_1018 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_dataproc_job_status_1018';
+    return 'TerraformGoogle::Google_dataproc_job_status_162';
   }
 }
 
@@ -14139,10 +14139,10 @@ export class Google_dns_record_setHandler implements PcoreValue {
 export class Google_endpoints_service implements PcoreValue {
   readonly service_name: string;
   readonly google_endpoints_service_id: string|null;
-  readonly apis: Google_endpoints_service_apis_1019[]|null;
+  readonly apis: Google_endpoints_service_apis_163[]|null;
   readonly config_id: string|null;
   readonly dns_address: string|null;
-  readonly endpoints: Google_endpoints_service_endpoints_1021[]|null;
+  readonly endpoints: Google_endpoints_service_endpoints_165[]|null;
   readonly grpc_config: string|null;
   readonly openapi_config: string|null;
   readonly project: string|null;
@@ -14164,10 +14164,10 @@ export class Google_endpoints_service implements PcoreValue {
   }: {
     service_name: string,
     google_endpoints_service_id?: string|null,
-    apis?: Google_endpoints_service_apis_1019[]|null,
+    apis?: Google_endpoints_service_apis_163[]|null,
     config_id?: string|null,
     dns_address?: string|null,
-    endpoints?: Google_endpoints_service_endpoints_1021[]|null,
+    endpoints?: Google_endpoints_service_endpoints_165[]|null,
     grpc_config?: string|null,
     openapi_config?: string|null,
     project?: string|null,
@@ -14238,8 +14238,8 @@ export class Google_endpoints_serviceHandler implements PcoreValue {
   }
 }
 
-export class Google_endpoints_service_apis_1019 implements PcoreValue {
-  readonly methods: Google_endpoints_service_apis_1019_methods_1020[]|null;
+export class Google_endpoints_service_apis_163 implements PcoreValue {
+  readonly methods: Google_endpoints_service_apis_163_methods_164[]|null;
   readonly name: string|null;
   readonly syntax: string|null;
   readonly version: string|null;
@@ -14250,7 +14250,7 @@ export class Google_endpoints_service_apis_1019 implements PcoreValue {
     syntax = null,
     version = null
   }: {
-    methods?: Google_endpoints_service_apis_1019_methods_1020[]|null,
+    methods?: Google_endpoints_service_apis_163_methods_164[]|null,
     name?: string|null,
     syntax?: string|null,
     version?: string|null
@@ -14279,11 +14279,11 @@ export class Google_endpoints_service_apis_1019 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_endpoints_service_apis_1019';
+    return 'TerraformGoogle::Google_endpoints_service_apis_163';
   }
 }
 
-export class Google_endpoints_service_apis_1019_methods_1020 implements PcoreValue {
+export class Google_endpoints_service_apis_163_methods_164 implements PcoreValue {
   readonly name: string|null;
   readonly request_type: string|null;
   readonly response_type: string|null;
@@ -14324,11 +14324,11 @@ export class Google_endpoints_service_apis_1019_methods_1020 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_endpoints_service_apis_1019_methods_1020';
+    return 'TerraformGoogle::Google_endpoints_service_apis_163_methods_164';
   }
 }
 
-export class Google_endpoints_service_endpoints_1021 implements PcoreValue {
+export class Google_endpoints_service_endpoints_165 implements PcoreValue {
   readonly address: string|null;
   readonly name: string|null;
 
@@ -14355,14 +14355,14 @@ export class Google_endpoints_service_endpoints_1021 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_endpoints_service_endpoints_1021';
+    return 'TerraformGoogle::Google_endpoints_service_endpoints_165';
   }
 }
 
 export class Google_filestore_instance implements PcoreValue {
-  readonly file_shares: Google_filestore_instance_file_shares_1022[];
+  readonly file_shares: Google_filestore_instance_file_shares_166[];
   readonly name: string;
-  readonly networks: Google_filestore_instance_networks_1023[];
+  readonly networks: Google_filestore_instance_networks_167[];
   readonly tier: string;
   readonly zone: string;
   readonly google_filestore_instance_id: string|null;
@@ -14385,9 +14385,9 @@ export class Google_filestore_instance implements PcoreValue {
     labels = null,
     project = null
   }: {
-    file_shares: Google_filestore_instance_file_shares_1022[],
+    file_shares: Google_filestore_instance_file_shares_166[],
     name: string,
-    networks: Google_filestore_instance_networks_1023[],
+    networks: Google_filestore_instance_networks_167[],
     tier: string,
     zone: string,
     google_filestore_instance_id?: string|null,
@@ -14453,7 +14453,7 @@ export class Google_filestore_instanceHandler implements PcoreValue {
   }
 }
 
-export class Google_filestore_instance_file_shares_1022 implements PcoreValue {
+export class Google_filestore_instance_file_shares_166 implements PcoreValue {
   readonly capacity_gb: number;
   readonly name: string;
 
@@ -14476,11 +14476,11 @@ export class Google_filestore_instance_file_shares_1022 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_filestore_instance_file_shares_1022';
+    return 'TerraformGoogle::Google_filestore_instance_file_shares_166';
   }
 }
 
-export class Google_filestore_instance_networks_1023 implements PcoreValue {
+export class Google_filestore_instance_networks_167 implements PcoreValue {
   readonly modes: string[];
   readonly network: string;
   readonly ip_addresses: string[]|null;
@@ -14517,7 +14517,7 @@ export class Google_filestore_instance_networks_1023 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_filestore_instance_networks_1023';
+    return 'TerraformGoogle::Google_filestore_instance_networks_167';
   }
 }
 
@@ -14753,10 +14753,10 @@ export class Google_folder_organization_policy implements PcoreValue {
   readonly constraint: string;
   readonly folder: string;
   readonly google_folder_organization_policy_id: string|null;
-  readonly boolean_policy: Google_folder_organization_policy_boolean_policy_1024[]|null;
+  readonly boolean_policy: Google_folder_organization_policy_boolean_policy_168[]|null;
   readonly etag: string|null;
-  readonly list_policy: Google_folder_organization_policy_list_policy_1025[]|null;
-  readonly restore_policy: Google_folder_organization_policy_restore_policy_1028[]|null;
+  readonly list_policy: Google_folder_organization_policy_list_policy_169[]|null;
+  readonly restore_policy: Google_folder_organization_policy_restore_policy_172[]|null;
   readonly update_time: string|null;
   readonly version: number|null;
 
@@ -14774,10 +14774,10 @@ export class Google_folder_organization_policy implements PcoreValue {
     constraint: string,
     folder: string,
     google_folder_organization_policy_id?: string|null,
-    boolean_policy?: Google_folder_organization_policy_boolean_policy_1024[]|null,
+    boolean_policy?: Google_folder_organization_policy_boolean_policy_168[]|null,
     etag?: string|null,
-    list_policy?: Google_folder_organization_policy_list_policy_1025[]|null,
-    restore_policy?: Google_folder_organization_policy_restore_policy_1028[]|null,
+    list_policy?: Google_folder_organization_policy_list_policy_169[]|null,
+    restore_policy?: Google_folder_organization_policy_restore_policy_172[]|null,
     update_time?: string|null,
     version?: number|null
   }) {
@@ -14835,7 +14835,7 @@ export class Google_folder_organization_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_folder_organization_policy_boolean_policy_1024 implements PcoreValue {
+export class Google_folder_organization_policy_boolean_policy_168 implements PcoreValue {
   readonly enforced: boolean;
 
   constructor({
@@ -14853,13 +14853,13 @@ export class Google_folder_organization_policy_boolean_policy_1024 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_folder_organization_policy_boolean_policy_1024';
+    return 'TerraformGoogle::Google_folder_organization_policy_boolean_policy_168';
   }
 }
 
-export class Google_folder_organization_policy_list_policy_1025 implements PcoreValue {
-  readonly allow: Google_folder_organization_policy_list_policy_1025_allow_1026[]|null;
-  readonly deny: Google_folder_organization_policy_list_policy_1025_deny_1027[]|null;
+export class Google_folder_organization_policy_list_policy_169 implements PcoreValue {
+  readonly allow: Google_folder_organization_policy_list_policy_169_allow_170[]|null;
+  readonly deny: Google_folder_organization_policy_list_policy_169_deny_171[]|null;
   readonly suggested_value: string|null;
 
   constructor({
@@ -14867,8 +14867,8 @@ export class Google_folder_organization_policy_list_policy_1025 implements Pcore
     deny = null,
     suggested_value = null
   }: {
-    allow?: Google_folder_organization_policy_list_policy_1025_allow_1026[]|null,
-    deny?: Google_folder_organization_policy_list_policy_1025_deny_1027[]|null,
+    allow?: Google_folder_organization_policy_list_policy_169_allow_170[]|null,
+    deny?: Google_folder_organization_policy_list_policy_169_deny_171[]|null,
     suggested_value?: string|null
   }) {
     this.allow = allow;
@@ -14891,11 +14891,11 @@ export class Google_folder_organization_policy_list_policy_1025 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_folder_organization_policy_list_policy_1025';
+    return 'TerraformGoogle::Google_folder_organization_policy_list_policy_169';
   }
 }
 
-export class Google_folder_organization_policy_list_policy_1025_allow_1026 implements PcoreValue {
+export class Google_folder_organization_policy_list_policy_169_allow_170 implements PcoreValue {
   readonly all: boolean|null;
   readonly values: string[]|null;
 
@@ -14922,11 +14922,11 @@ export class Google_folder_organization_policy_list_policy_1025_allow_1026 imple
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_folder_organization_policy_list_policy_1025_allow_1026';
+    return 'TerraformGoogle::Google_folder_organization_policy_list_policy_169_allow_170';
   }
 }
 
-export class Google_folder_organization_policy_list_policy_1025_deny_1027 implements PcoreValue {
+export class Google_folder_organization_policy_list_policy_169_deny_171 implements PcoreValue {
   readonly all: boolean|null;
   readonly values: string[]|null;
 
@@ -14953,11 +14953,11 @@ export class Google_folder_organization_policy_list_policy_1025_deny_1027 implem
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_folder_organization_policy_list_policy_1025_deny_1027';
+    return 'TerraformGoogle::Google_folder_organization_policy_list_policy_169_deny_171';
   }
 }
 
-export class Google_folder_organization_policy_restore_policy_1028 implements PcoreValue {
+export class Google_folder_organization_policy_restore_policy_172 implements PcoreValue {
   readonly default_: boolean;
 
   constructor({
@@ -14975,7 +14975,7 @@ export class Google_folder_organization_policy_restore_policy_1028 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_folder_organization_policy_restore_policy_1028';
+    return 'TerraformGoogle::Google_folder_organization_policy_restore_policy_172';
   }
 }
 
@@ -15901,11 +15901,11 @@ export class Google_logging_project_sinkHandler implements PcoreValue {
 
 export class Google_monitoring_alert_policy implements PcoreValue {
   readonly combiner: string;
-  readonly conditions: Google_monitoring_alert_policy_conditions_1029[];
+  readonly conditions: Google_monitoring_alert_policy_conditions_173[];
   readonly display_name: string;
   readonly enabled: boolean;
   readonly google_monitoring_alert_policy_id: string|null;
-  readonly creation_record: Google_monitoring_alert_policy_creation_record_1037[]|null;
+  readonly creation_record: Google_monitoring_alert_policy_creation_record_181[]|null;
   readonly labels: string[]|null;
   readonly name: string|null;
   readonly notification_channels: string[]|null;
@@ -15924,11 +15924,11 @@ export class Google_monitoring_alert_policy implements PcoreValue {
     project = null
   }: {
     combiner: string,
-    conditions: Google_monitoring_alert_policy_conditions_1029[],
+    conditions: Google_monitoring_alert_policy_conditions_173[],
     display_name: string,
     enabled: boolean,
     google_monitoring_alert_policy_id?: string|null,
-    creation_record?: Google_monitoring_alert_policy_creation_record_1037[]|null,
+    creation_record?: Google_monitoring_alert_policy_creation_record_181[]|null,
     labels?: string[]|null,
     name?: string|null,
     notification_channels?: string[]|null,
@@ -15988,10 +15988,10 @@ export class Google_monitoring_alert_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173 implements PcoreValue {
   readonly display_name: string;
-  readonly condition_absent: Google_monitoring_alert_policy_conditions_1029_condition_absent_1030[]|null;
-  readonly condition_threshold: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033[]|null;
+  readonly condition_absent: Google_monitoring_alert_policy_conditions_173_condition_absent_174[]|null;
+  readonly condition_threshold: Google_monitoring_alert_policy_conditions_173_condition_threshold_177[]|null;
   readonly name: string|null;
 
   constructor({
@@ -16001,8 +16001,8 @@ export class Google_monitoring_alert_policy_conditions_1029 implements PcoreValu
     name = null
   }: {
     display_name: string,
-    condition_absent?: Google_monitoring_alert_policy_conditions_1029_condition_absent_1030[]|null,
-    condition_threshold?: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033[]|null,
+    condition_absent?: Google_monitoring_alert_policy_conditions_173_condition_absent_174[]|null,
+    condition_threshold?: Google_monitoring_alert_policy_conditions_173_condition_threshold_177[]|null,
     name?: string|null
   }) {
     this.display_name = display_name;
@@ -16027,15 +16027,15 @@ export class Google_monitoring_alert_policy_conditions_1029 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_absent_1030 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_absent_174 implements PcoreValue {
   readonly duration: string;
-  readonly aggregations: Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_aggregations_1031[]|null;
+  readonly aggregations: Google_monitoring_alert_policy_conditions_173_condition_absent_174_aggregations_175[]|null;
   readonly filter: string|null;
-  readonly trigger: Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_trigger_1032[]|null;
+  readonly trigger: Google_monitoring_alert_policy_conditions_173_condition_absent_174_trigger_176[]|null;
 
   constructor({
     duration,
@@ -16044,9 +16044,9 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_absent_103
     trigger = null
   }: {
     duration: string,
-    aggregations?: Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_aggregations_1031[]|null,
+    aggregations?: Google_monitoring_alert_policy_conditions_173_condition_absent_174_aggregations_175[]|null,
     filter?: string|null,
-    trigger?: Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_trigger_1032[]|null
+    trigger?: Google_monitoring_alert_policy_conditions_173_condition_absent_174_trigger_176[]|null
   }) {
     this.duration = duration;
     this.aggregations = aggregations;
@@ -16070,11 +16070,11 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_absent_103
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_absent_1030';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_absent_174';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_aggregations_1031 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_absent_174_aggregations_175 implements PcoreValue {
   readonly alignment_period: string|null;
   readonly cross_series_reducer: string|null;
   readonly group_by_fields: string[]|null;
@@ -16115,11 +16115,11 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_absent_103
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_aggregations_1031';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_absent_174_aggregations_175';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_trigger_1032 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_absent_174_trigger_176 implements PcoreValue {
   readonly count: number|null;
   readonly percent: number|null;
 
@@ -16146,19 +16146,19 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_absent_103
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_absent_1030_trigger_1032';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_absent_174_trigger_176';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_threshold_177 implements PcoreValue {
   readonly comparison: string;
   readonly duration: string;
-  readonly aggregations: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_aggregations_1034[]|null;
-  readonly denominator_aggregations: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_denominator_aggregations_1035[]|null;
+  readonly aggregations: Google_monitoring_alert_policy_conditions_173_condition_threshold_177_aggregations_178[]|null;
+  readonly denominator_aggregations: Google_monitoring_alert_policy_conditions_173_condition_threshold_177_denominator_aggregations_179[]|null;
   readonly denominator_filter: string|null;
   readonly filter: string|null;
   readonly threshold_value: number|null;
-  readonly trigger: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_trigger_1036[]|null;
+  readonly trigger: Google_monitoring_alert_policy_conditions_173_condition_threshold_177_trigger_180[]|null;
 
   constructor({
     comparison,
@@ -16172,12 +16172,12 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_
   }: {
     comparison: string,
     duration: string,
-    aggregations?: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_aggregations_1034[]|null,
-    denominator_aggregations?: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_denominator_aggregations_1035[]|null,
+    aggregations?: Google_monitoring_alert_policy_conditions_173_condition_threshold_177_aggregations_178[]|null,
+    denominator_aggregations?: Google_monitoring_alert_policy_conditions_173_condition_threshold_177_denominator_aggregations_179[]|null,
     denominator_filter?: string|null,
     filter?: string|null,
     threshold_value?: number|null,
-    trigger?: Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_trigger_1036[]|null
+    trigger?: Google_monitoring_alert_policy_conditions_173_condition_threshold_177_trigger_180[]|null
   }) {
     this.comparison = comparison;
     this.duration = duration;
@@ -16215,11 +16215,11 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_threshold_177';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_aggregations_1034 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_threshold_177_aggregations_178 implements PcoreValue {
   readonly alignment_period: string|null;
   readonly cross_series_reducer: string|null;
   readonly group_by_fields: string[]|null;
@@ -16260,11 +16260,11 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_aggregations_1034';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_threshold_177_aggregations_178';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_denominator_aggregations_1035 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_threshold_177_denominator_aggregations_179 implements PcoreValue {
   readonly alignment_period: string|null;
   readonly cross_series_reducer: string|null;
   readonly group_by_fields: string[]|null;
@@ -16305,11 +16305,11 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_denominator_aggregations_1035';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_threshold_177_denominator_aggregations_179';
   }
 }
 
-export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_trigger_1036 implements PcoreValue {
+export class Google_monitoring_alert_policy_conditions_173_condition_threshold_177_trigger_180 implements PcoreValue {
   readonly count: number|null;
   readonly percent: number|null;
 
@@ -16336,11 +16336,11 @@ export class Google_monitoring_alert_policy_conditions_1029_condition_threshold_
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_1029_condition_threshold_1033_trigger_1036';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_conditions_173_condition_threshold_177_trigger_180';
   }
 }
 
-export class Google_monitoring_alert_policy_creation_record_1037 implements PcoreValue {
+export class Google_monitoring_alert_policy_creation_record_181 implements PcoreValue {
   readonly mutate_time: string|null;
   readonly mutated_by: string|null;
 
@@ -16367,7 +16367,7 @@ export class Google_monitoring_alert_policy_creation_record_1037 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_alert_policy_creation_record_1037';
+    return 'TerraformGoogle::Google_monitoring_alert_policy_creation_record_181';
   }
 }
 
@@ -16540,17 +16540,17 @@ export class Google_monitoring_uptime_check_config implements PcoreValue {
   readonly display_name: string;
   readonly timeout: string;
   readonly google_monitoring_uptime_check_config_id: string|null;
-  readonly content_matchers: Google_monitoring_uptime_check_config_content_matchers_1038[]|null;
-  readonly http_check: Google_monitoring_uptime_check_config_http_check_1039[]|null;
-  readonly internal_checkers: Google_monitoring_uptime_check_config_internal_checkers_1041[]|null;
+  readonly content_matchers: Google_monitoring_uptime_check_config_content_matchers_182[]|null;
+  readonly http_check: Google_monitoring_uptime_check_config_http_check_183[]|null;
+  readonly internal_checkers: Google_monitoring_uptime_check_config_internal_checkers_185[]|null;
   readonly is_internal: boolean|null;
-  readonly monitored_resource: Google_monitoring_uptime_check_config_monitored_resource_1042[]|null;
+  readonly monitored_resource: Google_monitoring_uptime_check_config_monitored_resource_186[]|null;
   readonly name: string|null;
   readonly period: string|null;
   readonly project: string|null;
-  readonly resource_group: Google_monitoring_uptime_check_config_resource_group_1043[]|null;
+  readonly resource_group: Google_monitoring_uptime_check_config_resource_group_187[]|null;
   readonly selected_regions: string[]|null;
-  readonly tcp_check: Google_monitoring_uptime_check_config_tcp_check_1044[]|null;
+  readonly tcp_check: Google_monitoring_uptime_check_config_tcp_check_188[]|null;
 
   constructor({
     display_name,
@@ -16571,17 +16571,17 @@ export class Google_monitoring_uptime_check_config implements PcoreValue {
     display_name: string,
     timeout: string,
     google_monitoring_uptime_check_config_id?: string|null,
-    content_matchers?: Google_monitoring_uptime_check_config_content_matchers_1038[]|null,
-    http_check?: Google_monitoring_uptime_check_config_http_check_1039[]|null,
-    internal_checkers?: Google_monitoring_uptime_check_config_internal_checkers_1041[]|null,
+    content_matchers?: Google_monitoring_uptime_check_config_content_matchers_182[]|null,
+    http_check?: Google_monitoring_uptime_check_config_http_check_183[]|null,
+    internal_checkers?: Google_monitoring_uptime_check_config_internal_checkers_185[]|null,
     is_internal?: boolean|null,
-    monitored_resource?: Google_monitoring_uptime_check_config_monitored_resource_1042[]|null,
+    monitored_resource?: Google_monitoring_uptime_check_config_monitored_resource_186[]|null,
     name?: string|null,
     period?: string|null,
     project?: string|null,
-    resource_group?: Google_monitoring_uptime_check_config_resource_group_1043[]|null,
+    resource_group?: Google_monitoring_uptime_check_config_resource_group_187[]|null,
     selected_regions?: string[]|null,
-    tcp_check?: Google_monitoring_uptime_check_config_tcp_check_1044[]|null
+    tcp_check?: Google_monitoring_uptime_check_config_tcp_check_188[]|null
   }) {
     this.display_name = display_name;
     this.timeout = timeout;
@@ -16657,7 +16657,7 @@ export class Google_monitoring_uptime_check_configHandler implements PcoreValue 
   }
 }
 
-export class Google_monitoring_uptime_check_config_content_matchers_1038 implements PcoreValue {
+export class Google_monitoring_uptime_check_config_content_matchers_182 implements PcoreValue {
   readonly content: string|null;
 
   constructor({
@@ -16677,12 +16677,12 @@ export class Google_monitoring_uptime_check_config_content_matchers_1038 impleme
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_content_matchers_1038';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_content_matchers_182';
   }
 }
 
-export class Google_monitoring_uptime_check_config_http_check_1039 implements PcoreValue {
-  readonly auth_info: Google_monitoring_uptime_check_config_http_check_1039_auth_info_1040[]|null;
+export class Google_monitoring_uptime_check_config_http_check_183 implements PcoreValue {
+  readonly auth_info: Google_monitoring_uptime_check_config_http_check_183_auth_info_184[]|null;
   readonly headers: {[s: string]: string}|null;
   readonly mask_headers: boolean|null;
   readonly path: string|null;
@@ -16697,7 +16697,7 @@ export class Google_monitoring_uptime_check_config_http_check_1039 implements Pc
     port = null,
     use_ssl = null
   }: {
-    auth_info?: Google_monitoring_uptime_check_config_http_check_1039_auth_info_1040[]|null,
+    auth_info?: Google_monitoring_uptime_check_config_http_check_183_auth_info_184[]|null,
     headers?: {[s: string]: string}|null,
     mask_headers?: boolean|null,
     path?: string|null,
@@ -16736,11 +16736,11 @@ export class Google_monitoring_uptime_check_config_http_check_1039 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_http_check_1039';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_http_check_183';
   }
 }
 
-export class Google_monitoring_uptime_check_config_http_check_1039_auth_info_1040 implements PcoreValue {
+export class Google_monitoring_uptime_check_config_http_check_183_auth_info_184 implements PcoreValue {
   readonly password: string|null;
   readonly username: string|null;
 
@@ -16767,11 +16767,11 @@ export class Google_monitoring_uptime_check_config_http_check_1039_auth_info_104
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_http_check_1039_auth_info_1040';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_http_check_183_auth_info_184';
   }
 }
 
-export class Google_monitoring_uptime_check_config_internal_checkers_1041 implements PcoreValue {
+export class Google_monitoring_uptime_check_config_internal_checkers_185 implements PcoreValue {
   readonly display_name: string|null;
   readonly gcp_zone: string|null;
   readonly name: string|null;
@@ -16819,11 +16819,11 @@ export class Google_monitoring_uptime_check_config_internal_checkers_1041 implem
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_internal_checkers_1041';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_internal_checkers_185';
   }
 }
 
-export class Google_monitoring_uptime_check_config_monitored_resource_1042 implements PcoreValue {
+export class Google_monitoring_uptime_check_config_monitored_resource_186 implements PcoreValue {
   readonly labels: {[s: string]: string};
   readonly type: string;
 
@@ -16846,11 +16846,11 @@ export class Google_monitoring_uptime_check_config_monitored_resource_1042 imple
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_monitored_resource_1042';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_monitored_resource_186';
   }
 }
 
-export class Google_monitoring_uptime_check_config_resource_group_1043 implements PcoreValue {
+export class Google_monitoring_uptime_check_config_resource_group_187 implements PcoreValue {
   readonly group_id: string|null;
   readonly resource_type: string|null;
 
@@ -16877,11 +16877,11 @@ export class Google_monitoring_uptime_check_config_resource_group_1043 implement
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_resource_group_1043';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_resource_group_187';
   }
 }
 
-export class Google_monitoring_uptime_check_config_tcp_check_1044 implements PcoreValue {
+export class Google_monitoring_uptime_check_config_tcp_check_188 implements PcoreValue {
   readonly port: number;
 
   constructor({
@@ -16899,7 +16899,7 @@ export class Google_monitoring_uptime_check_config_tcp_check_1044 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_monitoring_uptime_check_config_tcp_check_1044';
+    return 'TerraformGoogle::Google_monitoring_uptime_check_config_tcp_check_188';
   }
 }
 
@@ -17145,10 +17145,10 @@ export class Google_organization_policy implements PcoreValue {
   readonly constraint: string;
   readonly org_id: string;
   readonly google_organization_policy_id: string|null;
-  readonly boolean_policy: Google_organization_policy_boolean_policy_1045[]|null;
+  readonly boolean_policy: Google_organization_policy_boolean_policy_189[]|null;
   readonly etag: string|null;
-  readonly list_policy: Google_organization_policy_list_policy_1046[]|null;
-  readonly restore_policy: Google_organization_policy_restore_policy_1049[]|null;
+  readonly list_policy: Google_organization_policy_list_policy_190[]|null;
+  readonly restore_policy: Google_organization_policy_restore_policy_193[]|null;
   readonly update_time: string|null;
   readonly version: number|null;
 
@@ -17166,10 +17166,10 @@ export class Google_organization_policy implements PcoreValue {
     constraint: string,
     org_id: string,
     google_organization_policy_id?: string|null,
-    boolean_policy?: Google_organization_policy_boolean_policy_1045[]|null,
+    boolean_policy?: Google_organization_policy_boolean_policy_189[]|null,
     etag?: string|null,
-    list_policy?: Google_organization_policy_list_policy_1046[]|null,
-    restore_policy?: Google_organization_policy_restore_policy_1049[]|null,
+    list_policy?: Google_organization_policy_list_policy_190[]|null,
+    restore_policy?: Google_organization_policy_restore_policy_193[]|null,
     update_time?: string|null,
     version?: number|null
   }) {
@@ -17227,7 +17227,7 @@ export class Google_organization_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_organization_policy_boolean_policy_1045 implements PcoreValue {
+export class Google_organization_policy_boolean_policy_189 implements PcoreValue {
   readonly enforced: boolean;
 
   constructor({
@@ -17245,13 +17245,13 @@ export class Google_organization_policy_boolean_policy_1045 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_organization_policy_boolean_policy_1045';
+    return 'TerraformGoogle::Google_organization_policy_boolean_policy_189';
   }
 }
 
-export class Google_organization_policy_list_policy_1046 implements PcoreValue {
-  readonly allow: Google_organization_policy_list_policy_1046_allow_1047[]|null;
-  readonly deny: Google_organization_policy_list_policy_1046_deny_1048[]|null;
+export class Google_organization_policy_list_policy_190 implements PcoreValue {
+  readonly allow: Google_organization_policy_list_policy_190_allow_191[]|null;
+  readonly deny: Google_organization_policy_list_policy_190_deny_192[]|null;
   readonly suggested_value: string|null;
 
   constructor({
@@ -17259,8 +17259,8 @@ export class Google_organization_policy_list_policy_1046 implements PcoreValue {
     deny = null,
     suggested_value = null
   }: {
-    allow?: Google_organization_policy_list_policy_1046_allow_1047[]|null,
-    deny?: Google_organization_policy_list_policy_1046_deny_1048[]|null,
+    allow?: Google_organization_policy_list_policy_190_allow_191[]|null,
+    deny?: Google_organization_policy_list_policy_190_deny_192[]|null,
     suggested_value?: string|null
   }) {
     this.allow = allow;
@@ -17283,11 +17283,11 @@ export class Google_organization_policy_list_policy_1046 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_organization_policy_list_policy_1046';
+    return 'TerraformGoogle::Google_organization_policy_list_policy_190';
   }
 }
 
-export class Google_organization_policy_list_policy_1046_allow_1047 implements PcoreValue {
+export class Google_organization_policy_list_policy_190_allow_191 implements PcoreValue {
   readonly all: boolean|null;
   readonly values: string[]|null;
 
@@ -17314,11 +17314,11 @@ export class Google_organization_policy_list_policy_1046_allow_1047 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_organization_policy_list_policy_1046_allow_1047';
+    return 'TerraformGoogle::Google_organization_policy_list_policy_190_allow_191';
   }
 }
 
-export class Google_organization_policy_list_policy_1046_deny_1048 implements PcoreValue {
+export class Google_organization_policy_list_policy_190_deny_192 implements PcoreValue {
   readonly all: boolean|null;
   readonly values: string[]|null;
 
@@ -17345,11 +17345,11 @@ export class Google_organization_policy_list_policy_1046_deny_1048 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_organization_policy_list_policy_1046_deny_1048';
+    return 'TerraformGoogle::Google_organization_policy_list_policy_190_deny_192';
   }
 }
 
-export class Google_organization_policy_restore_policy_1049 implements PcoreValue {
+export class Google_organization_policy_restore_policy_193 implements PcoreValue {
   readonly default_: boolean;
 
   constructor({
@@ -17367,7 +17367,7 @@ export class Google_organization_policy_restore_policy_1049 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_organization_policy_restore_policy_1049';
+    return 'TerraformGoogle::Google_organization_policy_restore_policy_193';
   }
 }
 
@@ -17375,7 +17375,7 @@ export class Google_project implements PcoreValue {
   readonly name: string;
   readonly project_id: string;
   readonly google_project_id: string|null;
-  readonly app_engine: Google_project_app_engine_1050[]|null;
+  readonly app_engine: Google_project_app_engine_194[]|null;
   readonly auto_create_network: boolean|null;
   readonly billing_account: string|null;
   readonly folder_id: string|null;
@@ -17404,7 +17404,7 @@ export class Google_project implements PcoreValue {
     name: string,
     project_id: string,
     google_project_id?: string|null,
-    app_engine?: Google_project_app_engine_1050[]|null,
+    app_engine?: Google_project_app_engine_194[]|null,
     auto_create_network?: boolean|null,
     billing_account?: string|null,
     folder_id?: string|null,
@@ -17485,17 +17485,17 @@ export class Google_projectHandler implements PcoreValue {
   }
 }
 
-export class Google_project_app_engine_1050 implements PcoreValue {
+export class Google_project_app_engine_194 implements PcoreValue {
   readonly auth_domain: string|null;
   readonly code_bucket: string|null;
   readonly default_bucket: string|null;
   readonly default_hostname: string|null;
-  readonly feature_settings: Google_project_app_engine_1050_feature_settings_1051[]|null;
+  readonly feature_settings: Google_project_app_engine_194_feature_settings_195[]|null;
   readonly gcr_domain: string|null;
   readonly location_id: string|null;
   readonly name: string|null;
   readonly serving_status: string|null;
-  readonly url_dispatch_rule: Google_project_app_engine_1050_url_dispatch_rule_1052[]|null;
+  readonly url_dispatch_rule: Google_project_app_engine_194_url_dispatch_rule_196[]|null;
 
   constructor({
     auth_domain = null,
@@ -17513,12 +17513,12 @@ export class Google_project_app_engine_1050 implements PcoreValue {
     code_bucket?: string|null,
     default_bucket?: string|null,
     default_hostname?: string|null,
-    feature_settings?: Google_project_app_engine_1050_feature_settings_1051[]|null,
+    feature_settings?: Google_project_app_engine_194_feature_settings_195[]|null,
     gcr_domain?: string|null,
     location_id?: string|null,
     name?: string|null,
     serving_status?: string|null,
-    url_dispatch_rule?: Google_project_app_engine_1050_url_dispatch_rule_1052[]|null
+    url_dispatch_rule?: Google_project_app_engine_194_url_dispatch_rule_196[]|null
   }) {
     this.auth_domain = auth_domain;
     this.code_bucket = code_bucket;
@@ -17568,11 +17568,11 @@ export class Google_project_app_engine_1050 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_app_engine_1050';
+    return 'TerraformGoogle::Google_project_app_engine_194';
   }
 }
 
-export class Google_project_app_engine_1050_feature_settings_1051 implements PcoreValue {
+export class Google_project_app_engine_194_feature_settings_195 implements PcoreValue {
   readonly split_health_checks: boolean|null;
 
   constructor({
@@ -17592,11 +17592,11 @@ export class Google_project_app_engine_1050_feature_settings_1051 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_app_engine_1050_feature_settings_1051';
+    return 'TerraformGoogle::Google_project_app_engine_194_feature_settings_195';
   }
 }
 
-export class Google_project_app_engine_1050_url_dispatch_rule_1052 implements PcoreValue {
+export class Google_project_app_engine_194_url_dispatch_rule_196 implements PcoreValue {
   readonly domain: string|null;
   readonly path: string|null;
   readonly service: string|null;
@@ -17630,7 +17630,7 @@ export class Google_project_app_engine_1050_url_dispatch_rule_1052 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_app_engine_1050_url_dispatch_rule_1052';
+    return 'TerraformGoogle::Google_project_app_engine_194_url_dispatch_rule_196';
   }
 }
 
@@ -17905,10 +17905,10 @@ export class Google_project_organization_policy implements PcoreValue {
   readonly constraint: string;
   readonly project: string;
   readonly google_project_organization_policy_id: string|null;
-  readonly boolean_policy: Google_project_organization_policy_boolean_policy_1053[]|null;
+  readonly boolean_policy: Google_project_organization_policy_boolean_policy_197[]|null;
   readonly etag: string|null;
-  readonly list_policy: Google_project_organization_policy_list_policy_1054[]|null;
-  readonly restore_policy: Google_project_organization_policy_restore_policy_1057[]|null;
+  readonly list_policy: Google_project_organization_policy_list_policy_198[]|null;
+  readonly restore_policy: Google_project_organization_policy_restore_policy_201[]|null;
   readonly update_time: string|null;
   readonly version: number|null;
 
@@ -17926,10 +17926,10 @@ export class Google_project_organization_policy implements PcoreValue {
     constraint: string,
     project: string,
     google_project_organization_policy_id?: string|null,
-    boolean_policy?: Google_project_organization_policy_boolean_policy_1053[]|null,
+    boolean_policy?: Google_project_organization_policy_boolean_policy_197[]|null,
     etag?: string|null,
-    list_policy?: Google_project_organization_policy_list_policy_1054[]|null,
-    restore_policy?: Google_project_organization_policy_restore_policy_1057[]|null,
+    list_policy?: Google_project_organization_policy_list_policy_198[]|null,
+    restore_policy?: Google_project_organization_policy_restore_policy_201[]|null,
     update_time?: string|null,
     version?: number|null
   }) {
@@ -17987,7 +17987,7 @@ export class Google_project_organization_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_project_organization_policy_boolean_policy_1053 implements PcoreValue {
+export class Google_project_organization_policy_boolean_policy_197 implements PcoreValue {
   readonly enforced: boolean;
 
   constructor({
@@ -18005,13 +18005,13 @@ export class Google_project_organization_policy_boolean_policy_1053 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_organization_policy_boolean_policy_1053';
+    return 'TerraformGoogle::Google_project_organization_policy_boolean_policy_197';
   }
 }
 
-export class Google_project_organization_policy_list_policy_1054 implements PcoreValue {
-  readonly allow: Google_project_organization_policy_list_policy_1054_allow_1055[]|null;
-  readonly deny: Google_project_organization_policy_list_policy_1054_deny_1056[]|null;
+export class Google_project_organization_policy_list_policy_198 implements PcoreValue {
+  readonly allow: Google_project_organization_policy_list_policy_198_allow_199[]|null;
+  readonly deny: Google_project_organization_policy_list_policy_198_deny_200[]|null;
   readonly suggested_value: string|null;
 
   constructor({
@@ -18019,8 +18019,8 @@ export class Google_project_organization_policy_list_policy_1054 implements Pcor
     deny = null,
     suggested_value = null
   }: {
-    allow?: Google_project_organization_policy_list_policy_1054_allow_1055[]|null,
-    deny?: Google_project_organization_policy_list_policy_1054_deny_1056[]|null,
+    allow?: Google_project_organization_policy_list_policy_198_allow_199[]|null,
+    deny?: Google_project_organization_policy_list_policy_198_deny_200[]|null,
     suggested_value?: string|null
   }) {
     this.allow = allow;
@@ -18043,11 +18043,11 @@ export class Google_project_organization_policy_list_policy_1054 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_organization_policy_list_policy_1054';
+    return 'TerraformGoogle::Google_project_organization_policy_list_policy_198';
   }
 }
 
-export class Google_project_organization_policy_list_policy_1054_allow_1055 implements PcoreValue {
+export class Google_project_organization_policy_list_policy_198_allow_199 implements PcoreValue {
   readonly all: boolean|null;
   readonly values: string[]|null;
 
@@ -18074,11 +18074,11 @@ export class Google_project_organization_policy_list_policy_1054_allow_1055 impl
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_organization_policy_list_policy_1054_allow_1055';
+    return 'TerraformGoogle::Google_project_organization_policy_list_policy_198_allow_199';
   }
 }
 
-export class Google_project_organization_policy_list_policy_1054_deny_1056 implements PcoreValue {
+export class Google_project_organization_policy_list_policy_198_deny_200 implements PcoreValue {
   readonly all: boolean|null;
   readonly values: string[]|null;
 
@@ -18105,11 +18105,11 @@ export class Google_project_organization_policy_list_policy_1054_deny_1056 imple
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_organization_policy_list_policy_1054_deny_1056';
+    return 'TerraformGoogle::Google_project_organization_policy_list_policy_198_deny_200';
   }
 }
 
-export class Google_project_organization_policy_restore_policy_1057 implements PcoreValue {
+export class Google_project_organization_policy_restore_policy_201 implements PcoreValue {
   readonly default_: boolean;
 
   constructor({
@@ -18127,7 +18127,7 @@ export class Google_project_organization_policy_restore_policy_1057 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_project_organization_policy_restore_policy_1057';
+    return 'TerraformGoogle::Google_project_organization_policy_restore_policy_201';
   }
 }
 
@@ -18297,7 +18297,7 @@ export class Google_pubsub_subscription implements PcoreValue {
   readonly ack_deadline_seconds: number|null;
   readonly path: string|null;
   readonly project: string|null;
-  readonly push_config: Google_pubsub_subscription_push_config_1058[]|null;
+  readonly push_config: Google_pubsub_subscription_push_config_202[]|null;
 
   constructor({
     name,
@@ -18314,7 +18314,7 @@ export class Google_pubsub_subscription implements PcoreValue {
     ack_deadline_seconds?: number|null,
     path?: string|null,
     project?: string|null,
-    push_config?: Google_pubsub_subscription_push_config_1058[]|null
+    push_config?: Google_pubsub_subscription_push_config_202[]|null
   }) {
     this.name = name;
     this.topic = topic;
@@ -18546,7 +18546,7 @@ export class Google_pubsub_subscription_iam_policyHandler implements PcoreValue 
   }
 }
 
-export class Google_pubsub_subscription_push_config_1058 implements PcoreValue {
+export class Google_pubsub_subscription_push_config_202 implements PcoreValue {
   readonly push_endpoint: string;
   readonly attributes: {[s: string]: string}|null;
 
@@ -18571,7 +18571,7 @@ export class Google_pubsub_subscription_push_config_1058 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_pubsub_subscription_push_config_1058';
+    return 'TerraformGoogle::Google_pubsub_subscription_push_config_202';
   }
 }
 
@@ -20167,19 +20167,19 @@ export class Google_sql_databaseHandler implements PcoreValue {
 }
 
 export class Google_sql_database_instance implements PcoreValue {
-  readonly settings: Google_sql_database_instance_settings_1062[];
+  readonly settings: Google_sql_database_instance_settings_206[];
   readonly google_sql_database_instance_id: string|null;
   readonly connection_name: string|null;
   readonly database_version: string|null;
   readonly first_ip_address: string|null;
-  readonly ip_address: Google_sql_database_instance_ip_address_1059[]|null;
+  readonly ip_address: Google_sql_database_instance_ip_address_203[]|null;
   readonly master_instance_name: string|null;
   readonly name: string|null;
   readonly project: string|null;
   readonly region: string|null;
-  readonly replica_configuration: Google_sql_database_instance_replica_configuration_1060[]|null;
+  readonly replica_configuration: Google_sql_database_instance_replica_configuration_204[]|null;
   readonly self_link: string|null;
-  readonly server_ca_cert: Google_sql_database_instance_server_ca_cert_1061[]|null;
+  readonly server_ca_cert: Google_sql_database_instance_server_ca_cert_205[]|null;
   readonly service_account_email_address: string|null;
 
   constructor({
@@ -20198,19 +20198,19 @@ export class Google_sql_database_instance implements PcoreValue {
     server_ca_cert = null,
     service_account_email_address = null
   }: {
-    settings: Google_sql_database_instance_settings_1062[],
+    settings: Google_sql_database_instance_settings_206[],
     google_sql_database_instance_id?: string|null,
     connection_name?: string|null,
     database_version?: string|null,
     first_ip_address?: string|null,
-    ip_address?: Google_sql_database_instance_ip_address_1059[]|null,
+    ip_address?: Google_sql_database_instance_ip_address_203[]|null,
     master_instance_name?: string|null,
     name?: string|null,
     project?: string|null,
     region?: string|null,
-    replica_configuration?: Google_sql_database_instance_replica_configuration_1060[]|null,
+    replica_configuration?: Google_sql_database_instance_replica_configuration_204[]|null,
     self_link?: string|null,
-    server_ca_cert?: Google_sql_database_instance_server_ca_cert_1061[]|null,
+    server_ca_cert?: Google_sql_database_instance_server_ca_cert_205[]|null,
     service_account_email_address?: string|null
   }) {
     this.settings = settings;
@@ -20289,7 +20289,7 @@ export class Google_sql_database_instanceHandler implements PcoreValue {
   }
 }
 
-export class Google_sql_database_instance_ip_address_1059 implements PcoreValue {
+export class Google_sql_database_instance_ip_address_203 implements PcoreValue {
   readonly ip_address: string|null;
   readonly time_to_retire: string|null;
 
@@ -20316,11 +20316,11 @@ export class Google_sql_database_instance_ip_address_1059 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_ip_address_1059';
+    return 'TerraformGoogle::Google_sql_database_instance_ip_address_203';
   }
 }
 
-export class Google_sql_database_instance_replica_configuration_1060 implements PcoreValue {
+export class Google_sql_database_instance_replica_configuration_204 implements PcoreValue {
   readonly ca_certificate: string|null;
   readonly client_certificate: string|null;
   readonly client_key: string|null;
@@ -20410,11 +20410,11 @@ export class Google_sql_database_instance_replica_configuration_1060 implements 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_replica_configuration_1060';
+    return 'TerraformGoogle::Google_sql_database_instance_replica_configuration_204';
   }
 }
 
-export class Google_sql_database_instance_server_ca_cert_1061 implements PcoreValue {
+export class Google_sql_database_instance_server_ca_cert_205 implements PcoreValue {
   readonly cert: string|null;
   readonly common_name: string|null;
   readonly create_time: string|null;
@@ -20462,24 +20462,24 @@ export class Google_sql_database_instance_server_ca_cert_1061 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_server_ca_cert_1061';
+    return 'TerraformGoogle::Google_sql_database_instance_server_ca_cert_205';
   }
 }
 
-export class Google_sql_database_instance_settings_1062 implements PcoreValue {
+export class Google_sql_database_instance_settings_206 implements PcoreValue {
   readonly tier: string;
   readonly activation_policy: string|null;
   readonly authorized_gae_applications: string[]|null;
   readonly availability_type: string|null;
-  readonly backup_configuration: Google_sql_database_instance_settings_1062_backup_configuration_1063[]|null;
+  readonly backup_configuration: Google_sql_database_instance_settings_206_backup_configuration_207[]|null;
   readonly crash_safe_replication: boolean|null;
-  readonly database_flags: Google_sql_database_instance_settings_1062_database_flags_1064[]|null;
+  readonly database_flags: Google_sql_database_instance_settings_206_database_flags_208[]|null;
   readonly disk_autoresize: boolean|null;
   readonly disk_size: number|null;
   readonly disk_type: string|null;
-  readonly ip_configuration: Google_sql_database_instance_settings_1062_ip_configuration_1065[]|null;
-  readonly location_preference: Google_sql_database_instance_settings_1062_location_preference_1067[]|null;
-  readonly maintenance_window: Google_sql_database_instance_settings_1062_maintenance_window_1068[]|null;
+  readonly ip_configuration: Google_sql_database_instance_settings_206_ip_configuration_209[]|null;
+  readonly location_preference: Google_sql_database_instance_settings_206_location_preference_211[]|null;
+  readonly maintenance_window: Google_sql_database_instance_settings_206_maintenance_window_212[]|null;
   readonly pricing_plan: string|null;
   readonly replication_type: string|null;
   readonly user_labels: {[s: string]: string}|null;
@@ -20508,15 +20508,15 @@ export class Google_sql_database_instance_settings_1062 implements PcoreValue {
     activation_policy?: string|null,
     authorized_gae_applications?: string[]|null,
     availability_type?: string|null,
-    backup_configuration?: Google_sql_database_instance_settings_1062_backup_configuration_1063[]|null,
+    backup_configuration?: Google_sql_database_instance_settings_206_backup_configuration_207[]|null,
     crash_safe_replication?: boolean|null,
-    database_flags?: Google_sql_database_instance_settings_1062_database_flags_1064[]|null,
+    database_flags?: Google_sql_database_instance_settings_206_database_flags_208[]|null,
     disk_autoresize?: boolean|null,
     disk_size?: number|null,
     disk_type?: string|null,
-    ip_configuration?: Google_sql_database_instance_settings_1062_ip_configuration_1065[]|null,
-    location_preference?: Google_sql_database_instance_settings_1062_location_preference_1067[]|null,
-    maintenance_window?: Google_sql_database_instance_settings_1062_maintenance_window_1068[]|null,
+    ip_configuration?: Google_sql_database_instance_settings_206_ip_configuration_209[]|null,
+    location_preference?: Google_sql_database_instance_settings_206_location_preference_211[]|null,
+    maintenance_window?: Google_sql_database_instance_settings_206_maintenance_window_212[]|null,
     pricing_plan?: string|null,
     replication_type?: string|null,
     user_labels?: {[s: string]: string}|null,
@@ -20596,11 +20596,11 @@ export class Google_sql_database_instance_settings_1062 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206';
   }
 }
 
-export class Google_sql_database_instance_settings_1062_backup_configuration_1063 implements PcoreValue {
+export class Google_sql_database_instance_settings_206_backup_configuration_207 implements PcoreValue {
   readonly binary_log_enabled: boolean|null;
   readonly enabled: boolean|null;
   readonly start_time: string|null;
@@ -20634,11 +20634,11 @@ export class Google_sql_database_instance_settings_1062_backup_configuration_106
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062_backup_configuration_1063';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206_backup_configuration_207';
   }
 }
 
-export class Google_sql_database_instance_settings_1062_database_flags_1064 implements PcoreValue {
+export class Google_sql_database_instance_settings_206_database_flags_208 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -20665,12 +20665,12 @@ export class Google_sql_database_instance_settings_1062_database_flags_1064 impl
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062_database_flags_1064';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206_database_flags_208';
   }
 }
 
-export class Google_sql_database_instance_settings_1062_ip_configuration_1065 implements PcoreValue {
-  readonly authorized_networks: Google_sql_database_instance_settings_1062_ip_configuration_1065_authorized_networks_1066[]|null;
+export class Google_sql_database_instance_settings_206_ip_configuration_209 implements PcoreValue {
+  readonly authorized_networks: Google_sql_database_instance_settings_206_ip_configuration_209_authorized_networks_210[]|null;
   readonly ipv4_enabled: boolean|null;
   readonly private_network: string|null;
   readonly require_ssl: boolean|null;
@@ -20681,7 +20681,7 @@ export class Google_sql_database_instance_settings_1062_ip_configuration_1065 im
     private_network = null,
     require_ssl = null
   }: {
-    authorized_networks?: Google_sql_database_instance_settings_1062_ip_configuration_1065_authorized_networks_1066[]|null,
+    authorized_networks?: Google_sql_database_instance_settings_206_ip_configuration_209_authorized_networks_210[]|null,
     ipv4_enabled?: boolean|null,
     private_network?: string|null,
     require_ssl?: boolean|null
@@ -20710,11 +20710,11 @@ export class Google_sql_database_instance_settings_1062_ip_configuration_1065 im
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062_ip_configuration_1065';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206_ip_configuration_209';
   }
 }
 
-export class Google_sql_database_instance_settings_1062_ip_configuration_1065_authorized_networks_1066 implements PcoreValue {
+export class Google_sql_database_instance_settings_206_ip_configuration_209_authorized_networks_210 implements PcoreValue {
   readonly expiration_time: string|null;
   readonly name: string|null;
   readonly value: string|null;
@@ -20748,11 +20748,11 @@ export class Google_sql_database_instance_settings_1062_ip_configuration_1065_au
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062_ip_configuration_1065_authorized_networks_1066';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206_ip_configuration_209_authorized_networks_210';
   }
 }
 
-export class Google_sql_database_instance_settings_1062_location_preference_1067 implements PcoreValue {
+export class Google_sql_database_instance_settings_206_location_preference_211 implements PcoreValue {
   readonly follow_gae_application: string|null;
   readonly zone: string|null;
 
@@ -20779,11 +20779,11 @@ export class Google_sql_database_instance_settings_1062_location_preference_1067
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062_location_preference_1067';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206_location_preference_211';
   }
 }
 
-export class Google_sql_database_instance_settings_1062_maintenance_window_1068 implements PcoreValue {
+export class Google_sql_database_instance_settings_206_maintenance_window_212 implements PcoreValue {
   readonly day: number|null;
   readonly hour: number|null;
   readonly update_track: string|null;
@@ -20817,7 +20817,7 @@ export class Google_sql_database_instance_settings_1062_maintenance_window_1068 
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_sql_database_instance_settings_1062_maintenance_window_1068';
+    return 'TerraformGoogle::Google_sql_database_instance_settings_206_maintenance_window_212';
   }
 }
 
@@ -20982,20 +20982,20 @@ export class Google_sql_userHandler implements PcoreValue {
 export class Google_storage_bucket implements PcoreValue {
   readonly name: string;
   readonly google_storage_bucket_id: string|null;
-  readonly cors: Google_storage_bucket_cors_1069[]|null;
-  readonly encryption: Google_storage_bucket_encryption_1070[]|null;
+  readonly cors: Google_storage_bucket_cors_213[]|null;
+  readonly encryption: Google_storage_bucket_encryption_214[]|null;
   readonly force_destroy: boolean|null;
   readonly labels: {[s: string]: string}|null;
-  readonly lifecycle_rule: Google_storage_bucket_lifecycle_rule_1071[]|null;
+  readonly lifecycle_rule: Google_storage_bucket_lifecycle_rule_215[]|null;
   readonly location: string|null;
-  readonly logging: Google_storage_bucket_logging_1074[]|null;
+  readonly logging: Google_storage_bucket_logging_218[]|null;
   readonly predefined_acl: string|null;
   readonly project: string|null;
   readonly self_link: string|null;
   readonly storage_class: string|null;
   readonly url: string|null;
-  readonly versioning: Google_storage_bucket_versioning_1075[]|null;
-  readonly website: Google_storage_bucket_website_1076[]|null;
+  readonly versioning: Google_storage_bucket_versioning_219[]|null;
+  readonly website: Google_storage_bucket_website_220[]|null;
 
   constructor({
     name,
@@ -21017,20 +21017,20 @@ export class Google_storage_bucket implements PcoreValue {
   }: {
     name: string,
     google_storage_bucket_id?: string|null,
-    cors?: Google_storage_bucket_cors_1069[]|null,
-    encryption?: Google_storage_bucket_encryption_1070[]|null,
+    cors?: Google_storage_bucket_cors_213[]|null,
+    encryption?: Google_storage_bucket_encryption_214[]|null,
     force_destroy?: boolean|null,
     labels?: {[s: string]: string}|null,
-    lifecycle_rule?: Google_storage_bucket_lifecycle_rule_1071[]|null,
+    lifecycle_rule?: Google_storage_bucket_lifecycle_rule_215[]|null,
     location?: string|null,
-    logging?: Google_storage_bucket_logging_1074[]|null,
+    logging?: Google_storage_bucket_logging_218[]|null,
     predefined_acl?: string|null,
     project?: string|null,
     self_link?: string|null,
     storage_class?: string|null,
     url?: string|null,
-    versioning?: Google_storage_bucket_versioning_1075[]|null,
-    website?: Google_storage_bucket_website_1076[]|null
+    versioning?: Google_storage_bucket_versioning_219[]|null,
+    website?: Google_storage_bucket_website_220[]|null
   }) {
     this.name = name;
     this.google_storage_bucket_id = google_storage_bucket_id;
@@ -21176,7 +21176,7 @@ export class Google_storage_bucket_aclHandler implements PcoreValue {
   }
 }
 
-export class Google_storage_bucket_cors_1069 implements PcoreValue {
+export class Google_storage_bucket_cors_213 implements PcoreValue {
   readonly max_age_seconds: number|null;
   readonly method: string[]|null;
   readonly origin: string[]|null;
@@ -21217,11 +21217,11 @@ export class Google_storage_bucket_cors_1069 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_cors_1069';
+    return 'TerraformGoogle::Google_storage_bucket_cors_213';
   }
 }
 
-export class Google_storage_bucket_encryption_1070 implements PcoreValue {
+export class Google_storage_bucket_encryption_214 implements PcoreValue {
   readonly default_kms_key_name: string;
 
   constructor({
@@ -21239,7 +21239,7 @@ export class Google_storage_bucket_encryption_1070 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_encryption_1070';
+    return 'TerraformGoogle::Google_storage_bucket_encryption_214';
   }
 }
 
@@ -21406,16 +21406,16 @@ export class Google_storage_bucket_iam_policyHandler implements PcoreValue {
   }
 }
 
-export class Google_storage_bucket_lifecycle_rule_1071 implements PcoreValue {
-  readonly action: Google_storage_bucket_lifecycle_rule_1071_action_1072[];
-  readonly condition: Google_storage_bucket_lifecycle_rule_1071_condition_1073[];
+export class Google_storage_bucket_lifecycle_rule_215 implements PcoreValue {
+  readonly action: Google_storage_bucket_lifecycle_rule_215_action_216[];
+  readonly condition: Google_storage_bucket_lifecycle_rule_215_condition_217[];
 
   constructor({
     action,
     condition
   }: {
-    action: Google_storage_bucket_lifecycle_rule_1071_action_1072[],
-    condition: Google_storage_bucket_lifecycle_rule_1071_condition_1073[]
+    action: Google_storage_bucket_lifecycle_rule_215_action_216[],
+    condition: Google_storage_bucket_lifecycle_rule_215_condition_217[]
   }) {
     this.action = action;
     this.condition = condition;
@@ -21429,11 +21429,11 @@ export class Google_storage_bucket_lifecycle_rule_1071 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_lifecycle_rule_1071';
+    return 'TerraformGoogle::Google_storage_bucket_lifecycle_rule_215';
   }
 }
 
-export class Google_storage_bucket_lifecycle_rule_1071_action_1072 implements PcoreValue {
+export class Google_storage_bucket_lifecycle_rule_215_action_216 implements PcoreValue {
   readonly type: string;
   readonly storage_class: string|null;
 
@@ -21458,11 +21458,11 @@ export class Google_storage_bucket_lifecycle_rule_1071_action_1072 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_lifecycle_rule_1071_action_1072';
+    return 'TerraformGoogle::Google_storage_bucket_lifecycle_rule_215_action_216';
   }
 }
 
-export class Google_storage_bucket_lifecycle_rule_1071_condition_1073 implements PcoreValue {
+export class Google_storage_bucket_lifecycle_rule_215_condition_217 implements PcoreValue {
   readonly age: number|null;
   readonly created_before: string|null;
   readonly is_live: boolean|null;
@@ -21510,11 +21510,11 @@ export class Google_storage_bucket_lifecycle_rule_1071_condition_1073 implements
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_lifecycle_rule_1071_condition_1073';
+    return 'TerraformGoogle::Google_storage_bucket_lifecycle_rule_215_condition_217';
   }
 }
 
-export class Google_storage_bucket_logging_1074 implements PcoreValue {
+export class Google_storage_bucket_logging_218 implements PcoreValue {
   readonly log_bucket: string;
   readonly log_object_prefix: string|null;
 
@@ -21539,7 +21539,7 @@ export class Google_storage_bucket_logging_1074 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_logging_1074';
+    return 'TerraformGoogle::Google_storage_bucket_logging_218';
   }
 }
 
@@ -21671,7 +21671,7 @@ export class Google_storage_bucket_objectHandler implements PcoreValue {
   }
 }
 
-export class Google_storage_bucket_versioning_1075 implements PcoreValue {
+export class Google_storage_bucket_versioning_219 implements PcoreValue {
   readonly enabled: boolean|null;
 
   constructor({
@@ -21691,11 +21691,11 @@ export class Google_storage_bucket_versioning_1075 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_versioning_1075';
+    return 'TerraformGoogle::Google_storage_bucket_versioning_219';
   }
 }
 
-export class Google_storage_bucket_website_1076 implements PcoreValue {
+export class Google_storage_bucket_website_220 implements PcoreValue {
   readonly main_page_suffix: string|null;
   readonly not_found_page: string|null;
 
@@ -21722,7 +21722,7 @@ export class Google_storage_bucket_website_1076 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_bucket_website_1076';
+    return 'TerraformGoogle::Google_storage_bucket_website_220';
   }
 }
 
@@ -21736,7 +21736,7 @@ export class Google_storage_default_object_access_control implements PcoreValue 
   readonly entity_id: string|null;
   readonly generation: number|null;
   readonly object: string|null;
-  readonly project_team: Google_storage_default_object_access_control_project_team_1077[]|null;
+  readonly project_team: Google_storage_default_object_access_control_project_team_221[]|null;
 
   constructor({
     bucket,
@@ -21759,7 +21759,7 @@ export class Google_storage_default_object_access_control implements PcoreValue 
     entity_id?: string|null,
     generation?: number|null,
     object?: string|null,
-    project_team?: Google_storage_default_object_access_control_project_team_1077[]|null
+    project_team?: Google_storage_default_object_access_control_project_team_221[]|null
   }) {
     this.bucket = bucket;
     this.entity = entity;
@@ -21817,7 +21817,7 @@ export class Google_storage_default_object_access_controlHandler implements Pcor
   }
 }
 
-export class Google_storage_default_object_access_control_project_team_1077 implements PcoreValue {
+export class Google_storage_default_object_access_control_project_team_221 implements PcoreValue {
   readonly project_number: string|null;
   readonly team: string|null;
 
@@ -21844,7 +21844,7 @@ export class Google_storage_default_object_access_control_project_team_1077 impl
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_default_object_access_control_project_team_1077';
+    return 'TerraformGoogle::Google_storage_default_object_access_control_project_team_221';
   }
 }
 
@@ -21981,7 +21981,7 @@ export class Google_storage_object_access_control implements PcoreValue {
   readonly email: string|null;
   readonly entity_id: string|null;
   readonly generation: number|null;
-  readonly project_team: Google_storage_object_access_control_project_team_1078[]|null;
+  readonly project_team: Google_storage_object_access_control_project_team_222[]|null;
 
   constructor({
     bucket,
@@ -22004,7 +22004,7 @@ export class Google_storage_object_access_control implements PcoreValue {
     email?: string|null,
     entity_id?: string|null,
     generation?: number|null,
-    project_team?: Google_storage_object_access_control_project_team_1078[]|null
+    project_team?: Google_storage_object_access_control_project_team_222[]|null
   }) {
     this.bucket = bucket;
     this.entity = entity;
@@ -22060,7 +22060,7 @@ export class Google_storage_object_access_controlHandler implements PcoreValue {
   }
 }
 
-export class Google_storage_object_access_control_project_team_1078 implements PcoreValue {
+export class Google_storage_object_access_control_project_team_222 implements PcoreValue {
   readonly project_number: string|null;
   readonly team: string|null;
 
@@ -22087,7 +22087,7 @@ export class Google_storage_object_access_control_project_team_1078 implements P
   }
 
   __ptype(): string {
-    return 'TerraformGoogle::Google_storage_object_access_control_project_team_1078';
+    return 'TerraformGoogle::Google_storage_object_access_control_project_team_222';
   }
 }
 

--- a/examples/ts-samples/src/types/TerraformKubernetes.ts
+++ b/examples/ts-samples/src/types/TerraformKubernetes.ts
@@ -2,9 +2,9 @@
 import {PcoreValue, Value} from 'lyra-workflow';
 
 export class Kubernetes_cluster_role_binding implements PcoreValue {
-  readonly metadata: Kubernetes_cluster_role_binding_metadata_1079[];
+  readonly metadata: Kubernetes_cluster_role_binding_metadata_1[];
   readonly role_ref: {[s: string]: string};
-  readonly subject: Kubernetes_cluster_role_binding_subject_1080[];
+  readonly subject: Kubernetes_cluster_role_binding_subject_2[];
   readonly kubernetes_cluster_role_binding_id: string|null;
 
   constructor({
@@ -13,9 +13,9 @@ export class Kubernetes_cluster_role_binding implements PcoreValue {
     subject,
     kubernetes_cluster_role_binding_id = null
   }: {
-    metadata: Kubernetes_cluster_role_binding_metadata_1079[],
+    metadata: Kubernetes_cluster_role_binding_metadata_1[],
     role_ref: {[s: string]: string},
-    subject: Kubernetes_cluster_role_binding_subject_1080[],
+    subject: Kubernetes_cluster_role_binding_subject_2[],
     kubernetes_cluster_role_binding_id?: string|null
   }) {
     this.metadata = metadata;
@@ -50,7 +50,7 @@ export class Kubernetes_cluster_role_bindingHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_cluster_role_binding_metadata_1079 implements PcoreValue {
+export class Kubernetes_cluster_role_binding_metadata_1 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generation: number|null;
   readonly labels: {[s: string]: string}|null;
@@ -112,11 +112,11 @@ export class Kubernetes_cluster_role_binding_metadata_1079 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_cluster_role_binding_metadata_1079';
+    return 'TerraformKubernetes::Kubernetes_cluster_role_binding_metadata_1';
   }
 }
 
-export class Kubernetes_cluster_role_binding_subject_1080 implements PcoreValue {
+export class Kubernetes_cluster_role_binding_subject_2 implements PcoreValue {
   readonly kind: string;
   readonly name: string;
   readonly api_group: string|null;
@@ -153,12 +153,12 @@ export class Kubernetes_cluster_role_binding_subject_1080 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_cluster_role_binding_subject_1080';
+    return 'TerraformKubernetes::Kubernetes_cluster_role_binding_subject_2';
   }
 }
 
 export class Kubernetes_config_map implements PcoreValue {
-  readonly metadata: Kubernetes_config_map_metadata_1081[];
+  readonly metadata: Kubernetes_config_map_metadata_3[];
   readonly kubernetes_config_map_id: string|null;
   readonly data: {[s: string]: string}|null;
 
@@ -167,7 +167,7 @@ export class Kubernetes_config_map implements PcoreValue {
     kubernetes_config_map_id = null,
     data = null
   }: {
-    metadata: Kubernetes_config_map_metadata_1081[],
+    metadata: Kubernetes_config_map_metadata_3[],
     kubernetes_config_map_id?: string|null,
     data?: {[s: string]: string}|null
   }) {
@@ -203,7 +203,7 @@ export class Kubernetes_config_mapHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_config_map_metadata_1081 implements PcoreValue {
+export class Kubernetes_config_map_metadata_3 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -279,13 +279,13 @@ export class Kubernetes_config_map_metadata_1081 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_config_map_metadata_1081';
+    return 'TerraformKubernetes::Kubernetes_config_map_metadata_3';
   }
 }
 
 export class Kubernetes_deployment implements PcoreValue {
-  readonly metadata: Kubernetes_deployment_metadata_1082[];
-  readonly spec: Kubernetes_deployment_spec_1083[];
+  readonly metadata: Kubernetes_deployment_metadata_4[];
+  readonly spec: Kubernetes_deployment_spec_5[];
   readonly kubernetes_deployment_id: string|null;
 
   constructor({
@@ -293,8 +293,8 @@ export class Kubernetes_deployment implements PcoreValue {
     spec,
     kubernetes_deployment_id = null
   }: {
-    metadata: Kubernetes_deployment_metadata_1082[],
-    spec: Kubernetes_deployment_spec_1083[],
+    metadata: Kubernetes_deployment_metadata_4[],
+    spec: Kubernetes_deployment_spec_5[],
     kubernetes_deployment_id?: string|null
   }) {
     this.metadata = metadata;
@@ -327,7 +327,7 @@ export class Kubernetes_deploymentHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_deployment_metadata_1082 implements PcoreValue {
+export class Kubernetes_deployment_metadata_4 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -403,19 +403,19 @@ export class Kubernetes_deployment_metadata_1082 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_metadata_1082';
+    return 'TerraformKubernetes::Kubernetes_deployment_metadata_4';
   }
 }
 
-export class Kubernetes_deployment_spec_1083 implements PcoreValue {
-  readonly template: Kubernetes_deployment_spec_1083_template_1088[];
+export class Kubernetes_deployment_spec_5 implements PcoreValue {
+  readonly template: Kubernetes_deployment_spec_5_template_10[];
   readonly min_ready_seconds: number|null;
   readonly paused: boolean|null;
   readonly progress_deadline_seconds: number|null;
   readonly replicas: number|null;
   readonly revision_history_limit: number|null;
-  readonly selector: Kubernetes_deployment_spec_1083_selector_1084[]|null;
-  readonly strategy: Kubernetes_deployment_spec_1083_strategy_1086[]|null;
+  readonly selector: Kubernetes_deployment_spec_5_selector_6[]|null;
+  readonly strategy: Kubernetes_deployment_spec_5_strategy_8[]|null;
 
   constructor({
     template,
@@ -427,14 +427,14 @@ export class Kubernetes_deployment_spec_1083 implements PcoreValue {
     selector = null,
     strategy = null
   }: {
-    template: Kubernetes_deployment_spec_1083_template_1088[],
+    template: Kubernetes_deployment_spec_5_template_10[],
     min_ready_seconds?: number|null,
     paused?: boolean|null,
     progress_deadline_seconds?: number|null,
     replicas?: number|null,
     revision_history_limit?: number|null,
-    selector?: Kubernetes_deployment_spec_1083_selector_1084[]|null,
-    strategy?: Kubernetes_deployment_spec_1083_strategy_1086[]|null
+    selector?: Kubernetes_deployment_spec_5_selector_6[]|null,
+    strategy?: Kubernetes_deployment_spec_5_strategy_8[]|null
   }) {
     this.template = template;
     this.min_ready_seconds = min_ready_seconds;
@@ -474,19 +474,19 @@ export class Kubernetes_deployment_spec_1083 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_selector_1084 implements PcoreValue {
-  readonly match_expressions: Kubernetes_deployment_spec_1083_selector_1084_match_expressions_1085[]|null;
+export class Kubernetes_deployment_spec_5_selector_6 implements PcoreValue {
+  readonly match_expressions: Kubernetes_deployment_spec_5_selector_6_match_expressions_7[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_deployment_spec_1083_selector_1084_match_expressions_1085[]|null,
+    match_expressions?: Kubernetes_deployment_spec_5_selector_6_match_expressions_7[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -505,11 +505,11 @@ export class Kubernetes_deployment_spec_1083_selector_1084 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_selector_1084';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_selector_6';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_selector_1084_match_expressions_1085 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_selector_6_match_expressions_7 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -543,19 +543,19 @@ export class Kubernetes_deployment_spec_1083_selector_1084_match_expressions_108
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_selector_1084_match_expressions_1085';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_selector_6_match_expressions_7';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_strategy_1086 implements PcoreValue {
-  readonly rolling_update: Kubernetes_deployment_spec_1083_strategy_1086_rolling_update_1087[]|null;
+export class Kubernetes_deployment_spec_5_strategy_8 implements PcoreValue {
+  readonly rolling_update: Kubernetes_deployment_spec_5_strategy_8_rolling_update_9[]|null;
   readonly type: string|null;
 
   constructor({
     rolling_update = null,
     type = null
   }: {
-    rolling_update?: Kubernetes_deployment_spec_1083_strategy_1086_rolling_update_1087[]|null,
+    rolling_update?: Kubernetes_deployment_spec_5_strategy_8_rolling_update_9[]|null,
     type?: string|null
   }) {
     this.rolling_update = rolling_update;
@@ -574,11 +574,11 @@ export class Kubernetes_deployment_spec_1083_strategy_1086 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_strategy_1086';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_strategy_8';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_strategy_1086_rolling_update_1087 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_strategy_8_rolling_update_9 implements PcoreValue {
   readonly max_surge: string|null;
   readonly max_unavailable: string|null;
 
@@ -605,20 +605,20 @@ export class Kubernetes_deployment_spec_1083_strategy_1086_rolling_update_1087 i
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_strategy_1086_rolling_update_1087';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_strategy_8_rolling_update_9';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088 implements PcoreValue {
-  readonly metadata: Kubernetes_deployment_spec_1083_template_1088_metadata_1089[];
-  readonly spec: Kubernetes_deployment_spec_1083_template_1088_spec_1090[];
+export class Kubernetes_deployment_spec_5_template_10 implements PcoreValue {
+  readonly metadata: Kubernetes_deployment_spec_5_template_10_metadata_11[];
+  readonly spec: Kubernetes_deployment_spec_5_template_10_spec_12[];
 
   constructor({
     metadata,
     spec
   }: {
-    metadata: Kubernetes_deployment_spec_1083_template_1088_metadata_1089[],
-    spec: Kubernetes_deployment_spec_1083_template_1088_spec_1090[]
+    metadata: Kubernetes_deployment_spec_5_template_10_metadata_11[],
+    spec: Kubernetes_deployment_spec_5_template_10_spec_12[]
   }) {
     this.metadata = metadata;
     this.spec = spec;
@@ -632,11 +632,11 @@ export class Kubernetes_deployment_spec_1083_template_1088 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_metadata_1089 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_metadata_11 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -712,28 +712,28 @@ export class Kubernetes_deployment_spec_1083_template_1088_metadata_1089 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_metadata_1089';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_metadata_11';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12 implements PcoreValue {
   readonly active_deadline_seconds: number|null;
-  readonly container: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091[]|null;
+  readonly container: Kubernetes_deployment_spec_5_template_10_spec_12_container_13[]|null;
   readonly dns_policy: string|null;
   readonly host_ipc: boolean|null;
   readonly host_network: boolean|null;
   readonly host_pid: boolean|null;
   readonly hostname: string|null;
-  readonly image_pull_secrets: Kubernetes_deployment_spec_1083_template_1088_spec_1090_image_pull_secrets_1130[]|null;
-  readonly init_container: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131[]|null;
+  readonly image_pull_secrets: Kubernetes_deployment_spec_5_template_10_spec_12_image_pull_secrets_52[]|null;
+  readonly init_container: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53[]|null;
   readonly node_name: string|null;
   readonly node_selector: {[s: string]: string}|null;
   readonly restart_policy: string|null;
-  readonly security_context: Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170[]|null;
+  readonly security_context: Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92[]|null;
   readonly service_account_name: string|null;
   readonly subdomain: string|null;
   readonly termination_grace_period_seconds: number|null;
-  readonly volume: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172[]|null;
+  readonly volume: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94[]|null;
 
   constructor({
     active_deadline_seconds = null,
@@ -755,22 +755,22 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090 implements 
     volume = null
   }: {
     active_deadline_seconds?: number|null,
-    container?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091[]|null,
+    container?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13[]|null,
     dns_policy?: string|null,
     host_ipc?: boolean|null,
     host_network?: boolean|null,
     host_pid?: boolean|null,
     hostname?: string|null,
-    image_pull_secrets?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_image_pull_secrets_1130[]|null,
-    init_container?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131[]|null,
+    image_pull_secrets?: Kubernetes_deployment_spec_5_template_10_spec_12_image_pull_secrets_52[]|null,
+    init_container?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53[]|null,
     node_name?: string|null,
     node_selector?: {[s: string]: string}|null,
     restart_policy?: string|null,
-    security_context?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170[]|null,
+    security_context?: Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92[]|null,
     service_account_name?: string|null,
     subdomain?: string|null,
     termination_grace_period_seconds?: number|null,
-    volume?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172[]|null
+    volume?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94[]|null
   }) {
     this.active_deadline_seconds = active_deadline_seconds;
     this.container = container;
@@ -848,29 +848,29 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090 implements 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092[]|null;
-  readonly env_from: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098[]|null;
+  readonly env: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14[]|null;
+  readonly env_from: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101[]|null;
-  readonly liveness_probe: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112[]|null;
-  readonly port: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_port_1117[]|null;
-  readonly readiness_probe: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118[]|null;
-  readonly resources: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123[]|null;
-  readonly security_context: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126[]|null;
+  readonly lifecycle: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23[]|null;
+  readonly liveness_probe: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34[]|null;
+  readonly port: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_port_39[]|null;
+  readonly readiness_probe: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40[]|null;
+  readonly resources: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45[]|null;
+  readonly security_context: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_volume_mount_1129[]|null;
+  readonly volume_mount: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_volume_mount_51[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -897,21 +897,21 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092[]|null,
-    env_from?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098[]|null,
+    env?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14[]|null,
+    env_from?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101[]|null,
-    liveness_probe?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112[]|null,
-    port?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_port_1117[]|null,
-    readiness_probe?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118[]|null,
-    resources?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123[]|null,
-    security_context?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126[]|null,
+    lifecycle?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23[]|null,
+    liveness_probe?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34[]|null,
+    port?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_port_39[]|null,
+    readiness_probe?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40[]|null,
+    resources?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45[]|null,
+    security_context?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_volume_mount_1129[]|null,
+    volume_mount?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_volume_mount_51[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -996,14 +996,14 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093[]|null;
+  readonly value_from: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15[]|null;
 
   constructor({
     name,
@@ -1012,7 +1012,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093[]|null
+    value_from?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -1032,15 +1032,15 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_config_map_key_ref_1094[]|null;
-  readonly field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_field_ref_1095[]|null;
-  readonly resource_field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_resource_field_ref_1096[]|null;
-  readonly secret_key_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_secret_key_ref_1097[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_config_map_key_ref_16[]|null;
+  readonly field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_field_ref_17[]|null;
+  readonly resource_field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_resource_field_ref_18[]|null;
+  readonly secret_key_ref: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_secret_key_ref_19[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -1048,10 +1048,10 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_config_map_key_ref_1094[]|null,
-    field_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_field_ref_1095[]|null,
-    resource_field_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_resource_field_ref_1096[]|null,
-    secret_key_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_secret_key_ref_1097[]|null
+    config_map_key_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_config_map_key_ref_16[]|null,
+    field_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_field_ref_17[]|null,
+    resource_field_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_resource_field_ref_18[]|null,
+    secret_key_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_secret_key_ref_19[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -1077,11 +1077,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_config_map_key_ref_1094 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_config_map_key_ref_16 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -1108,11 +1108,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_config_map_key_ref_1094';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_config_map_key_ref_16';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_field_ref_1095 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_field_ref_17 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -1139,11 +1139,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_field_ref_1095';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_field_ref_17';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_resource_field_ref_1096 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_resource_field_ref_18 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -1168,11 +1168,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_resource_field_ref_1096';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_resource_field_ref_18';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_secret_key_ref_1097 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_secret_key_ref_19 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -1199,23 +1199,23 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_1092_value_from_1093_secret_key_ref_1097';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_14_value_from_15_secret_key_ref_19';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_config_map_ref_1099[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_config_map_ref_21[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_secret_ref_1100[]|null;
+  readonly secret_ref: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_secret_ref_22[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_config_map_ref_1099[]|null,
+    config_map_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_config_map_ref_21[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_secret_ref_1100[]|null
+    secret_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_secret_ref_22[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -1237,11 +1237,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_config_map_ref_1099 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_config_map_ref_21 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -1266,11 +1266,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_config_map_ref_1099';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_config_map_ref_21';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_secret_ref_1100 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_secret_ref_22 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -1295,20 +1295,20 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_env_from_1098_secret_ref_1100';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_env_from_20_secret_ref_22';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101 implements PcoreValue {
-  readonly post_start: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102[]|null;
-  readonly pre_stop: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23 implements PcoreValue {
+  readonly post_start: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24[]|null;
+  readonly pre_stop: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102[]|null,
-    pre_stop?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107[]|null
+    post_start?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24[]|null,
+    pre_stop?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -1326,23 +1326,23 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_exec_1103[]|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104[]|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_tcp_socket_1106[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_exec_25[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_tcp_socket_28[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_exec_1103[]|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104[]|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_tcp_socket_1106[]|null
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_exec_25[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_tcp_socket_28[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -1364,11 +1364,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_exec_1103 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_exec_25 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -1388,13 +1388,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_exec_1103';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_exec_25';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104_http_header_1105[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26_http_header_27[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -1407,7 +1407,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104_http_header_1105[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26_http_header_27[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -1440,11 +1440,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104_http_header_1105 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26_http_header_27 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -1471,11 +1471,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_http_get_1104_http_header_1105';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_http_get_26_http_header_27';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_tcp_socket_1106 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_tcp_socket_28 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -1493,23 +1493,23 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_post_start_1102_tcp_socket_1106';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_post_start_24_tcp_socket_28';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_exec_1108[]|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109[]|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_tcp_socket_1111[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_exec_30[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_tcp_socket_33[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_exec_1108[]|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109[]|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_tcp_socket_1111[]|null
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_exec_30[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_tcp_socket_33[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -1531,11 +1531,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_exec_1108 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_exec_30 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -1555,13 +1555,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_exec_1108';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_exec_30';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109_http_header_1110[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31_http_header_32[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -1574,7 +1574,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109_http_header_1110[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31_http_header_32[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -1607,11 +1607,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109_http_header_1110 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31_http_header_32 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -1638,11 +1638,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_http_get_1109_http_header_1110';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_http_get_31_http_header_32';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_tcp_socket_1111 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_tcp_socket_33 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -1660,18 +1660,18 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_lifecycle_1101_pre_stop_1107_tcp_socket_1111';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_lifecycle_23_pre_stop_29_tcp_socket_33';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_exec_1113[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_exec_35[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_tcp_socket_1116[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_tcp_socket_38[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -1684,13 +1684,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_exec_1113[]|null,
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_exec_35[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_tcp_socket_1116[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_tcp_socket_38[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -1733,11 +1733,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_exec_1113 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_exec_35 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -1757,13 +1757,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_exec_1113';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_exec_35';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114_http_header_1115[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36_http_header_37[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -1776,7 +1776,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114_http_header_1115[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36_http_header_37[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -1809,11 +1809,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114_http_header_1115 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36_http_header_37 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -1840,11 +1840,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_http_get_1114_http_header_1115';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_http_get_36_http_header_37';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_tcp_socket_1116 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_tcp_socket_38 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -1862,11 +1862,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_liveness_probe_1112_tcp_socket_1116';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_liveness_probe_34_tcp_socket_38';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_port_1117 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_port_39 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -1912,18 +1912,18 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_port_1117';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_port_39';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_exec_1119[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_exec_41[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_tcp_socket_1122[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_tcp_socket_44[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -1936,13 +1936,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_exec_1119[]|null,
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_exec_41[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_tcp_socket_1122[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_tcp_socket_44[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -1985,11 +1985,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_exec_1119 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_exec_41 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -2009,13 +2009,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_exec_1119';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_exec_41';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120_http_header_1121[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42_http_header_43[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -2028,7 +2028,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120_http_header_1121[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42_http_header_43[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -2061,11 +2061,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120_http_header_1121 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42_http_header_43 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -2092,11 +2092,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_http_get_1120_http_header_1121';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_http_get_42_http_header_43';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_tcp_socket_1122 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_tcp_socket_44 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -2114,20 +2114,20 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_readiness_probe_1118_tcp_socket_1122';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_readiness_probe_40_tcp_socket_44';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123 implements PcoreValue {
-  readonly limits: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_limits_1124[]|null;
-  readonly requests: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_requests_1125[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45 implements PcoreValue {
+  readonly limits: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_limits_46[]|null;
+  readonly requests: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_requests_47[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_limits_1124[]|null,
-    requests?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_requests_1125[]|null
+    limits?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_limits_46[]|null,
+    requests?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_requests_47[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -2145,11 +2145,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_limits_1124 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_limits_46 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -2176,11 +2176,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_limits_1124';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_limits_46';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_requests_1125 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_requests_47 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -2207,18 +2207,18 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_resources_1123_requests_1125';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_resources_45_requests_47';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_capabilities_1127[]|null;
+  readonly capabilities: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_capabilities_49[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_se_linux_options_1128[]|null;
+  readonly se_linux_options: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_se_linux_options_50[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -2230,12 +2230,12 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_capabilities_1127[]|null,
+    capabilities?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_capabilities_49[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_se_linux_options_1128[]|null
+    se_linux_options?: Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_se_linux_options_50[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -2273,11 +2273,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_capabilities_1127 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_capabilities_49 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -2304,11 +2304,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_capabilities_1127';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_capabilities_49';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_se_linux_options_1128 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_se_linux_options_50 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -2349,11 +2349,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_security_context_1126_se_linux_options_1128';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_security_context_48_se_linux_options_50';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_volume_mount_1129 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_container_13_volume_mount_51 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -2390,11 +2390,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_container_1091_volume_mount_1129';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_container_13_volume_mount_51';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_image_pull_secrets_1130 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_image_pull_secrets_52 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -2412,29 +2412,29 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_image_pull_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_image_pull_secrets_1130';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_image_pull_secrets_52';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132[]|null;
-  readonly env_from: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138[]|null;
+  readonly env: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54[]|null;
+  readonly env_from: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141[]|null;
-  readonly liveness_probe: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152[]|null;
-  readonly port: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_port_1157[]|null;
-  readonly readiness_probe: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158[]|null;
-  readonly resources: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163[]|null;
-  readonly security_context: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166[]|null;
+  readonly lifecycle: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63[]|null;
+  readonly liveness_probe: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74[]|null;
+  readonly port: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_port_79[]|null;
+  readonly readiness_probe: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80[]|null;
+  readonly resources: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85[]|null;
+  readonly security_context: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_volume_mount_1169[]|null;
+  readonly volume_mount: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_volume_mount_91[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -2461,21 +2461,21 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132[]|null,
-    env_from?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138[]|null,
+    env?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54[]|null,
+    env_from?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141[]|null,
-    liveness_probe?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152[]|null,
-    port?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_port_1157[]|null,
-    readiness_probe?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158[]|null,
-    resources?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163[]|null,
-    security_context?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166[]|null,
+    lifecycle?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63[]|null,
+    liveness_probe?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74[]|null,
+    port?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_port_79[]|null,
+    readiness_probe?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80[]|null,
+    resources?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85[]|null,
+    security_context?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_volume_mount_1169[]|null,
+    volume_mount?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_volume_mount_91[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -2560,14 +2560,14 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133[]|null;
+  readonly value_from: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55[]|null;
 
   constructor({
     name,
@@ -2576,7 +2576,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133[]|null
+    value_from?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -2596,15 +2596,15 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_config_map_key_ref_1134[]|null;
-  readonly field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_field_ref_1135[]|null;
-  readonly resource_field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_resource_field_ref_1136[]|null;
-  readonly secret_key_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_secret_key_ref_1137[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_config_map_key_ref_56[]|null;
+  readonly field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_field_ref_57[]|null;
+  readonly resource_field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_resource_field_ref_58[]|null;
+  readonly secret_key_ref: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_secret_key_ref_59[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -2612,10 +2612,10 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_config_map_key_ref_1134[]|null,
-    field_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_field_ref_1135[]|null,
-    resource_field_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_resource_field_ref_1136[]|null,
-    secret_key_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_secret_key_ref_1137[]|null
+    config_map_key_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_config_map_key_ref_56[]|null,
+    field_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_field_ref_57[]|null,
+    resource_field_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_resource_field_ref_58[]|null,
+    secret_key_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_secret_key_ref_59[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -2641,11 +2641,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_config_map_key_ref_1134 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_config_map_key_ref_56 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -2672,11 +2672,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_config_map_key_ref_1134';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_config_map_key_ref_56';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_field_ref_1135 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_field_ref_57 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -2703,11 +2703,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_field_ref_1135';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_field_ref_57';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_resource_field_ref_1136 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_resource_field_ref_58 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -2732,11 +2732,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_resource_field_ref_1136';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_resource_field_ref_58';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_secret_key_ref_1137 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_secret_key_ref_59 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -2763,23 +2763,23 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_1132_value_from_1133_secret_key_ref_1137';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_54_value_from_55_secret_key_ref_59';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_config_map_ref_1139[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_config_map_ref_61[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_secret_ref_1140[]|null;
+  readonly secret_ref: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_secret_ref_62[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_config_map_ref_1139[]|null,
+    config_map_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_config_map_ref_61[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_secret_ref_1140[]|null
+    secret_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_secret_ref_62[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -2801,11 +2801,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_config_map_ref_1139 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_config_map_ref_61 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -2830,11 +2830,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_config_map_ref_1139';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_config_map_ref_61';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_secret_ref_1140 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_secret_ref_62 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -2859,20 +2859,20 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_env_from_1138_secret_ref_1140';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_env_from_60_secret_ref_62';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141 implements PcoreValue {
-  readonly post_start: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142[]|null;
-  readonly pre_stop: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63 implements PcoreValue {
+  readonly post_start: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64[]|null;
+  readonly pre_stop: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142[]|null,
-    pre_stop?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147[]|null
+    post_start?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64[]|null,
+    pre_stop?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -2890,23 +2890,23 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_exec_1143[]|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144[]|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_tcp_socket_1146[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_exec_65[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_tcp_socket_68[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_exec_1143[]|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144[]|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_tcp_socket_1146[]|null
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_exec_65[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_tcp_socket_68[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -2928,11 +2928,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_exec_1143 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_exec_65 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -2952,13 +2952,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_exec_1143';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_exec_65';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144_http_header_1145[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66_http_header_67[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -2971,7 +2971,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144_http_header_1145[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66_http_header_67[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -3004,11 +3004,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144_http_header_1145 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66_http_header_67 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -3035,11 +3035,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_http_get_1144_http_header_1145';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_http_get_66_http_header_67';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_tcp_socket_1146 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_tcp_socket_68 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -3057,23 +3057,23 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_post_start_1142_tcp_socket_1146';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_post_start_64_tcp_socket_68';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_exec_1148[]|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149[]|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_tcp_socket_1151[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_exec_70[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_tcp_socket_73[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_exec_1148[]|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149[]|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_tcp_socket_1151[]|null
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_exec_70[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_tcp_socket_73[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -3095,11 +3095,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_exec_1148 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_exec_70 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -3119,13 +3119,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_exec_1148';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_exec_70';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149_http_header_1150[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71_http_header_72[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -3138,7 +3138,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149_http_header_1150[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71_http_header_72[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -3171,11 +3171,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149_http_header_1150 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71_http_header_72 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -3202,11 +3202,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_http_get_1149_http_header_1150';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_http_get_71_http_header_72';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_tcp_socket_1151 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_tcp_socket_73 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -3224,18 +3224,18 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_lifecycle_1141_pre_stop_1147_tcp_socket_1151';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_lifecycle_63_pre_stop_69_tcp_socket_73';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_exec_1153[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_exec_75[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_tcp_socket_1156[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_tcp_socket_78[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -3248,13 +3248,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_exec_1153[]|null,
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_exec_75[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_tcp_socket_1156[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_tcp_socket_78[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -3297,11 +3297,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_exec_1153 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_exec_75 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -3321,13 +3321,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_exec_1153';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_exec_75';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154_http_header_1155[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76_http_header_77[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -3340,7 +3340,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154_http_header_1155[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76_http_header_77[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -3373,11 +3373,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154_http_header_1155 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76_http_header_77 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -3404,11 +3404,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_http_get_1154_http_header_1155';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_http_get_76_http_header_77';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_tcp_socket_1156 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_tcp_socket_78 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -3426,11 +3426,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_liveness_probe_1152_tcp_socket_1156';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_liveness_probe_74_tcp_socket_78';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_port_1157 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_port_79 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -3476,18 +3476,18 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_port_1157';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_port_79';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158 implements PcoreValue {
-  readonly exec: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_exec_1159[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80 implements PcoreValue {
+  readonly exec: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_exec_81[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160[]|null;
+  readonly http_get: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_tcp_socket_1162[]|null;
+  readonly tcp_socket: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_tcp_socket_84[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -3500,13 +3500,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_exec_1159[]|null,
+    exec?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_exec_81[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160[]|null,
+    http_get?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_tcp_socket_1162[]|null,
+    tcp_socket?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_tcp_socket_84[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -3549,11 +3549,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_exec_1159 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_exec_81 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -3573,13 +3573,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_exec_1159';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_exec_81';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160_http_header_1161[]|null;
+  readonly http_header: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82_http_header_83[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -3592,7 +3592,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160_http_header_1161[]|null,
+    http_header?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82_http_header_83[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -3625,11 +3625,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160_http_header_1161 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82_http_header_83 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -3656,11 +3656,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_http_get_1160_http_header_1161';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_http_get_82_http_header_83';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_tcp_socket_1162 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_tcp_socket_84 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -3678,20 +3678,20 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_readiness_probe_1158_tcp_socket_1162';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_readiness_probe_80_tcp_socket_84';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163 implements PcoreValue {
-  readonly limits: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_limits_1164[]|null;
-  readonly requests: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_requests_1165[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85 implements PcoreValue {
+  readonly limits: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_limits_86[]|null;
+  readonly requests: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_requests_87[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_limits_1164[]|null,
-    requests?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_requests_1165[]|null
+    limits?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_limits_86[]|null,
+    requests?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_requests_87[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -3709,11 +3709,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_limits_1164 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_limits_86 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -3740,11 +3740,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_limits_1164';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_limits_86';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_requests_1165 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_requests_87 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -3771,18 +3771,18 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_resources_1163_requests_1165';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_resources_85_requests_87';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_capabilities_1167[]|null;
+  readonly capabilities: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_capabilities_89[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_se_linux_options_1168[]|null;
+  readonly se_linux_options: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_se_linux_options_90[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -3794,12 +3794,12 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_capabilities_1167[]|null,
+    capabilities?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_capabilities_89[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_se_linux_options_1168[]|null
+    se_linux_options?: Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_se_linux_options_90[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -3837,11 +3837,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_capabilities_1167 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_capabilities_89 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -3868,11 +3868,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_capabilities_1167';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_capabilities_89';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_se_linux_options_1168 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_se_linux_options_90 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -3913,11 +3913,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_security_context_1166_se_linux_options_1168';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_security_context_88_se_linux_options_90';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_volume_mount_1169 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_volume_mount_91 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -3954,15 +3954,15 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_contai
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_init_container_1131_volume_mount_1169';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_init_container_53_volume_mount_91';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92 implements PcoreValue {
   readonly fs_group: number|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170_se_linux_options_1171[]|null;
+  readonly se_linux_options: Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92_se_linux_options_93[]|null;
   readonly supplemental_groups: number[]|null;
 
   constructor({
@@ -3975,7 +3975,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_co
     fs_group?: number|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170_se_linux_options_1171[]|null,
+    se_linux_options?: Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92_se_linux_options_93[]|null,
     supplemental_groups?: number[]|null
   }) {
     this.fs_group = fs_group;
@@ -4006,11 +4006,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_co
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170_se_linux_options_1171 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92_se_linux_options_93 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -4051,36 +4051,36 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_co
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_security_context_1170_se_linux_options_1171';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_security_context_92_se_linux_options_93';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172 implements PcoreValue {
-  readonly aws_elastic_block_store: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_aws_elastic_block_store_1173[]|null;
-  readonly azure_disk: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_disk_1174[]|null;
-  readonly azure_file: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_file_1175[]|null;
-  readonly ceph_fs: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176[]|null;
-  readonly cinder: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_cinder_1178[]|null;
-  readonly config_map: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179[]|null;
-  readonly downward_api: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181[]|null;
-  readonly empty_dir: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_empty_dir_1185[]|null;
-  readonly fc: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_fc_1186[]|null;
-  readonly flex_volume: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187[]|null;
-  readonly flocker: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flocker_1189[]|null;
-  readonly gce_persistent_disk: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_gce_persistent_disk_1190[]|null;
-  readonly git_repo: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_git_repo_1191[]|null;
-  readonly glusterfs: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_glusterfs_1192[]|null;
-  readonly host_path: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_host_path_1193[]|null;
-  readonly iscsi: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_iscsi_1194[]|null;
-  readonly local: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_local_1195[]|null;
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94 implements PcoreValue {
+  readonly aws_elastic_block_store: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_aws_elastic_block_store_95[]|null;
+  readonly azure_disk: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_disk_96[]|null;
+  readonly azure_file: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_file_97[]|null;
+  readonly ceph_fs: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98[]|null;
+  readonly cinder: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_cinder_100[]|null;
+  readonly config_map: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101[]|null;
+  readonly downward_api: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103[]|null;
+  readonly empty_dir: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_empty_dir_107[]|null;
+  readonly fc: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_fc_108[]|null;
+  readonly flex_volume: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109[]|null;
+  readonly flocker: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flocker_111[]|null;
+  readonly gce_persistent_disk: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_gce_persistent_disk_112[]|null;
+  readonly git_repo: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_git_repo_113[]|null;
+  readonly glusterfs: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_glusterfs_114[]|null;
+  readonly host_path: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_host_path_115[]|null;
+  readonly iscsi: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_iscsi_116[]|null;
+  readonly local: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_local_117[]|null;
   readonly name: string|null;
-  readonly nfs: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_nfs_1196[]|null;
-  readonly persistent_volume_claim: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_persistent_volume_claim_1197[]|null;
-  readonly photon_persistent_disk: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_photon_persistent_disk_1198[]|null;
-  readonly quobyte: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_quobyte_1199[]|null;
-  readonly rbd: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200[]|null;
-  readonly secret: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202[]|null;
-  readonly vsphere_volume: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_vsphere_volume_1204[]|null;
+  readonly nfs: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_nfs_118[]|null;
+  readonly persistent_volume_claim: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_persistent_volume_claim_119[]|null;
+  readonly photon_persistent_disk: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_photon_persistent_disk_120[]|null;
+  readonly quobyte: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_quobyte_121[]|null;
+  readonly rbd: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122[]|null;
+  readonly secret: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124[]|null;
+  readonly vsphere_volume: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_vsphere_volume_126[]|null;
 
   constructor({
     aws_elastic_block_store = null,
@@ -4109,31 +4109,31 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     secret = null,
     vsphere_volume = null
   }: {
-    aws_elastic_block_store?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_aws_elastic_block_store_1173[]|null,
-    azure_disk?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_disk_1174[]|null,
-    azure_file?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_file_1175[]|null,
-    ceph_fs?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176[]|null,
-    cinder?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_cinder_1178[]|null,
-    config_map?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179[]|null,
-    downward_api?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181[]|null,
-    empty_dir?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_empty_dir_1185[]|null,
-    fc?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_fc_1186[]|null,
-    flex_volume?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187[]|null,
-    flocker?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flocker_1189[]|null,
-    gce_persistent_disk?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_gce_persistent_disk_1190[]|null,
-    git_repo?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_git_repo_1191[]|null,
-    glusterfs?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_glusterfs_1192[]|null,
-    host_path?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_host_path_1193[]|null,
-    iscsi?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_iscsi_1194[]|null,
-    local?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_local_1195[]|null,
+    aws_elastic_block_store?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_aws_elastic_block_store_95[]|null,
+    azure_disk?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_disk_96[]|null,
+    azure_file?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_file_97[]|null,
+    ceph_fs?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98[]|null,
+    cinder?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_cinder_100[]|null,
+    config_map?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101[]|null,
+    downward_api?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103[]|null,
+    empty_dir?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_empty_dir_107[]|null,
+    fc?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_fc_108[]|null,
+    flex_volume?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109[]|null,
+    flocker?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flocker_111[]|null,
+    gce_persistent_disk?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_gce_persistent_disk_112[]|null,
+    git_repo?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_git_repo_113[]|null,
+    glusterfs?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_glusterfs_114[]|null,
+    host_path?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_host_path_115[]|null,
+    iscsi?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_iscsi_116[]|null,
+    local?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_local_117[]|null,
     name?: string|null,
-    nfs?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_nfs_1196[]|null,
-    persistent_volume_claim?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_persistent_volume_claim_1197[]|null,
-    photon_persistent_disk?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_photon_persistent_disk_1198[]|null,
-    quobyte?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_quobyte_1199[]|null,
-    rbd?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200[]|null,
-    secret?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202[]|null,
-    vsphere_volume?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_vsphere_volume_1204[]|null
+    nfs?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_nfs_118[]|null,
+    persistent_volume_claim?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_persistent_volume_claim_119[]|null,
+    photon_persistent_disk?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_photon_persistent_disk_120[]|null,
+    quobyte?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_quobyte_121[]|null,
+    rbd?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122[]|null,
+    secret?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124[]|null,
+    vsphere_volume?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_vsphere_volume_126[]|null
   }) {
     this.aws_elastic_block_store = aws_elastic_block_store;
     this.azure_disk = azure_disk;
@@ -4243,11 +4243,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_aws_elastic_block_store_1173 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_aws_elastic_block_store_95 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -4286,11 +4286,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_aws_elastic_block_store_1173';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_aws_elastic_block_store_95';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_disk_1174 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_disk_96 implements PcoreValue {
   readonly caching_mode: string;
   readonly data_disk_uri: string;
   readonly disk_name: string;
@@ -4332,11 +4332,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_disk_1174';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_disk_96';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_file_1175 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_file_97 implements PcoreValue {
   readonly secret_name: string;
   readonly share_name: string;
   readonly read_only: boolean|null;
@@ -4366,16 +4366,16 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_azure_file_1175';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_azure_file_97';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98 implements PcoreValue {
   readonly monitors: string[];
   readonly path: string|null;
   readonly read_only: boolean|null;
   readonly secret_file: string|null;
-  readonly secret_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176_secret_ref_1177[]|null;
+  readonly secret_ref: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98_secret_ref_99[]|null;
   readonly user: string|null;
 
   constructor({
@@ -4390,7 +4390,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     path?: string|null,
     read_only?: boolean|null,
     secret_file?: string|null,
-    secret_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176_secret_ref_1177[]|null,
+    secret_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98_secret_ref_99[]|null,
     user?: string|null
   }) {
     this.monitors = monitors;
@@ -4423,11 +4423,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176_secret_ref_1177 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98_secret_ref_99 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -4447,11 +4447,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_ceph_fs_1176_secret_ref_1177';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_ceph_fs_98_secret_ref_99';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_cinder_1178 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_cinder_100 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly read_only: boolean|null;
@@ -4483,13 +4483,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_cinder_1178';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_cinder_100';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179_items_1180[]|null;
+  readonly items: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101_items_102[]|null;
   readonly name: string|null;
 
   constructor({
@@ -4498,7 +4498,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179_items_1180[]|null,
+    items?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101_items_102[]|null,
     name?: string|null
   }) {
     this.default_mode = default_mode;
@@ -4521,11 +4521,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179_items_1180 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101_items_102 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -4559,20 +4559,20 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_config_map_1179_items_1180';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_config_map_101_items_102';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182[]|null;
+  readonly items: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104[]|null;
 
   constructor({
     default_mode = null,
     items = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182[]|null
+    items?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104[]|null
   }) {
     this.default_mode = default_mode;
     this.items = items;
@@ -4590,15 +4590,15 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182 implements PcoreValue {
-  readonly field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_field_ref_1183[];
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104 implements PcoreValue {
+  readonly field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_field_ref_105[];
   readonly path: string;
   readonly mode: number|null;
-  readonly resource_field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_resource_field_ref_1184[]|null;
+  readonly resource_field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_resource_field_ref_106[]|null;
 
   constructor({
     field_ref,
@@ -4606,10 +4606,10 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     mode = null,
     resource_field_ref = null
   }: {
-    field_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_field_ref_1183[],
+    field_ref: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_field_ref_105[],
     path: string,
     mode?: number|null,
-    resource_field_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_resource_field_ref_1184[]|null
+    resource_field_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_resource_field_ref_106[]|null
   }) {
     this.field_ref = field_ref;
     this.path = path;
@@ -4631,11 +4631,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_field_ref_1183 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_field_ref_105 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -4662,11 +4662,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_field_ref_1183';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_field_ref_105';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_resource_field_ref_1184 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_resource_field_ref_106 implements PcoreValue {
   readonly container_name: string;
   readonly resource: string;
   readonly quantity: string|null;
@@ -4696,11 +4696,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_downward_api_1181_items_1182_resource_field_ref_1184';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_downward_api_103_items_104_resource_field_ref_106';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_empty_dir_1185 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_empty_dir_107 implements PcoreValue {
   readonly medium: string|null;
 
   constructor({
@@ -4720,11 +4720,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_empty_dir_1185';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_empty_dir_107';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_fc_1186 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_fc_108 implements PcoreValue {
   readonly lun: number;
   readonly target_ww_ns: string[];
   readonly fs_type: string|null;
@@ -4761,16 +4761,16 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_fc_1186';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_fc_108';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109 implements PcoreValue {
   readonly driver: string;
   readonly fs_type: string|null;
   readonly options: {[s: string]: string}|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187_secret_ref_1188[]|null;
+  readonly secret_ref: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109_secret_ref_110[]|null;
 
   constructor({
     driver,
@@ -4783,7 +4783,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     fs_type?: string|null,
     options?: {[s: string]: string}|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187_secret_ref_1188[]|null
+    secret_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109_secret_ref_110[]|null
   }) {
     this.driver = driver;
     this.fs_type = fs_type;
@@ -4811,11 +4811,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187_secret_ref_1188 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109_secret_ref_110 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -4835,11 +4835,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flex_volume_1187_secret_ref_1188';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flex_volume_109_secret_ref_110';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flocker_1189 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flocker_111 implements PcoreValue {
   readonly dataset_name: string|null;
   readonly dataset_uuid: string|null;
 
@@ -4866,11 +4866,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_flocker_1189';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_flocker_111';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_gce_persistent_disk_1190 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_gce_persistent_disk_112 implements PcoreValue {
   readonly pd_name: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -4909,11 +4909,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_gce_persistent_disk_1190';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_gce_persistent_disk_112';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_git_repo_1191 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_git_repo_113 implements PcoreValue {
   readonly directory: string|null;
   readonly repository: string|null;
   readonly revision: string|null;
@@ -4947,11 +4947,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_git_repo_1191';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_git_repo_113';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_glusterfs_1192 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_glusterfs_114 implements PcoreValue {
   readonly endpoints_name: string;
   readonly path: string;
   readonly read_only: boolean|null;
@@ -4981,11 +4981,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_glusterfs_1192';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_glusterfs_114';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_host_path_1193 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_host_path_115 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -5005,11 +5005,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_host_path_1193';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_host_path_115';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_iscsi_1194 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_iscsi_116 implements PcoreValue {
   readonly iqn: string;
   readonly target_portal: string;
   readonly fs_type: string|null;
@@ -5060,11 +5060,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_iscsi_1194';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_iscsi_116';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_local_1195 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_local_117 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -5084,11 +5084,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_local_1195';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_local_117';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_nfs_1196 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_nfs_118 implements PcoreValue {
   readonly path: string;
   readonly server: string;
   readonly read_only: boolean|null;
@@ -5118,11 +5118,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_nfs_1196';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_nfs_118';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_persistent_volume_claim_1197 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_persistent_volume_claim_119 implements PcoreValue {
   readonly claim_name: string|null;
   readonly read_only: boolean|null;
 
@@ -5149,11 +5149,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_persistent_volume_claim_1197';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_persistent_volume_claim_119';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_photon_persistent_disk_1198 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_photon_persistent_disk_120 implements PcoreValue {
   readonly pd_id: string;
   readonly fs_type: string|null;
 
@@ -5178,11 +5178,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_photon_persistent_disk_1198';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_photon_persistent_disk_120';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_quobyte_1199 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_quobyte_121 implements PcoreValue {
   readonly registry: string;
   readonly volume: string;
   readonly group: string|null;
@@ -5226,11 +5226,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_quobyte_1199';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_quobyte_121';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122 implements PcoreValue {
   readonly ceph_monitors: string[];
   readonly rbd_image: string;
   readonly fs_type: string|null;
@@ -5238,7 +5238,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   readonly rados_user: string|null;
   readonly rbd_pool: string|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200_secret_ref_1201[]|null;
+  readonly secret_ref: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122_secret_ref_123[]|null;
 
   constructor({
     ceph_monitors,
@@ -5257,7 +5257,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     rados_user?: string|null,
     rbd_pool?: string|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200_secret_ref_1201[]|null
+    secret_ref?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122_secret_ref_123[]|null
   }) {
     this.ceph_monitors = ceph_monitors;
     this.rbd_image = rbd_image;
@@ -5295,11 +5295,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200_secret_ref_1201 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122_secret_ref_123 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -5319,13 +5319,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_rbd_1200_secret_ref_1201';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_rbd_122_secret_ref_123';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202_items_1203[]|null;
+  readonly items: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124_items_125[]|null;
   readonly optional: boolean|null;
   readonly secret_name: string|null;
 
@@ -5336,7 +5336,7 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
     secret_name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202_items_1203[]|null,
+    items?: Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124_items_125[]|null,
     optional?: boolean|null,
     secret_name?: string|null
   }) {
@@ -5364,11 +5364,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202_items_1203 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124_items_125 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -5402,11 +5402,11 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_secret_1202_items_1203';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_secret_124_items_125';
   }
 }
 
-export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_vsphere_volume_1204 implements PcoreValue {
+export class Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_vsphere_volume_126 implements PcoreValue {
   readonly volume_path: string;
   readonly fs_type: string|null;
 
@@ -5431,13 +5431,13 @@ export class Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_deployment_spec_1083_template_1088_spec_1090_volume_1172_vsphere_volume_1204';
+    return 'TerraformKubernetes::Kubernetes_deployment_spec_5_template_10_spec_12_volume_94_vsphere_volume_126';
   }
 }
 
 export class Kubernetes_horizontal_pod_autoscaler implements PcoreValue {
-  readonly metadata: Kubernetes_horizontal_pod_autoscaler_metadata_1205[];
-  readonly spec: Kubernetes_horizontal_pod_autoscaler_spec_1206[];
+  readonly metadata: Kubernetes_horizontal_pod_autoscaler_metadata_127[];
+  readonly spec: Kubernetes_horizontal_pod_autoscaler_spec_128[];
   readonly kubernetes_horizontal_pod_autoscaler_id: string|null;
 
   constructor({
@@ -5445,8 +5445,8 @@ export class Kubernetes_horizontal_pod_autoscaler implements PcoreValue {
     spec,
     kubernetes_horizontal_pod_autoscaler_id = null
   }: {
-    metadata: Kubernetes_horizontal_pod_autoscaler_metadata_1205[],
-    spec: Kubernetes_horizontal_pod_autoscaler_spec_1206[],
+    metadata: Kubernetes_horizontal_pod_autoscaler_metadata_127[],
+    spec: Kubernetes_horizontal_pod_autoscaler_spec_128[],
     kubernetes_horizontal_pod_autoscaler_id?: string|null
   }) {
     this.metadata = metadata;
@@ -5479,7 +5479,7 @@ export class Kubernetes_horizontal_pod_autoscalerHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_horizontal_pod_autoscaler_metadata_1205 implements PcoreValue {
+export class Kubernetes_horizontal_pod_autoscaler_metadata_127 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -5555,13 +5555,13 @@ export class Kubernetes_horizontal_pod_autoscaler_metadata_1205 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_horizontal_pod_autoscaler_metadata_1205';
+    return 'TerraformKubernetes::Kubernetes_horizontal_pod_autoscaler_metadata_127';
   }
 }
 
-export class Kubernetes_horizontal_pod_autoscaler_spec_1206 implements PcoreValue {
+export class Kubernetes_horizontal_pod_autoscaler_spec_128 implements PcoreValue {
   readonly max_replicas: number;
-  readonly scale_target_ref: Kubernetes_horizontal_pod_autoscaler_spec_1206_scale_target_ref_1207[];
+  readonly scale_target_ref: Kubernetes_horizontal_pod_autoscaler_spec_128_scale_target_ref_129[];
   readonly min_replicas: number|null;
   readonly target_cpu_utilization_percentage: number|null;
 
@@ -5572,7 +5572,7 @@ export class Kubernetes_horizontal_pod_autoscaler_spec_1206 implements PcoreValu
     target_cpu_utilization_percentage = null
   }: {
     max_replicas: number,
-    scale_target_ref: Kubernetes_horizontal_pod_autoscaler_spec_1206_scale_target_ref_1207[],
+    scale_target_ref: Kubernetes_horizontal_pod_autoscaler_spec_128_scale_target_ref_129[],
     min_replicas?: number|null,
     target_cpu_utilization_percentage?: number|null
   }) {
@@ -5596,11 +5596,11 @@ export class Kubernetes_horizontal_pod_autoscaler_spec_1206 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_horizontal_pod_autoscaler_spec_1206';
+    return 'TerraformKubernetes::Kubernetes_horizontal_pod_autoscaler_spec_128';
   }
 }
 
-export class Kubernetes_horizontal_pod_autoscaler_spec_1206_scale_target_ref_1207 implements PcoreValue {
+export class Kubernetes_horizontal_pod_autoscaler_spec_128_scale_target_ref_129 implements PcoreValue {
   readonly kind: string;
   readonly name: string;
   readonly api_version: string|null;
@@ -5630,23 +5630,23 @@ export class Kubernetes_horizontal_pod_autoscaler_spec_1206_scale_target_ref_120
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_horizontal_pod_autoscaler_spec_1206_scale_target_ref_1207';
+    return 'TerraformKubernetes::Kubernetes_horizontal_pod_autoscaler_spec_128_scale_target_ref_129';
   }
 }
 
 export class Kubernetes_limit_range implements PcoreValue {
-  readonly metadata: Kubernetes_limit_range_metadata_1208[];
+  readonly metadata: Kubernetes_limit_range_metadata_130[];
   readonly kubernetes_limit_range_id: string|null;
-  readonly spec: Kubernetes_limit_range_spec_1209[]|null;
+  readonly spec: Kubernetes_limit_range_spec_131[]|null;
 
   constructor({
     metadata,
     kubernetes_limit_range_id = null,
     spec = null
   }: {
-    metadata: Kubernetes_limit_range_metadata_1208[],
+    metadata: Kubernetes_limit_range_metadata_130[],
     kubernetes_limit_range_id?: string|null,
-    spec?: Kubernetes_limit_range_spec_1209[]|null
+    spec?: Kubernetes_limit_range_spec_131[]|null
   }) {
     this.metadata = metadata;
     this.kubernetes_limit_range_id = kubernetes_limit_range_id;
@@ -5680,7 +5680,7 @@ export class Kubernetes_limit_rangeHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_limit_range_metadata_1208 implements PcoreValue {
+export class Kubernetes_limit_range_metadata_130 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -5756,17 +5756,17 @@ export class Kubernetes_limit_range_metadata_1208 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_limit_range_metadata_1208';
+    return 'TerraformKubernetes::Kubernetes_limit_range_metadata_130';
   }
 }
 
-export class Kubernetes_limit_range_spec_1209 implements PcoreValue {
-  readonly limit: Kubernetes_limit_range_spec_1209_limit_1210[]|null;
+export class Kubernetes_limit_range_spec_131 implements PcoreValue {
+  readonly limit: Kubernetes_limit_range_spec_131_limit_132[]|null;
 
   constructor({
     limit = null
   }: {
-    limit?: Kubernetes_limit_range_spec_1209_limit_1210[]|null
+    limit?: Kubernetes_limit_range_spec_131_limit_132[]|null
   }) {
     this.limit = limit;
   }
@@ -5780,11 +5780,11 @@ export class Kubernetes_limit_range_spec_1209 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_limit_range_spec_1209';
+    return 'TerraformKubernetes::Kubernetes_limit_range_spec_131';
   }
 }
 
-export class Kubernetes_limit_range_spec_1209_limit_1210 implements PcoreValue {
+export class Kubernetes_limit_range_spec_131_limit_132 implements PcoreValue {
   readonly default_: {[s: string]: string}|null;
   readonly default_request: {[s: string]: string}|null;
   readonly max: {[s: string]: string}|null;
@@ -5839,19 +5839,19 @@ export class Kubernetes_limit_range_spec_1209_limit_1210 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_limit_range_spec_1209_limit_1210';
+    return 'TerraformKubernetes::Kubernetes_limit_range_spec_131_limit_132';
   }
 }
 
 export class Kubernetes_namespace implements PcoreValue {
-  readonly metadata: Kubernetes_namespace_metadata_1211[];
+  readonly metadata: Kubernetes_namespace_metadata_133[];
   readonly kubernetes_namespace_id: string|null;
 
   constructor({
     metadata,
     kubernetes_namespace_id = null
   }: {
-    metadata: Kubernetes_namespace_metadata_1211[],
+    metadata: Kubernetes_namespace_metadata_133[],
     kubernetes_namespace_id?: string|null
   }) {
     this.metadata = metadata;
@@ -5882,7 +5882,7 @@ export class Kubernetes_namespaceHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_namespace_metadata_1211 implements PcoreValue {
+export class Kubernetes_namespace_metadata_133 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -5951,13 +5951,13 @@ export class Kubernetes_namespace_metadata_1211 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_namespace_metadata_1211';
+    return 'TerraformKubernetes::Kubernetes_namespace_metadata_133';
   }
 }
 
 export class Kubernetes_network_policy implements PcoreValue {
-  readonly metadata: Kubernetes_network_policy_metadata_1212[];
-  readonly spec: Kubernetes_network_policy_spec_1213[];
+  readonly metadata: Kubernetes_network_policy_metadata_134[];
+  readonly spec: Kubernetes_network_policy_spec_135[];
   readonly kubernetes_network_policy_id: string|null;
 
   constructor({
@@ -5965,8 +5965,8 @@ export class Kubernetes_network_policy implements PcoreValue {
     spec,
     kubernetes_network_policy_id = null
   }: {
-    metadata: Kubernetes_network_policy_metadata_1212[],
-    spec: Kubernetes_network_policy_spec_1213[],
+    metadata: Kubernetes_network_policy_metadata_134[],
+    spec: Kubernetes_network_policy_spec_135[],
     kubernetes_network_policy_id?: string|null
   }) {
     this.metadata = metadata;
@@ -5999,7 +5999,7 @@ export class Kubernetes_network_policyHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_network_policy_metadata_1212 implements PcoreValue {
+export class Kubernetes_network_policy_metadata_134 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -6075,15 +6075,15 @@ export class Kubernetes_network_policy_metadata_1212 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_metadata_1212';
+    return 'TerraformKubernetes::Kubernetes_network_policy_metadata_134';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213 implements PcoreValue {
-  readonly pod_selector: Kubernetes_network_policy_spec_1213_pod_selector_1230[];
+export class Kubernetes_network_policy_spec_135 implements PcoreValue {
+  readonly pod_selector: Kubernetes_network_policy_spec_135_pod_selector_152[];
   readonly policy_types: string[];
-  readonly egress: Kubernetes_network_policy_spec_1213_egress_1214[]|null;
-  readonly ingress: Kubernetes_network_policy_spec_1213_ingress_1222[]|null;
+  readonly egress: Kubernetes_network_policy_spec_135_egress_136[]|null;
+  readonly ingress: Kubernetes_network_policy_spec_135_ingress_144[]|null;
 
   constructor({
     pod_selector,
@@ -6091,10 +6091,10 @@ export class Kubernetes_network_policy_spec_1213 implements PcoreValue {
     egress = null,
     ingress = null
   }: {
-    pod_selector: Kubernetes_network_policy_spec_1213_pod_selector_1230[],
+    pod_selector: Kubernetes_network_policy_spec_135_pod_selector_152[],
     policy_types: string[],
-    egress?: Kubernetes_network_policy_spec_1213_egress_1214[]|null,
-    ingress?: Kubernetes_network_policy_spec_1213_ingress_1222[]|null
+    egress?: Kubernetes_network_policy_spec_135_egress_136[]|null,
+    ingress?: Kubernetes_network_policy_spec_135_ingress_144[]|null
   }) {
     this.pod_selector = pod_selector;
     this.policy_types = policy_types;
@@ -6116,20 +6116,20 @@ export class Kubernetes_network_policy_spec_1213 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214 implements PcoreValue {
-  readonly ports: Kubernetes_network_policy_spec_1213_egress_1214_ports_1215[]|null;
-  readonly to: Kubernetes_network_policy_spec_1213_egress_1214_to_1216[]|null;
+export class Kubernetes_network_policy_spec_135_egress_136 implements PcoreValue {
+  readonly ports: Kubernetes_network_policy_spec_135_egress_136_ports_137[]|null;
+  readonly to: Kubernetes_network_policy_spec_135_egress_136_to_138[]|null;
 
   constructor({
     ports = null,
     to = null
   }: {
-    ports?: Kubernetes_network_policy_spec_1213_egress_1214_ports_1215[]|null,
-    to?: Kubernetes_network_policy_spec_1213_egress_1214_to_1216[]|null
+    ports?: Kubernetes_network_policy_spec_135_egress_136_ports_137[]|null,
+    to?: Kubernetes_network_policy_spec_135_egress_136_to_138[]|null
   }) {
     this.ports = ports;
     this.to = to;
@@ -6147,11 +6147,11 @@ export class Kubernetes_network_policy_spec_1213_egress_1214 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_ports_1215 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_egress_136_ports_137 implements PcoreValue {
   readonly port: string|null;
   readonly protocol: string|null;
 
@@ -6178,23 +6178,23 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_ports_1215 implemen
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_ports_1215';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_ports_137';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216 implements PcoreValue {
-  readonly ip_block: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_ip_block_1217[]|null;
-  readonly namespace_selector: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218[]|null;
-  readonly pod_selector: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220[]|null;
+export class Kubernetes_network_policy_spec_135_egress_136_to_138 implements PcoreValue {
+  readonly ip_block: Kubernetes_network_policy_spec_135_egress_136_to_138_ip_block_139[]|null;
+  readonly namespace_selector: Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140[]|null;
+  readonly pod_selector: Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142[]|null;
 
   constructor({
     ip_block = null,
     namespace_selector = null,
     pod_selector = null
   }: {
-    ip_block?: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_ip_block_1217[]|null,
-    namespace_selector?: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218[]|null,
-    pod_selector?: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220[]|null
+    ip_block?: Kubernetes_network_policy_spec_135_egress_136_to_138_ip_block_139[]|null,
+    namespace_selector?: Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140[]|null,
+    pod_selector?: Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142[]|null
   }) {
     this.ip_block = ip_block;
     this.namespace_selector = namespace_selector;
@@ -6216,11 +6216,11 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216 implements 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_to_1216';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_to_138';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_ip_block_1217 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_egress_136_to_138_ip_block_139 implements PcoreValue {
   readonly cidr: string|null;
   readonly except: string[]|null;
 
@@ -6247,19 +6247,19 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_ip_block_12
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_to_1216_ip_block_1217';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_to_138_ip_block_139';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218 implements PcoreValue {
-  readonly match_expressions: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218_match_expressions_1219[]|null;
+export class Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140 implements PcoreValue {
+  readonly match_expressions: Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140_match_expressions_141[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218_match_expressions_1219[]|null,
+    match_expressions?: Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140_match_expressions_141[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -6278,11 +6278,11 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_s
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218_match_expressions_1219 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140_match_expressions_141 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -6316,19 +6316,19 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_s
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_to_1216_namespace_selector_1218_match_expressions_1219';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_to_138_namespace_selector_140_match_expressions_141';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220 implements PcoreValue {
-  readonly match_expressions: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220_match_expressions_1221[]|null;
+export class Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142 implements PcoreValue {
+  readonly match_expressions: Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142_match_expressions_143[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220_match_expressions_1221[]|null,
+    match_expressions?: Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142_match_expressions_143[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -6347,11 +6347,11 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selecto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220_match_expressions_1221 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142_match_expressions_143 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -6385,20 +6385,20 @@ export class Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selecto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_egress_1214_to_1216_pod_selector_1220_match_expressions_1221';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_egress_136_to_138_pod_selector_142_match_expressions_143';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222 implements PcoreValue {
-  readonly from: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223[]|null;
-  readonly ports: Kubernetes_network_policy_spec_1213_ingress_1222_ports_1229[]|null;
+export class Kubernetes_network_policy_spec_135_ingress_144 implements PcoreValue {
+  readonly from: Kubernetes_network_policy_spec_135_ingress_144_from_145[]|null;
+  readonly ports: Kubernetes_network_policy_spec_135_ingress_144_ports_151[]|null;
 
   constructor({
     from = null,
     ports = null
   }: {
-    from?: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223[]|null,
-    ports?: Kubernetes_network_policy_spec_1213_ingress_1222_ports_1229[]|null
+    from?: Kubernetes_network_policy_spec_135_ingress_144_from_145[]|null,
+    ports?: Kubernetes_network_policy_spec_135_ingress_144_ports_151[]|null
   }) {
     this.from = from;
     this.ports = ports;
@@ -6416,23 +6416,23 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223 implements PcoreValue {
-  readonly ip_block: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_ip_block_1224[]|null;
-  readonly namespace_selector: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225[]|null;
-  readonly pod_selector: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227[]|null;
+export class Kubernetes_network_policy_spec_135_ingress_144_from_145 implements PcoreValue {
+  readonly ip_block: Kubernetes_network_policy_spec_135_ingress_144_from_145_ip_block_146[]|null;
+  readonly namespace_selector: Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147[]|null;
+  readonly pod_selector: Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149[]|null;
 
   constructor({
     ip_block = null,
     namespace_selector = null,
     pod_selector = null
   }: {
-    ip_block?: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_ip_block_1224[]|null,
-    namespace_selector?: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225[]|null,
-    pod_selector?: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227[]|null
+    ip_block?: Kubernetes_network_policy_spec_135_ingress_144_from_145_ip_block_146[]|null,
+    namespace_selector?: Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147[]|null,
+    pod_selector?: Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149[]|null
   }) {
     this.ip_block = ip_block;
     this.namespace_selector = namespace_selector;
@@ -6454,11 +6454,11 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223 implemen
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_from_1223';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_from_145';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_ip_block_1224 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_ingress_144_from_145_ip_block_146 implements PcoreValue {
   readonly cidr: string|null;
   readonly except: string[]|null;
 
@@ -6485,19 +6485,19 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_ip_block
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_ip_block_1224';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_from_145_ip_block_146';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225 implements PcoreValue {
-  readonly match_expressions: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225_match_expressions_1226[]|null;
+export class Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147 implements PcoreValue {
+  readonly match_expressions: Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147_match_expressions_148[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225_match_expressions_1226[]|null,
+    match_expressions?: Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147_match_expressions_148[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -6516,11 +6516,11 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespac
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225_match_expressions_1226 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147_match_expressions_148 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -6554,19 +6554,19 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespac
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_namespace_selector_1225_match_expressions_1226';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_from_145_namespace_selector_147_match_expressions_148';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227 implements PcoreValue {
-  readonly match_expressions: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227_match_expressions_1228[]|null;
+export class Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149 implements PcoreValue {
+  readonly match_expressions: Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149_match_expressions_150[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227_match_expressions_1228[]|null,
+    match_expressions?: Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149_match_expressions_150[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -6585,11 +6585,11 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_sele
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227_match_expressions_1228 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149_match_expressions_150 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -6623,11 +6623,11 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_sele
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_from_1223_pod_selector_1227_match_expressions_1228';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_from_145_pod_selector_149_match_expressions_150';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_ingress_1222_ports_1229 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_ingress_144_ports_151 implements PcoreValue {
   readonly port: string|null;
   readonly protocol: string|null;
 
@@ -6654,19 +6654,19 @@ export class Kubernetes_network_policy_spec_1213_ingress_1222_ports_1229 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_ingress_1222_ports_1229';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_ingress_144_ports_151';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_pod_selector_1230 implements PcoreValue {
-  readonly match_expressions: Kubernetes_network_policy_spec_1213_pod_selector_1230_match_expressions_1231[]|null;
+export class Kubernetes_network_policy_spec_135_pod_selector_152 implements PcoreValue {
+  readonly match_expressions: Kubernetes_network_policy_spec_135_pod_selector_152_match_expressions_153[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_network_policy_spec_1213_pod_selector_1230_match_expressions_1231[]|null,
+    match_expressions?: Kubernetes_network_policy_spec_135_pod_selector_152_match_expressions_153[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -6685,11 +6685,11 @@ export class Kubernetes_network_policy_spec_1213_pod_selector_1230 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_pod_selector_1230';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_pod_selector_152';
   }
 }
 
-export class Kubernetes_network_policy_spec_1213_pod_selector_1230_match_expressions_1231 implements PcoreValue {
+export class Kubernetes_network_policy_spec_135_pod_selector_152_match_expressions_153 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -6723,13 +6723,13 @@ export class Kubernetes_network_policy_spec_1213_pod_selector_1230_match_express
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_network_policy_spec_1213_pod_selector_1230_match_expressions_1231';
+    return 'TerraformKubernetes::Kubernetes_network_policy_spec_135_pod_selector_152_match_expressions_153';
   }
 }
 
 export class Kubernetes_persistent_volume implements PcoreValue {
-  readonly metadata: Kubernetes_persistent_volume_metadata_1232[];
-  readonly spec: Kubernetes_persistent_volume_spec_1233[];
+  readonly metadata: Kubernetes_persistent_volume_metadata_154[];
+  readonly spec: Kubernetes_persistent_volume_spec_155[];
   readonly kubernetes_persistent_volume_id: string|null;
 
   constructor({
@@ -6737,8 +6737,8 @@ export class Kubernetes_persistent_volume implements PcoreValue {
     spec,
     kubernetes_persistent_volume_id = null
   }: {
-    metadata: Kubernetes_persistent_volume_metadata_1232[],
-    spec: Kubernetes_persistent_volume_spec_1233[],
+    metadata: Kubernetes_persistent_volume_metadata_154[],
+    spec: Kubernetes_persistent_volume_spec_155[],
     kubernetes_persistent_volume_id?: string|null
   }) {
     this.metadata = metadata;
@@ -6772,8 +6772,8 @@ export class Kubernetes_persistent_volumeHandler implements PcoreValue {
 }
 
 export class Kubernetes_persistent_volume_claim implements PcoreValue {
-  readonly metadata: Kubernetes_persistent_volume_claim_metadata_1261[];
-  readonly spec: Kubernetes_persistent_volume_claim_spec_1262[];
+  readonly metadata: Kubernetes_persistent_volume_claim_metadata_183[];
+  readonly spec: Kubernetes_persistent_volume_claim_spec_184[];
   readonly kubernetes_persistent_volume_claim_id: string|null;
   readonly wait_until_bound: boolean|null;
 
@@ -6783,8 +6783,8 @@ export class Kubernetes_persistent_volume_claim implements PcoreValue {
     kubernetes_persistent_volume_claim_id = null,
     wait_until_bound = null
   }: {
-    metadata: Kubernetes_persistent_volume_claim_metadata_1261[],
-    spec: Kubernetes_persistent_volume_claim_spec_1262[],
+    metadata: Kubernetes_persistent_volume_claim_metadata_183[],
+    spec: Kubernetes_persistent_volume_claim_spec_184[],
     kubernetes_persistent_volume_claim_id?: string|null,
     wait_until_bound?: boolean|null
   }) {
@@ -6822,7 +6822,7 @@ export class Kubernetes_persistent_volume_claimHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_persistent_volume_claim_metadata_1261 implements PcoreValue {
+export class Kubernetes_persistent_volume_claim_metadata_183 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -6898,14 +6898,14 @@ export class Kubernetes_persistent_volume_claim_metadata_1261 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_metadata_1261';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_metadata_183';
   }
 }
 
-export class Kubernetes_persistent_volume_claim_spec_1262 implements PcoreValue {
+export class Kubernetes_persistent_volume_claim_spec_184 implements PcoreValue {
   readonly access_modes: string[];
-  readonly resources: Kubernetes_persistent_volume_claim_spec_1262_resources_1263[];
-  readonly selector: Kubernetes_persistent_volume_claim_spec_1262_selector_1264[]|null;
+  readonly resources: Kubernetes_persistent_volume_claim_spec_184_resources_185[];
+  readonly selector: Kubernetes_persistent_volume_claim_spec_184_selector_186[]|null;
   readonly storage_class_name: string|null;
   readonly volume_name: string|null;
 
@@ -6917,8 +6917,8 @@ export class Kubernetes_persistent_volume_claim_spec_1262 implements PcoreValue 
     volume_name = null
   }: {
     access_modes: string[],
-    resources: Kubernetes_persistent_volume_claim_spec_1262_resources_1263[],
-    selector?: Kubernetes_persistent_volume_claim_spec_1262_selector_1264[]|null,
+    resources: Kubernetes_persistent_volume_claim_spec_184_resources_185[],
+    selector?: Kubernetes_persistent_volume_claim_spec_184_selector_186[]|null,
     storage_class_name?: string|null,
     volume_name?: string|null
   }) {
@@ -6946,11 +6946,11 @@ export class Kubernetes_persistent_volume_claim_spec_1262 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_1262';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_184';
   }
 }
 
-export class Kubernetes_persistent_volume_claim_spec_1262_resources_1263 implements PcoreValue {
+export class Kubernetes_persistent_volume_claim_spec_184_resources_185 implements PcoreValue {
   readonly limits: {[s: string]: string}|null;
   readonly requests: {[s: string]: string}|null;
 
@@ -6977,19 +6977,19 @@ export class Kubernetes_persistent_volume_claim_spec_1262_resources_1263 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_1262_resources_1263';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_184_resources_185';
   }
 }
 
-export class Kubernetes_persistent_volume_claim_spec_1262_selector_1264 implements PcoreValue {
-  readonly match_expressions: Kubernetes_persistent_volume_claim_spec_1262_selector_1264_match_expressions_1265[]|null;
+export class Kubernetes_persistent_volume_claim_spec_184_selector_186 implements PcoreValue {
+  readonly match_expressions: Kubernetes_persistent_volume_claim_spec_184_selector_186_match_expressions_187[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_persistent_volume_claim_spec_1262_selector_1264_match_expressions_1265[]|null,
+    match_expressions?: Kubernetes_persistent_volume_claim_spec_184_selector_186_match_expressions_187[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -7008,11 +7008,11 @@ export class Kubernetes_persistent_volume_claim_spec_1262_selector_1264 implemen
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_1262_selector_1264';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_184_selector_186';
   }
 }
 
-export class Kubernetes_persistent_volume_claim_spec_1262_selector_1264_match_expressions_1265 implements PcoreValue {
+export class Kubernetes_persistent_volume_claim_spec_184_selector_186_match_expressions_187 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -7046,11 +7046,11 @@ export class Kubernetes_persistent_volume_claim_spec_1262_selector_1264_match_ex
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_1262_selector_1264_match_expressions_1265';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_claim_spec_184_selector_186_match_expressions_187';
   }
 }
 
-export class Kubernetes_persistent_volume_metadata_1232 implements PcoreValue {
+export class Kubernetes_persistent_volume_metadata_154 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generation: number|null;
   readonly labels: {[s: string]: string}|null;
@@ -7112,15 +7112,15 @@ export class Kubernetes_persistent_volume_metadata_1232 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_metadata_1232';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_metadata_154';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155 implements PcoreValue {
   readonly access_modes: string[];
   readonly capacity: {[s: string]: string};
-  readonly persistent_volume_source: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239[];
-  readonly node_affinity: Kubernetes_persistent_volume_spec_1233_node_affinity_1234[]|null;
+  readonly persistent_volume_source: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161[];
+  readonly node_affinity: Kubernetes_persistent_volume_spec_155_node_affinity_156[]|null;
   readonly persistent_volume_reclaim_policy: string|null;
   readonly storage_class_name: string|null;
 
@@ -7134,8 +7134,8 @@ export class Kubernetes_persistent_volume_spec_1233 implements PcoreValue {
   }: {
     access_modes: string[],
     capacity: {[s: string]: string},
-    persistent_volume_source: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239[],
-    node_affinity?: Kubernetes_persistent_volume_spec_1233_node_affinity_1234[]|null,
+    persistent_volume_source: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161[],
+    node_affinity?: Kubernetes_persistent_volume_spec_155_node_affinity_156[]|null,
     persistent_volume_reclaim_policy?: string|null,
     storage_class_name?: string|null
   }) {
@@ -7165,17 +7165,17 @@ export class Kubernetes_persistent_volume_spec_1233 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234 implements PcoreValue {
-  readonly required: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235[]|null;
+export class Kubernetes_persistent_volume_spec_155_node_affinity_156 implements PcoreValue {
+  readonly required: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157[]|null;
 
   constructor({
     required = null
   }: {
-    required?: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235[]|null
+    required?: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157[]|null
   }) {
     this.required = required;
   }
@@ -7189,17 +7189,17 @@ export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234 implement
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_node_affinity_1234';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_node_affinity_156';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235 implements PcoreValue {
-  readonly node_selector_term: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236[]|null;
+export class Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157 implements PcoreValue {
+  readonly node_selector_term: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158[]|null;
 
   constructor({
     node_selector_term = null
   }: {
-    node_selector_term?: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236[]|null
+    node_selector_term?: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158[]|null
   }) {
     this.node_selector_term = node_selector_term;
   }
@@ -7213,20 +7213,20 @@ export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236 implements PcoreValue {
-  readonly match_expressions: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_expressions_1237[]|null;
-  readonly match_fields: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_fields_1238[]|null;
+export class Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158 implements PcoreValue {
+  readonly match_expressions: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_expressions_159[]|null;
+  readonly match_fields: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_fields_160[]|null;
 
   constructor({
     match_expressions = null,
     match_fields = null
   }: {
-    match_expressions?: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_expressions_1237[]|null,
-    match_fields?: Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_fields_1238[]|null
+    match_expressions?: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_expressions_159[]|null,
+    match_fields?: Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_fields_160[]|null
   }) {
     this.match_expressions = match_expressions;
     this.match_fields = match_fields;
@@ -7244,11 +7244,11 @@ export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_expressions_1237 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_expressions_159 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -7282,11 +7282,11 @@ export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_expressions_1237';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_expressions_159';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_fields_1238 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_fields_160 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -7320,29 +7320,29 @@ export class Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_node_affinity_1234_required_1235_node_selector_term_1236_match_fields_1238';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_node_affinity_156_required_157_node_selector_term_158_match_fields_160';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239 implements PcoreValue {
-  readonly aws_elastic_block_store: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_aws_elastic_block_store_1240[]|null;
-  readonly azure_disk: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_disk_1241[]|null;
-  readonly azure_file: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_file_1242[]|null;
-  readonly ceph_fs: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243[]|null;
-  readonly cinder: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_cinder_1245[]|null;
-  readonly fc: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_fc_1246[]|null;
-  readonly flex_volume: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247[]|null;
-  readonly flocker: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flocker_1249[]|null;
-  readonly gce_persistent_disk: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_gce_persistent_disk_1250[]|null;
-  readonly glusterfs: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_glusterfs_1251[]|null;
-  readonly host_path: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_host_path_1252[]|null;
-  readonly iscsi: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_iscsi_1253[]|null;
-  readonly local: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_local_1254[]|null;
-  readonly nfs: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_nfs_1255[]|null;
-  readonly photon_persistent_disk: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_photon_persistent_disk_1256[]|null;
-  readonly quobyte: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_quobyte_1257[]|null;
-  readonly rbd: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258[]|null;
-  readonly vsphere_volume: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_vsphere_volume_1260[]|null;
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161 implements PcoreValue {
+  readonly aws_elastic_block_store: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_aws_elastic_block_store_162[]|null;
+  readonly azure_disk: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_disk_163[]|null;
+  readonly azure_file: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_file_164[]|null;
+  readonly ceph_fs: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165[]|null;
+  readonly cinder: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_cinder_167[]|null;
+  readonly fc: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_fc_168[]|null;
+  readonly flex_volume: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169[]|null;
+  readonly flocker: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flocker_171[]|null;
+  readonly gce_persistent_disk: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_gce_persistent_disk_172[]|null;
+  readonly glusterfs: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_glusterfs_173[]|null;
+  readonly host_path: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_host_path_174[]|null;
+  readonly iscsi: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_iscsi_175[]|null;
+  readonly local: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_local_176[]|null;
+  readonly nfs: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_nfs_177[]|null;
+  readonly photon_persistent_disk: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_photon_persistent_disk_178[]|null;
+  readonly quobyte: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_quobyte_179[]|null;
+  readonly rbd: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180[]|null;
+  readonly vsphere_volume: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_vsphere_volume_182[]|null;
 
   constructor({
     aws_elastic_block_store = null,
@@ -7364,24 +7364,24 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
     rbd = null,
     vsphere_volume = null
   }: {
-    aws_elastic_block_store?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_aws_elastic_block_store_1240[]|null,
-    azure_disk?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_disk_1241[]|null,
-    azure_file?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_file_1242[]|null,
-    ceph_fs?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243[]|null,
-    cinder?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_cinder_1245[]|null,
-    fc?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_fc_1246[]|null,
-    flex_volume?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247[]|null,
-    flocker?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flocker_1249[]|null,
-    gce_persistent_disk?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_gce_persistent_disk_1250[]|null,
-    glusterfs?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_glusterfs_1251[]|null,
-    host_path?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_host_path_1252[]|null,
-    iscsi?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_iscsi_1253[]|null,
-    local?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_local_1254[]|null,
-    nfs?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_nfs_1255[]|null,
-    photon_persistent_disk?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_photon_persistent_disk_1256[]|null,
-    quobyte?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_quobyte_1257[]|null,
-    rbd?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258[]|null,
-    vsphere_volume?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_vsphere_volume_1260[]|null
+    aws_elastic_block_store?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_aws_elastic_block_store_162[]|null,
+    azure_disk?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_disk_163[]|null,
+    azure_file?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_file_164[]|null,
+    ceph_fs?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165[]|null,
+    cinder?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_cinder_167[]|null,
+    fc?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_fc_168[]|null,
+    flex_volume?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169[]|null,
+    flocker?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flocker_171[]|null,
+    gce_persistent_disk?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_gce_persistent_disk_172[]|null,
+    glusterfs?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_glusterfs_173[]|null,
+    host_path?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_host_path_174[]|null,
+    iscsi?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_iscsi_175[]|null,
+    local?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_local_176[]|null,
+    nfs?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_nfs_177[]|null,
+    photon_persistent_disk?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_photon_persistent_disk_178[]|null,
+    quobyte?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_quobyte_179[]|null,
+    rbd?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180[]|null,
+    vsphere_volume?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_vsphere_volume_182[]|null
   }) {
     this.aws_elastic_block_store = aws_elastic_block_store;
     this.azure_disk = azure_disk;
@@ -7463,11 +7463,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_aws_elastic_block_store_1240 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_aws_elastic_block_store_162 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -7506,11 +7506,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_aws_elastic_block_store_1240';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_aws_elastic_block_store_162';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_disk_1241 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_disk_163 implements PcoreValue {
   readonly caching_mode: string;
   readonly data_disk_uri: string;
   readonly disk_name: string;
@@ -7552,11 +7552,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_disk_1241';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_disk_163';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_file_1242 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_file_164 implements PcoreValue {
   readonly secret_name: string;
   readonly share_name: string;
   readonly read_only: boolean|null;
@@ -7586,16 +7586,16 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_azure_file_1242';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_azure_file_164';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165 implements PcoreValue {
   readonly monitors: string[];
   readonly path: string|null;
   readonly read_only: boolean|null;
   readonly secret_file: string|null;
-  readonly secret_ref: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243_secret_ref_1244[]|null;
+  readonly secret_ref: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165_secret_ref_166[]|null;
   readonly user: string|null;
 
   constructor({
@@ -7610,7 +7610,7 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
     path?: string|null,
     read_only?: boolean|null,
     secret_file?: string|null,
-    secret_ref?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243_secret_ref_1244[]|null,
+    secret_ref?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165_secret_ref_166[]|null,
     user?: string|null
   }) {
     this.monitors = monitors;
@@ -7643,11 +7643,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243_secret_ref_1244 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165_secret_ref_166 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -7667,11 +7667,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_ceph_fs_1243_secret_ref_1244';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_ceph_fs_165_secret_ref_166';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_cinder_1245 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_cinder_167 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly read_only: boolean|null;
@@ -7703,11 +7703,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_cinder_1245';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_cinder_167';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_fc_1246 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_fc_168 implements PcoreValue {
   readonly lun: number;
   readonly target_ww_ns: string[];
   readonly fs_type: string|null;
@@ -7744,16 +7744,16 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_fc_1246';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_fc_168';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169 implements PcoreValue {
   readonly driver: string;
   readonly fs_type: string|null;
   readonly options: {[s: string]: string}|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247_secret_ref_1248[]|null;
+  readonly secret_ref: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169_secret_ref_170[]|null;
 
   constructor({
     driver,
@@ -7766,7 +7766,7 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
     fs_type?: string|null,
     options?: {[s: string]: string}|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247_secret_ref_1248[]|null
+    secret_ref?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169_secret_ref_170[]|null
   }) {
     this.driver = driver;
     this.fs_type = fs_type;
@@ -7794,11 +7794,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247_secret_ref_1248 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169_secret_ref_170 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -7818,11 +7818,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flex_volume_1247_secret_ref_1248';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flex_volume_169_secret_ref_170';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flocker_1249 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flocker_171 implements PcoreValue {
   readonly dataset_name: string|null;
   readonly dataset_uuid: string|null;
 
@@ -7849,11 +7849,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_flocker_1249';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_flocker_171';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_gce_persistent_disk_1250 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_gce_persistent_disk_172 implements PcoreValue {
   readonly pd_name: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -7892,11 +7892,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_gce_persistent_disk_1250';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_gce_persistent_disk_172';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_glusterfs_1251 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_glusterfs_173 implements PcoreValue {
   readonly endpoints_name: string;
   readonly path: string;
   readonly read_only: boolean|null;
@@ -7926,11 +7926,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_glusterfs_1251';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_glusterfs_173';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_host_path_1252 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_host_path_174 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -7950,11 +7950,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_host_path_1252';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_host_path_174';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_iscsi_1253 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_iscsi_175 implements PcoreValue {
   readonly iqn: string;
   readonly target_portal: string;
   readonly fs_type: string|null;
@@ -8005,11 +8005,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_iscsi_1253';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_iscsi_175';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_local_1254 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_local_176 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -8029,11 +8029,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_local_1254';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_local_176';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_nfs_1255 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_nfs_177 implements PcoreValue {
   readonly path: string;
   readonly server: string;
   readonly read_only: boolean|null;
@@ -8063,11 +8063,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_nfs_1255';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_nfs_177';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_photon_persistent_disk_1256 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_photon_persistent_disk_178 implements PcoreValue {
   readonly pd_id: string;
   readonly fs_type: string|null;
 
@@ -8092,11 +8092,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_photon_persistent_disk_1256';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_photon_persistent_disk_178';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_quobyte_1257 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_quobyte_179 implements PcoreValue {
   readonly registry: string;
   readonly volume: string;
   readonly group: string|null;
@@ -8140,11 +8140,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_quobyte_1257';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_quobyte_179';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180 implements PcoreValue {
   readonly ceph_monitors: string[];
   readonly rbd_image: string;
   readonly fs_type: string|null;
@@ -8152,7 +8152,7 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   readonly rados_user: string|null;
   readonly rbd_pool: string|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258_secret_ref_1259[]|null;
+  readonly secret_ref: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180_secret_ref_181[]|null;
 
   constructor({
     ceph_monitors,
@@ -8171,7 +8171,7 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
     rados_user?: string|null,
     rbd_pool?: string|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258_secret_ref_1259[]|null
+    secret_ref?: Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180_secret_ref_181[]|null
   }) {
     this.ceph_monitors = ceph_monitors;
     this.rbd_image = rbd_image;
@@ -8209,11 +8209,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258_secret_ref_1259 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180_secret_ref_181 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -8233,11 +8233,11 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_rbd_1258_secret_ref_1259';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_rbd_180_secret_ref_181';
   }
 }
 
-export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_vsphere_volume_1260 implements PcoreValue {
+export class Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_vsphere_volume_182 implements PcoreValue {
   readonly volume_path: string;
   readonly fs_type: string|null;
 
@@ -8262,13 +8262,13 @@ export class Kubernetes_persistent_volume_spec_1233_persistent_volume_source_123
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_1233_persistent_volume_source_1239_vsphere_volume_1260';
+    return 'TerraformKubernetes::Kubernetes_persistent_volume_spec_155_persistent_volume_source_161_vsphere_volume_182';
   }
 }
 
 export class Kubernetes_pod implements PcoreValue {
-  readonly metadata: Kubernetes_pod_metadata_1266[];
-  readonly spec: Kubernetes_pod_spec_1267[];
+  readonly metadata: Kubernetes_pod_metadata_188[];
+  readonly spec: Kubernetes_pod_spec_189[];
   readonly kubernetes_pod_id: string|null;
 
   constructor({
@@ -8276,8 +8276,8 @@ export class Kubernetes_pod implements PcoreValue {
     spec,
     kubernetes_pod_id = null
   }: {
-    metadata: Kubernetes_pod_metadata_1266[],
-    spec: Kubernetes_pod_spec_1267[],
+    metadata: Kubernetes_pod_metadata_188[],
+    spec: Kubernetes_pod_spec_189[],
     kubernetes_pod_id?: string|null
   }) {
     this.metadata = metadata;
@@ -8310,7 +8310,7 @@ export class Kubernetes_podHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_pod_metadata_1266 implements PcoreValue {
+export class Kubernetes_pod_metadata_188 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -8386,28 +8386,28 @@ export class Kubernetes_pod_metadata_1266 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_metadata_1266';
+    return 'TerraformKubernetes::Kubernetes_pod_metadata_188';
   }
 }
 
-export class Kubernetes_pod_spec_1267 implements PcoreValue {
+export class Kubernetes_pod_spec_189 implements PcoreValue {
   readonly active_deadline_seconds: number|null;
-  readonly container: Kubernetes_pod_spec_1267_container_1268[]|null;
+  readonly container: Kubernetes_pod_spec_189_container_190[]|null;
   readonly dns_policy: string|null;
   readonly host_ipc: boolean|null;
   readonly host_network: boolean|null;
   readonly host_pid: boolean|null;
   readonly hostname: string|null;
-  readonly image_pull_secrets: Kubernetes_pod_spec_1267_image_pull_secrets_1307[]|null;
-  readonly init_container: Kubernetes_pod_spec_1267_init_container_1308[]|null;
+  readonly image_pull_secrets: Kubernetes_pod_spec_189_image_pull_secrets_229[]|null;
+  readonly init_container: Kubernetes_pod_spec_189_init_container_230[]|null;
   readonly node_name: string|null;
   readonly node_selector: {[s: string]: string}|null;
   readonly restart_policy: string|null;
-  readonly security_context: Kubernetes_pod_spec_1267_security_context_1347[]|null;
+  readonly security_context: Kubernetes_pod_spec_189_security_context_269[]|null;
   readonly service_account_name: string|null;
   readonly subdomain: string|null;
   readonly termination_grace_period_seconds: number|null;
-  readonly volume: Kubernetes_pod_spec_1267_volume_1349[]|null;
+  readonly volume: Kubernetes_pod_spec_189_volume_271[]|null;
 
   constructor({
     active_deadline_seconds = null,
@@ -8429,22 +8429,22 @@ export class Kubernetes_pod_spec_1267 implements PcoreValue {
     volume = null
   }: {
     active_deadline_seconds?: number|null,
-    container?: Kubernetes_pod_spec_1267_container_1268[]|null,
+    container?: Kubernetes_pod_spec_189_container_190[]|null,
     dns_policy?: string|null,
     host_ipc?: boolean|null,
     host_network?: boolean|null,
     host_pid?: boolean|null,
     hostname?: string|null,
-    image_pull_secrets?: Kubernetes_pod_spec_1267_image_pull_secrets_1307[]|null,
-    init_container?: Kubernetes_pod_spec_1267_init_container_1308[]|null,
+    image_pull_secrets?: Kubernetes_pod_spec_189_image_pull_secrets_229[]|null,
+    init_container?: Kubernetes_pod_spec_189_init_container_230[]|null,
     node_name?: string|null,
     node_selector?: {[s: string]: string}|null,
     restart_policy?: string|null,
-    security_context?: Kubernetes_pod_spec_1267_security_context_1347[]|null,
+    security_context?: Kubernetes_pod_spec_189_security_context_269[]|null,
     service_account_name?: string|null,
     subdomain?: string|null,
     termination_grace_period_seconds?: number|null,
-    volume?: Kubernetes_pod_spec_1267_volume_1349[]|null
+    volume?: Kubernetes_pod_spec_189_volume_271[]|null
   }) {
     this.active_deadline_seconds = active_deadline_seconds;
     this.container = container;
@@ -8522,29 +8522,29 @@ export class Kubernetes_pod_spec_1267 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_pod_spec_1267_container_1268_env_1269[]|null;
-  readonly env_from: Kubernetes_pod_spec_1267_container_1268_env_from_1275[]|null;
+  readonly env: Kubernetes_pod_spec_189_container_190_env_191[]|null;
+  readonly env_from: Kubernetes_pod_spec_189_container_190_env_from_197[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278[]|null;
-  readonly liveness_probe: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289[]|null;
-  readonly port: Kubernetes_pod_spec_1267_container_1268_port_1294[]|null;
-  readonly readiness_probe: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295[]|null;
-  readonly resources: Kubernetes_pod_spec_1267_container_1268_resources_1300[]|null;
-  readonly security_context: Kubernetes_pod_spec_1267_container_1268_security_context_1303[]|null;
+  readonly lifecycle: Kubernetes_pod_spec_189_container_190_lifecycle_200[]|null;
+  readonly liveness_probe: Kubernetes_pod_spec_189_container_190_liveness_probe_211[]|null;
+  readonly port: Kubernetes_pod_spec_189_container_190_port_216[]|null;
+  readonly readiness_probe: Kubernetes_pod_spec_189_container_190_readiness_probe_217[]|null;
+  readonly resources: Kubernetes_pod_spec_189_container_190_resources_222[]|null;
+  readonly security_context: Kubernetes_pod_spec_189_container_190_security_context_225[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_pod_spec_1267_container_1268_volume_mount_1306[]|null;
+  readonly volume_mount: Kubernetes_pod_spec_189_container_190_volume_mount_228[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -8571,21 +8571,21 @@ export class Kubernetes_pod_spec_1267_container_1268 implements PcoreValue {
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_pod_spec_1267_container_1268_env_1269[]|null,
-    env_from?: Kubernetes_pod_spec_1267_container_1268_env_from_1275[]|null,
+    env?: Kubernetes_pod_spec_189_container_190_env_191[]|null,
+    env_from?: Kubernetes_pod_spec_189_container_190_env_from_197[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278[]|null,
-    liveness_probe?: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289[]|null,
-    port?: Kubernetes_pod_spec_1267_container_1268_port_1294[]|null,
-    readiness_probe?: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295[]|null,
-    resources?: Kubernetes_pod_spec_1267_container_1268_resources_1300[]|null,
-    security_context?: Kubernetes_pod_spec_1267_container_1268_security_context_1303[]|null,
+    lifecycle?: Kubernetes_pod_spec_189_container_190_lifecycle_200[]|null,
+    liveness_probe?: Kubernetes_pod_spec_189_container_190_liveness_probe_211[]|null,
+    port?: Kubernetes_pod_spec_189_container_190_port_216[]|null,
+    readiness_probe?: Kubernetes_pod_spec_189_container_190_readiness_probe_217[]|null,
+    resources?: Kubernetes_pod_spec_189_container_190_resources_222[]|null,
+    security_context?: Kubernetes_pod_spec_189_container_190_security_context_225[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_pod_spec_1267_container_1268_volume_mount_1306[]|null,
+    volume_mount?: Kubernetes_pod_spec_189_container_190_volume_mount_228[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -8670,14 +8670,14 @@ export class Kubernetes_pod_spec_1267_container_1268 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_1269 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_191 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270[]|null;
+  readonly value_from: Kubernetes_pod_spec_189_container_190_env_191_value_from_192[]|null;
 
   constructor({
     name,
@@ -8686,7 +8686,7 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269 implements PcoreVa
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270[]|null
+    value_from?: Kubernetes_pod_spec_189_container_190_env_191_value_from_192[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -8706,15 +8706,15 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_1269';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_191';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_config_map_key_ref_1271[]|null;
-  readonly field_ref: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_field_ref_1272[]|null;
-  readonly resource_field_ref: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_resource_field_ref_1273[]|null;
-  readonly secret_key_ref: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_secret_key_ref_1274[]|null;
+export class Kubernetes_pod_spec_189_container_190_env_191_value_from_192 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_config_map_key_ref_193[]|null;
+  readonly field_ref: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_field_ref_194[]|null;
+  readonly resource_field_ref: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_resource_field_ref_195[]|null;
+  readonly secret_key_ref: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_secret_key_ref_196[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -8722,10 +8722,10 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270 im
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_config_map_key_ref_1271[]|null,
-    field_ref?: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_field_ref_1272[]|null,
-    resource_field_ref?: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_resource_field_ref_1273[]|null,
-    secret_key_ref?: Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_secret_key_ref_1274[]|null
+    config_map_key_ref?: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_config_map_key_ref_193[]|null,
+    field_ref?: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_field_ref_194[]|null,
+    resource_field_ref?: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_resource_field_ref_195[]|null,
+    secret_key_ref?: Kubernetes_pod_spec_189_container_190_env_191_value_from_192_secret_key_ref_196[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -8751,11 +8751,11 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270 im
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_191_value_from_192';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_config_map_key_ref_1271 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_191_value_from_192_config_map_key_ref_193 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -8782,11 +8782,11 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_co
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_config_map_key_ref_1271';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_191_value_from_192_config_map_key_ref_193';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_field_ref_1272 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_191_value_from_192_field_ref_194 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -8813,11 +8813,11 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_fi
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_field_ref_1272';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_191_value_from_192_field_ref_194';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_resource_field_ref_1273 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_191_value_from_192_resource_field_ref_195 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -8842,11 +8842,11 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_re
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_resource_field_ref_1273';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_191_value_from_192_resource_field_ref_195';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_secret_key_ref_1274 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_191_value_from_192_secret_key_ref_196 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -8873,23 +8873,23 @@ export class Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_se
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_1269_value_from_1270_secret_key_ref_1274';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_191_value_from_192_secret_key_ref_196';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_from_1275 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_pod_spec_1267_container_1268_env_from_1275_config_map_ref_1276[]|null;
+export class Kubernetes_pod_spec_189_container_190_env_from_197 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_pod_spec_189_container_190_env_from_197_config_map_ref_198[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_pod_spec_1267_container_1268_env_from_1275_secret_ref_1277[]|null;
+  readonly secret_ref: Kubernetes_pod_spec_189_container_190_env_from_197_secret_ref_199[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_pod_spec_1267_container_1268_env_from_1275_config_map_ref_1276[]|null,
+    config_map_ref?: Kubernetes_pod_spec_189_container_190_env_from_197_config_map_ref_198[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_pod_spec_1267_container_1268_env_from_1275_secret_ref_1277[]|null
+    secret_ref?: Kubernetes_pod_spec_189_container_190_env_from_197_secret_ref_199[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -8911,11 +8911,11 @@ export class Kubernetes_pod_spec_1267_container_1268_env_from_1275 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_from_1275';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_from_197';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_from_1275_config_map_ref_1276 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_from_197_config_map_ref_198 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -8940,11 +8940,11 @@ export class Kubernetes_pod_spec_1267_container_1268_env_from_1275_config_map_re
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_from_1275_config_map_ref_1276';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_from_197_config_map_ref_198';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_env_from_1275_secret_ref_1277 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_env_from_197_secret_ref_199 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -8969,20 +8969,20 @@ export class Kubernetes_pod_spec_1267_container_1268_env_from_1275_secret_ref_12
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_env_from_1275_secret_ref_1277';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_env_from_197_secret_ref_199';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278 implements PcoreValue {
-  readonly post_start: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279[]|null;
-  readonly pre_stop: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284[]|null;
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200 implements PcoreValue {
+  readonly post_start: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201[]|null;
+  readonly pre_stop: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279[]|null,
-    pre_stop?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284[]|null
+    post_start?: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201[]|null,
+    pre_stop?: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -9000,23 +9000,23 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278 implements P
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_exec_1280[]|null;
-  readonly http_get: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281[]|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_tcp_socket_1283[]|null;
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_exec_202[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_tcp_socket_205[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_exec_1280[]|null,
-    http_get?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281[]|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_tcp_socket_1283[]|null
+    exec?: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_exec_202[]|null,
+    http_get?: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_tcp_socket_205[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -9038,11 +9038,11 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_exec_1280 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_exec_202 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -9062,13 +9062,13 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_exec_1280';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_exec_202';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281_http_header_1282[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203_http_header_204[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -9081,7 +9081,7 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281_http_header_1282[]|null,
+    http_header?: Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203_http_header_204[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -9114,11 +9114,11 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281_http_header_1282 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203_http_header_204 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -9145,11 +9145,11 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_http_get_1281_http_header_1282';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_http_get_203_http_header_204';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_tcp_socket_1283 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_tcp_socket_205 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -9167,23 +9167,23 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_post_start_1279_tcp_socket_1283';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_post_start_201_tcp_socket_205';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_exec_1285[]|null;
-  readonly http_get: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286[]|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_tcp_socket_1288[]|null;
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_exec_207[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_tcp_socket_210[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_exec_1285[]|null,
-    http_get?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286[]|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_tcp_socket_1288[]|null
+    exec?: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_exec_207[]|null,
+    http_get?: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_tcp_socket_210[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -9205,11 +9205,11 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_128
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_exec_1285 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_exec_207 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -9229,13 +9229,13 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_128
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_exec_1285';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_exec_207';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286_http_header_1287[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208_http_header_209[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -9248,7 +9248,7 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_128
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286_http_header_1287[]|null,
+    http_header?: Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208_http_header_209[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -9281,11 +9281,11 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_128
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286_http_header_1287 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208_http_header_209 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -9312,11 +9312,11 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_128
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_http_get_1286_http_header_1287';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_http_get_208_http_header_209';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_tcp_socket_1288 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_tcp_socket_210 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -9334,18 +9334,18 @@ export class Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_128
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_lifecycle_1278_pre_stop_1284_tcp_socket_1288';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_lifecycle_200_pre_stop_206_tcp_socket_210';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_exec_1290[]|null;
+export class Kubernetes_pod_spec_189_container_190_liveness_probe_211 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_container_190_liveness_probe_211_exec_212[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_tcp_socket_1293[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_container_190_liveness_probe_211_tcp_socket_215[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -9358,13 +9358,13 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289 impleme
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_exec_1290[]|null,
+    exec?: Kubernetes_pod_spec_189_container_190_liveness_probe_211_exec_212[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291[]|null,
+    http_get?: Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_tcp_socket_1293[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_container_190_liveness_probe_211_tcp_socket_215[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -9407,11 +9407,11 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_liveness_probe_211';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_exec_1290 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_liveness_probe_211_exec_212 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -9431,13 +9431,13 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_exec_12
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_exec_1290';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_liveness_probe_211_exec_212';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291_http_header_1292[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213_http_header_214[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -9450,7 +9450,7 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_ge
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291_http_header_1292[]|null,
+    http_header?: Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213_http_header_214[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -9483,11 +9483,11 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_ge
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291_http_header_1292 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213_http_header_214 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -9514,11 +9514,11 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_ge
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_http_get_1291_http_header_1292';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_liveness_probe_211_http_get_213_http_header_214';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_tcp_socket_1293 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_liveness_probe_211_tcp_socket_215 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -9536,11 +9536,11 @@ export class Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_tcp_soc
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_liveness_probe_1289_tcp_socket_1293';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_liveness_probe_211_tcp_socket_215';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_port_1294 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_port_216 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -9586,18 +9586,18 @@ export class Kubernetes_pod_spec_1267_container_1268_port_1294 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_port_1294';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_port_216';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_exec_1296[]|null;
+export class Kubernetes_pod_spec_189_container_190_readiness_probe_217 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_container_190_readiness_probe_217_exec_218[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_tcp_socket_1299[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_container_190_readiness_probe_217_tcp_socket_221[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -9610,13 +9610,13 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295 implem
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_exec_1296[]|null,
+    exec?: Kubernetes_pod_spec_189_container_190_readiness_probe_217_exec_218[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297[]|null,
+    http_get?: Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_tcp_socket_1299[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_container_190_readiness_probe_217_tcp_socket_221[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -9659,11 +9659,11 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295 implem
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_readiness_probe_217';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_exec_1296 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_readiness_probe_217_exec_218 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -9683,13 +9683,13 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_exec_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_exec_1296';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_readiness_probe_217_exec_218';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297_http_header_1298[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219_http_header_220[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -9702,7 +9702,7 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_g
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297_http_header_1298[]|null,
+    http_header?: Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219_http_header_220[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -9735,11 +9735,11 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_g
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297_http_header_1298 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219_http_header_220 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -9766,11 +9766,11 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_g
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_http_get_1297_http_header_1298';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_readiness_probe_217_http_get_219_http_header_220';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_tcp_socket_1299 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_readiness_probe_217_tcp_socket_221 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -9788,20 +9788,20 @@ export class Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_tcp_so
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_readiness_probe_1295_tcp_socket_1299';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_readiness_probe_217_tcp_socket_221';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_resources_1300 implements PcoreValue {
-  readonly limits: Kubernetes_pod_spec_1267_container_1268_resources_1300_limits_1301[]|null;
-  readonly requests: Kubernetes_pod_spec_1267_container_1268_resources_1300_requests_1302[]|null;
+export class Kubernetes_pod_spec_189_container_190_resources_222 implements PcoreValue {
+  readonly limits: Kubernetes_pod_spec_189_container_190_resources_222_limits_223[]|null;
+  readonly requests: Kubernetes_pod_spec_189_container_190_resources_222_requests_224[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_pod_spec_1267_container_1268_resources_1300_limits_1301[]|null,
-    requests?: Kubernetes_pod_spec_1267_container_1268_resources_1300_requests_1302[]|null
+    limits?: Kubernetes_pod_spec_189_container_190_resources_222_limits_223[]|null,
+    requests?: Kubernetes_pod_spec_189_container_190_resources_222_requests_224[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -9819,11 +9819,11 @@ export class Kubernetes_pod_spec_1267_container_1268_resources_1300 implements P
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_resources_1300';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_resources_222';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_resources_1300_limits_1301 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_resources_222_limits_223 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -9850,11 +9850,11 @@ export class Kubernetes_pod_spec_1267_container_1268_resources_1300_limits_1301 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_resources_1300_limits_1301';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_resources_222_limits_223';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_resources_1300_requests_1302 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_resources_222_requests_224 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -9881,18 +9881,18 @@ export class Kubernetes_pod_spec_1267_container_1268_resources_1300_requests_130
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_resources_1300_requests_1302';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_resources_222_requests_224';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_security_context_1303 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_security_context_225 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_pod_spec_1267_container_1268_security_context_1303_capabilities_1304[]|null;
+  readonly capabilities: Kubernetes_pod_spec_189_container_190_security_context_225_capabilities_226[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_pod_spec_1267_container_1268_security_context_1303_se_linux_options_1305[]|null;
+  readonly se_linux_options: Kubernetes_pod_spec_189_container_190_security_context_225_se_linux_options_227[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -9904,12 +9904,12 @@ export class Kubernetes_pod_spec_1267_container_1268_security_context_1303 imple
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_pod_spec_1267_container_1268_security_context_1303_capabilities_1304[]|null,
+    capabilities?: Kubernetes_pod_spec_189_container_190_security_context_225_capabilities_226[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_pod_spec_1267_container_1268_security_context_1303_se_linux_options_1305[]|null
+    se_linux_options?: Kubernetes_pod_spec_189_container_190_security_context_225_se_linux_options_227[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -9947,11 +9947,11 @@ export class Kubernetes_pod_spec_1267_container_1268_security_context_1303 imple
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_security_context_1303';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_security_context_225';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_security_context_1303_capabilities_1304 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_security_context_225_capabilities_226 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -9978,11 +9978,11 @@ export class Kubernetes_pod_spec_1267_container_1268_security_context_1303_capab
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_security_context_1303_capabilities_1304';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_security_context_225_capabilities_226';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_security_context_1303_se_linux_options_1305 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_security_context_225_se_linux_options_227 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -10023,11 +10023,11 @@ export class Kubernetes_pod_spec_1267_container_1268_security_context_1303_se_li
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_security_context_1303_se_linux_options_1305';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_security_context_225_se_linux_options_227';
   }
 }
 
-export class Kubernetes_pod_spec_1267_container_1268_volume_mount_1306 implements PcoreValue {
+export class Kubernetes_pod_spec_189_container_190_volume_mount_228 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -10064,11 +10064,11 @@ export class Kubernetes_pod_spec_1267_container_1268_volume_mount_1306 implement
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_container_1268_volume_mount_1306';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_container_190_volume_mount_228';
   }
 }
 
-export class Kubernetes_pod_spec_1267_image_pull_secrets_1307 implements PcoreValue {
+export class Kubernetes_pod_spec_189_image_pull_secrets_229 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -10086,29 +10086,29 @@ export class Kubernetes_pod_spec_1267_image_pull_secrets_1307 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_image_pull_secrets_1307';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_image_pull_secrets_229';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_pod_spec_1267_init_container_1308_env_1309[]|null;
-  readonly env_from: Kubernetes_pod_spec_1267_init_container_1308_env_from_1315[]|null;
+  readonly env: Kubernetes_pod_spec_189_init_container_230_env_231[]|null;
+  readonly env_from: Kubernetes_pod_spec_189_init_container_230_env_from_237[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318[]|null;
-  readonly liveness_probe: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329[]|null;
-  readonly port: Kubernetes_pod_spec_1267_init_container_1308_port_1334[]|null;
-  readonly readiness_probe: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335[]|null;
-  readonly resources: Kubernetes_pod_spec_1267_init_container_1308_resources_1340[]|null;
-  readonly security_context: Kubernetes_pod_spec_1267_init_container_1308_security_context_1343[]|null;
+  readonly lifecycle: Kubernetes_pod_spec_189_init_container_230_lifecycle_240[]|null;
+  readonly liveness_probe: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251[]|null;
+  readonly port: Kubernetes_pod_spec_189_init_container_230_port_256[]|null;
+  readonly readiness_probe: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257[]|null;
+  readonly resources: Kubernetes_pod_spec_189_init_container_230_resources_262[]|null;
+  readonly security_context: Kubernetes_pod_spec_189_init_container_230_security_context_265[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_pod_spec_1267_init_container_1308_volume_mount_1346[]|null;
+  readonly volume_mount: Kubernetes_pod_spec_189_init_container_230_volume_mount_268[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -10135,21 +10135,21 @@ export class Kubernetes_pod_spec_1267_init_container_1308 implements PcoreValue 
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_pod_spec_1267_init_container_1308_env_1309[]|null,
-    env_from?: Kubernetes_pod_spec_1267_init_container_1308_env_from_1315[]|null,
+    env?: Kubernetes_pod_spec_189_init_container_230_env_231[]|null,
+    env_from?: Kubernetes_pod_spec_189_init_container_230_env_from_237[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318[]|null,
-    liveness_probe?: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329[]|null,
-    port?: Kubernetes_pod_spec_1267_init_container_1308_port_1334[]|null,
-    readiness_probe?: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335[]|null,
-    resources?: Kubernetes_pod_spec_1267_init_container_1308_resources_1340[]|null,
-    security_context?: Kubernetes_pod_spec_1267_init_container_1308_security_context_1343[]|null,
+    lifecycle?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240[]|null,
+    liveness_probe?: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251[]|null,
+    port?: Kubernetes_pod_spec_189_init_container_230_port_256[]|null,
+    readiness_probe?: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257[]|null,
+    resources?: Kubernetes_pod_spec_189_init_container_230_resources_262[]|null,
+    security_context?: Kubernetes_pod_spec_189_init_container_230_security_context_265[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_pod_spec_1267_init_container_1308_volume_mount_1346[]|null,
+    volume_mount?: Kubernetes_pod_spec_189_init_container_230_volume_mount_268[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -10234,14 +10234,14 @@ export class Kubernetes_pod_spec_1267_init_container_1308 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_1309 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_231 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310[]|null;
+  readonly value_from: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232[]|null;
 
   constructor({
     name,
@@ -10250,7 +10250,7 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309 implements Pc
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310[]|null
+    value_from?: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -10270,15 +10270,15 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_1309';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_231';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_config_map_key_ref_1311[]|null;
-  readonly field_ref: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_field_ref_1312[]|null;
-  readonly resource_field_ref: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_resource_field_ref_1313[]|null;
-  readonly secret_key_ref: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_secret_key_ref_1314[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_config_map_key_ref_233[]|null;
+  readonly field_ref: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_field_ref_234[]|null;
+  readonly resource_field_ref: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_resource_field_ref_235[]|null;
+  readonly secret_key_ref: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_secret_key_ref_236[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -10286,10 +10286,10 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_13
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_config_map_key_ref_1311[]|null,
-    field_ref?: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_field_ref_1312[]|null,
-    resource_field_ref?: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_resource_field_ref_1313[]|null,
-    secret_key_ref?: Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_secret_key_ref_1314[]|null
+    config_map_key_ref?: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_config_map_key_ref_233[]|null,
+    field_ref?: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_field_ref_234[]|null,
+    resource_field_ref?: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_resource_field_ref_235[]|null,
+    secret_key_ref?: Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_secret_key_ref_236[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -10315,11 +10315,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_13
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_config_map_key_ref_1311 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_config_map_key_ref_233 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -10346,11 +10346,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_13
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_config_map_key_ref_1311';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_config_map_key_ref_233';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_field_ref_1312 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_field_ref_234 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -10377,11 +10377,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_13
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_field_ref_1312';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_field_ref_234';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_resource_field_ref_1313 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_resource_field_ref_235 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -10406,11 +10406,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_13
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_resource_field_ref_1313';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_resource_field_ref_235';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_secret_key_ref_1314 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_secret_key_ref_236 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -10437,23 +10437,23 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_13
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_1309_value_from_1310_secret_key_ref_1314';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_231_value_from_232_secret_key_ref_236';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_from_1315 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_config_map_ref_1316[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_env_from_237 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_pod_spec_189_init_container_230_env_from_237_config_map_ref_238[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_secret_ref_1317[]|null;
+  readonly secret_ref: Kubernetes_pod_spec_189_init_container_230_env_from_237_secret_ref_239[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_config_map_ref_1316[]|null,
+    config_map_ref?: Kubernetes_pod_spec_189_init_container_230_env_from_237_config_map_ref_238[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_secret_ref_1317[]|null
+    secret_ref?: Kubernetes_pod_spec_189_init_container_230_env_from_237_secret_ref_239[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -10475,11 +10475,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_from_1315 implemen
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_from_1315';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_from_237';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_config_map_ref_1316 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_from_237_config_map_ref_238 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -10504,11 +10504,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_config_m
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_config_map_ref_1316';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_from_237_config_map_ref_238';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_secret_ref_1317 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_env_from_237_secret_ref_239 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -10533,20 +10533,20 @@ export class Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_secret_r
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_env_from_1315_secret_ref_1317';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_env_from_237_secret_ref_239';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318 implements PcoreValue {
-  readonly post_start: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319[]|null;
-  readonly pre_stop: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240 implements PcoreValue {
+  readonly post_start: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241[]|null;
+  readonly pre_stop: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319[]|null,
-    pre_stop?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324[]|null
+    post_start?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241[]|null,
+    pre_stop?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -10564,23 +10564,23 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_exec_1320[]|null;
-  readonly http_get: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321[]|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_tcp_socket_1323[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_exec_242[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_tcp_socket_245[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_exec_1320[]|null,
-    http_get?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321[]|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_tcp_socket_1323[]|null
+    exec?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_exec_242[]|null,
+    http_get?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_tcp_socket_245[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -10602,11 +10602,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_st
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_exec_1320 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_exec_242 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -10626,13 +10626,13 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_st
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_exec_1320';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_exec_242';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321_http_header_1322[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243_http_header_244[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -10645,7 +10645,7 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_st
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321_http_header_1322[]|null,
+    http_header?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243_http_header_244[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -10678,11 +10678,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_st
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321_http_header_1322 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243_http_header_244 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -10709,11 +10709,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_st
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_http_get_1321_http_header_1322';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_http_get_243_http_header_244';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_tcp_socket_1323 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_tcp_socket_245 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -10731,23 +10731,23 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_st
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_post_start_1319_tcp_socket_1323';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_post_start_241_tcp_socket_245';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_exec_1325[]|null;
-  readonly http_get: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326[]|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_tcp_socket_1328[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_exec_247[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_tcp_socket_250[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_exec_1325[]|null,
-    http_get?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326[]|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_tcp_socket_1328[]|null
+    exec?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_exec_247[]|null,
+    http_get?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_tcp_socket_250[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -10769,11 +10769,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_sto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_exec_1325 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_exec_247 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -10793,13 +10793,13 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_sto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_exec_1325';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_exec_247';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326_http_header_1327[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248_http_header_249[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -10812,7 +10812,7 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_sto
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326_http_header_1327[]|null,
+    http_header?: Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248_http_header_249[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -10845,11 +10845,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_sto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326_http_header_1327 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248_http_header_249 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -10876,11 +10876,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_sto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_http_get_1326_http_header_1327';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_http_get_248_http_header_249';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_tcp_socket_1328 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_tcp_socket_250 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -10898,18 +10898,18 @@ export class Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_sto
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_lifecycle_1318_pre_stop_1324_tcp_socket_1328';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_lifecycle_240_pre_stop_246_tcp_socket_250';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_exec_1330[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_liveness_probe_251 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_exec_252[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_tcp_socket_1333[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_tcp_socket_255[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -10922,13 +10922,13 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329 im
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_exec_1330[]|null,
+    exec?: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_exec_252[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331[]|null,
+    http_get?: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_tcp_socket_1333[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_tcp_socket_255[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -10971,11 +10971,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329 im
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_liveness_probe_251';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_exec_1330 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_exec_252 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -10995,13 +10995,13 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_ex
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_exec_1330';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_exec_252';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331_http_header_1332[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253_http_header_254[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -11014,7 +11014,7 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_ht
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331_http_header_1332[]|null,
+    http_header?: Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253_http_header_254[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -11047,11 +11047,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_ht
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331_http_header_1332 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253_http_header_254 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -11078,11 +11078,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_ht
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_http_get_1331_http_header_1332';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_http_get_253_http_header_254';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_tcp_socket_1333 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_tcp_socket_255 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -11100,11 +11100,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_tc
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_liveness_probe_1329_tcp_socket_1333';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_liveness_probe_251_tcp_socket_255';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_port_1334 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_port_256 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -11150,18 +11150,18 @@ export class Kubernetes_pod_spec_1267_init_container_1308_port_1334 implements P
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_port_1334';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_port_256';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335 implements PcoreValue {
-  readonly exec: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_exec_1336[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_readiness_probe_257 implements PcoreValue {
+  readonly exec: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_exec_258[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337[]|null;
+  readonly http_get: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_tcp_socket_1339[]|null;
+  readonly tcp_socket: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_tcp_socket_261[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -11174,13 +11174,13 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335 i
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_exec_1336[]|null,
+    exec?: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_exec_258[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337[]|null,
+    http_get?: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_tcp_socket_1339[]|null,
+    tcp_socket?: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_tcp_socket_261[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -11223,11 +11223,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335 i
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_readiness_probe_257';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_exec_1336 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_exec_258 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -11247,13 +11247,13 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_e
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_exec_1336';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_exec_258';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337_http_header_1338[]|null;
+  readonly http_header: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259_http_header_260[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -11266,7 +11266,7 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_h
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337_http_header_1338[]|null,
+    http_header?: Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259_http_header_260[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -11299,11 +11299,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_h
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337_http_header_1338 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259_http_header_260 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -11330,11 +11330,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_h
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_http_get_1337_http_header_1338';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_http_get_259_http_header_260';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_tcp_socket_1339 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_tcp_socket_261 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -11352,20 +11352,20 @@ export class Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_t
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_readiness_probe_1335_tcp_socket_1339';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_readiness_probe_257_tcp_socket_261';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_resources_1340 implements PcoreValue {
-  readonly limits: Kubernetes_pod_spec_1267_init_container_1308_resources_1340_limits_1341[]|null;
-  readonly requests: Kubernetes_pod_spec_1267_init_container_1308_resources_1340_requests_1342[]|null;
+export class Kubernetes_pod_spec_189_init_container_230_resources_262 implements PcoreValue {
+  readonly limits: Kubernetes_pod_spec_189_init_container_230_resources_262_limits_263[]|null;
+  readonly requests: Kubernetes_pod_spec_189_init_container_230_resources_262_requests_264[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_pod_spec_1267_init_container_1308_resources_1340_limits_1341[]|null,
-    requests?: Kubernetes_pod_spec_1267_init_container_1308_resources_1340_requests_1342[]|null
+    limits?: Kubernetes_pod_spec_189_init_container_230_resources_262_limits_263[]|null,
+    requests?: Kubernetes_pod_spec_189_init_container_230_resources_262_requests_264[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -11383,11 +11383,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_resources_1340 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_resources_1340';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_resources_262';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_resources_1340_limits_1341 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_resources_262_limits_263 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -11414,11 +11414,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_resources_1340_limits_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_resources_1340_limits_1341';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_resources_262_limits_263';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_resources_1340_requests_1342 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_resources_262_requests_264 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -11445,18 +11445,18 @@ export class Kubernetes_pod_spec_1267_init_container_1308_resources_1340_request
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_resources_1340_requests_1342';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_resources_262_requests_264';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_security_context_265 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_capabilities_1344[]|null;
+  readonly capabilities: Kubernetes_pod_spec_189_init_container_230_security_context_265_capabilities_266[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_se_linux_options_1345[]|null;
+  readonly se_linux_options: Kubernetes_pod_spec_189_init_container_230_security_context_265_se_linux_options_267[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -11468,12 +11468,12 @@ export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343 
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_capabilities_1344[]|null,
+    capabilities?: Kubernetes_pod_spec_189_init_container_230_security_context_265_capabilities_266[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_se_linux_options_1345[]|null
+    se_linux_options?: Kubernetes_pod_spec_189_init_container_230_security_context_265_se_linux_options_267[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -11511,11 +11511,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_security_context_1343';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_security_context_265';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_capabilities_1344 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_security_context_265_capabilities_266 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -11542,11 +11542,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_capabilities_1344';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_security_context_265_capabilities_266';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_se_linux_options_1345 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_security_context_265_se_linux_options_267 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -11587,11 +11587,11 @@ export class Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_security_context_1343_se_linux_options_1345';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_security_context_265_se_linux_options_267';
   }
 }
 
-export class Kubernetes_pod_spec_1267_init_container_1308_volume_mount_1346 implements PcoreValue {
+export class Kubernetes_pod_spec_189_init_container_230_volume_mount_268 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -11628,15 +11628,15 @@ export class Kubernetes_pod_spec_1267_init_container_1308_volume_mount_1346 impl
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_init_container_1308_volume_mount_1346';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_init_container_230_volume_mount_268';
   }
 }
 
-export class Kubernetes_pod_spec_1267_security_context_1347 implements PcoreValue {
+export class Kubernetes_pod_spec_189_security_context_269 implements PcoreValue {
   readonly fs_group: number|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_pod_spec_1267_security_context_1347_se_linux_options_1348[]|null;
+  readonly se_linux_options: Kubernetes_pod_spec_189_security_context_269_se_linux_options_270[]|null;
   readonly supplemental_groups: number[]|null;
 
   constructor({
@@ -11649,7 +11649,7 @@ export class Kubernetes_pod_spec_1267_security_context_1347 implements PcoreValu
     fs_group?: number|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_pod_spec_1267_security_context_1347_se_linux_options_1348[]|null,
+    se_linux_options?: Kubernetes_pod_spec_189_security_context_269_se_linux_options_270[]|null,
     supplemental_groups?: number[]|null
   }) {
     this.fs_group = fs_group;
@@ -11680,11 +11680,11 @@ export class Kubernetes_pod_spec_1267_security_context_1347 implements PcoreValu
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_security_context_1347';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_security_context_269';
   }
 }
 
-export class Kubernetes_pod_spec_1267_security_context_1347_se_linux_options_1348 implements PcoreValue {
+export class Kubernetes_pod_spec_189_security_context_269_se_linux_options_270 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -11725,36 +11725,36 @@ export class Kubernetes_pod_spec_1267_security_context_1347_se_linux_options_134
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_security_context_1347_se_linux_options_1348';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_security_context_269_se_linux_options_270';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349 implements PcoreValue {
-  readonly aws_elastic_block_store: Kubernetes_pod_spec_1267_volume_1349_aws_elastic_block_store_1350[]|null;
-  readonly azure_disk: Kubernetes_pod_spec_1267_volume_1349_azure_disk_1351[]|null;
-  readonly azure_file: Kubernetes_pod_spec_1267_volume_1349_azure_file_1352[]|null;
-  readonly ceph_fs: Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353[]|null;
-  readonly cinder: Kubernetes_pod_spec_1267_volume_1349_cinder_1355[]|null;
-  readonly config_map: Kubernetes_pod_spec_1267_volume_1349_config_map_1356[]|null;
-  readonly downward_api: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358[]|null;
-  readonly empty_dir: Kubernetes_pod_spec_1267_volume_1349_empty_dir_1362[]|null;
-  readonly fc: Kubernetes_pod_spec_1267_volume_1349_fc_1363[]|null;
-  readonly flex_volume: Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364[]|null;
-  readonly flocker: Kubernetes_pod_spec_1267_volume_1349_flocker_1366[]|null;
-  readonly gce_persistent_disk: Kubernetes_pod_spec_1267_volume_1349_gce_persistent_disk_1367[]|null;
-  readonly git_repo: Kubernetes_pod_spec_1267_volume_1349_git_repo_1368[]|null;
-  readonly glusterfs: Kubernetes_pod_spec_1267_volume_1349_glusterfs_1369[]|null;
-  readonly host_path: Kubernetes_pod_spec_1267_volume_1349_host_path_1370[]|null;
-  readonly iscsi: Kubernetes_pod_spec_1267_volume_1349_iscsi_1371[]|null;
-  readonly local: Kubernetes_pod_spec_1267_volume_1349_local_1372[]|null;
+export class Kubernetes_pod_spec_189_volume_271 implements PcoreValue {
+  readonly aws_elastic_block_store: Kubernetes_pod_spec_189_volume_271_aws_elastic_block_store_272[]|null;
+  readonly azure_disk: Kubernetes_pod_spec_189_volume_271_azure_disk_273[]|null;
+  readonly azure_file: Kubernetes_pod_spec_189_volume_271_azure_file_274[]|null;
+  readonly ceph_fs: Kubernetes_pod_spec_189_volume_271_ceph_fs_275[]|null;
+  readonly cinder: Kubernetes_pod_spec_189_volume_271_cinder_277[]|null;
+  readonly config_map: Kubernetes_pod_spec_189_volume_271_config_map_278[]|null;
+  readonly downward_api: Kubernetes_pod_spec_189_volume_271_downward_api_280[]|null;
+  readonly empty_dir: Kubernetes_pod_spec_189_volume_271_empty_dir_284[]|null;
+  readonly fc: Kubernetes_pod_spec_189_volume_271_fc_285[]|null;
+  readonly flex_volume: Kubernetes_pod_spec_189_volume_271_flex_volume_286[]|null;
+  readonly flocker: Kubernetes_pod_spec_189_volume_271_flocker_288[]|null;
+  readonly gce_persistent_disk: Kubernetes_pod_spec_189_volume_271_gce_persistent_disk_289[]|null;
+  readonly git_repo: Kubernetes_pod_spec_189_volume_271_git_repo_290[]|null;
+  readonly glusterfs: Kubernetes_pod_spec_189_volume_271_glusterfs_291[]|null;
+  readonly host_path: Kubernetes_pod_spec_189_volume_271_host_path_292[]|null;
+  readonly iscsi: Kubernetes_pod_spec_189_volume_271_iscsi_293[]|null;
+  readonly local: Kubernetes_pod_spec_189_volume_271_local_294[]|null;
   readonly name: string|null;
-  readonly nfs: Kubernetes_pod_spec_1267_volume_1349_nfs_1373[]|null;
-  readonly persistent_volume_claim: Kubernetes_pod_spec_1267_volume_1349_persistent_volume_claim_1374[]|null;
-  readonly photon_persistent_disk: Kubernetes_pod_spec_1267_volume_1349_photon_persistent_disk_1375[]|null;
-  readonly quobyte: Kubernetes_pod_spec_1267_volume_1349_quobyte_1376[]|null;
-  readonly rbd: Kubernetes_pod_spec_1267_volume_1349_rbd_1377[]|null;
-  readonly secret: Kubernetes_pod_spec_1267_volume_1349_secret_1379[]|null;
-  readonly vsphere_volume: Kubernetes_pod_spec_1267_volume_1349_vsphere_volume_1381[]|null;
+  readonly nfs: Kubernetes_pod_spec_189_volume_271_nfs_295[]|null;
+  readonly persistent_volume_claim: Kubernetes_pod_spec_189_volume_271_persistent_volume_claim_296[]|null;
+  readonly photon_persistent_disk: Kubernetes_pod_spec_189_volume_271_photon_persistent_disk_297[]|null;
+  readonly quobyte: Kubernetes_pod_spec_189_volume_271_quobyte_298[]|null;
+  readonly rbd: Kubernetes_pod_spec_189_volume_271_rbd_299[]|null;
+  readonly secret: Kubernetes_pod_spec_189_volume_271_secret_301[]|null;
+  readonly vsphere_volume: Kubernetes_pod_spec_189_volume_271_vsphere_volume_303[]|null;
 
   constructor({
     aws_elastic_block_store = null,
@@ -11783,31 +11783,31 @@ export class Kubernetes_pod_spec_1267_volume_1349 implements PcoreValue {
     secret = null,
     vsphere_volume = null
   }: {
-    aws_elastic_block_store?: Kubernetes_pod_spec_1267_volume_1349_aws_elastic_block_store_1350[]|null,
-    azure_disk?: Kubernetes_pod_spec_1267_volume_1349_azure_disk_1351[]|null,
-    azure_file?: Kubernetes_pod_spec_1267_volume_1349_azure_file_1352[]|null,
-    ceph_fs?: Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353[]|null,
-    cinder?: Kubernetes_pod_spec_1267_volume_1349_cinder_1355[]|null,
-    config_map?: Kubernetes_pod_spec_1267_volume_1349_config_map_1356[]|null,
-    downward_api?: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358[]|null,
-    empty_dir?: Kubernetes_pod_spec_1267_volume_1349_empty_dir_1362[]|null,
-    fc?: Kubernetes_pod_spec_1267_volume_1349_fc_1363[]|null,
-    flex_volume?: Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364[]|null,
-    flocker?: Kubernetes_pod_spec_1267_volume_1349_flocker_1366[]|null,
-    gce_persistent_disk?: Kubernetes_pod_spec_1267_volume_1349_gce_persistent_disk_1367[]|null,
-    git_repo?: Kubernetes_pod_spec_1267_volume_1349_git_repo_1368[]|null,
-    glusterfs?: Kubernetes_pod_spec_1267_volume_1349_glusterfs_1369[]|null,
-    host_path?: Kubernetes_pod_spec_1267_volume_1349_host_path_1370[]|null,
-    iscsi?: Kubernetes_pod_spec_1267_volume_1349_iscsi_1371[]|null,
-    local?: Kubernetes_pod_spec_1267_volume_1349_local_1372[]|null,
+    aws_elastic_block_store?: Kubernetes_pod_spec_189_volume_271_aws_elastic_block_store_272[]|null,
+    azure_disk?: Kubernetes_pod_spec_189_volume_271_azure_disk_273[]|null,
+    azure_file?: Kubernetes_pod_spec_189_volume_271_azure_file_274[]|null,
+    ceph_fs?: Kubernetes_pod_spec_189_volume_271_ceph_fs_275[]|null,
+    cinder?: Kubernetes_pod_spec_189_volume_271_cinder_277[]|null,
+    config_map?: Kubernetes_pod_spec_189_volume_271_config_map_278[]|null,
+    downward_api?: Kubernetes_pod_spec_189_volume_271_downward_api_280[]|null,
+    empty_dir?: Kubernetes_pod_spec_189_volume_271_empty_dir_284[]|null,
+    fc?: Kubernetes_pod_spec_189_volume_271_fc_285[]|null,
+    flex_volume?: Kubernetes_pod_spec_189_volume_271_flex_volume_286[]|null,
+    flocker?: Kubernetes_pod_spec_189_volume_271_flocker_288[]|null,
+    gce_persistent_disk?: Kubernetes_pod_spec_189_volume_271_gce_persistent_disk_289[]|null,
+    git_repo?: Kubernetes_pod_spec_189_volume_271_git_repo_290[]|null,
+    glusterfs?: Kubernetes_pod_spec_189_volume_271_glusterfs_291[]|null,
+    host_path?: Kubernetes_pod_spec_189_volume_271_host_path_292[]|null,
+    iscsi?: Kubernetes_pod_spec_189_volume_271_iscsi_293[]|null,
+    local?: Kubernetes_pod_spec_189_volume_271_local_294[]|null,
     name?: string|null,
-    nfs?: Kubernetes_pod_spec_1267_volume_1349_nfs_1373[]|null,
-    persistent_volume_claim?: Kubernetes_pod_spec_1267_volume_1349_persistent_volume_claim_1374[]|null,
-    photon_persistent_disk?: Kubernetes_pod_spec_1267_volume_1349_photon_persistent_disk_1375[]|null,
-    quobyte?: Kubernetes_pod_spec_1267_volume_1349_quobyte_1376[]|null,
-    rbd?: Kubernetes_pod_spec_1267_volume_1349_rbd_1377[]|null,
-    secret?: Kubernetes_pod_spec_1267_volume_1349_secret_1379[]|null,
-    vsphere_volume?: Kubernetes_pod_spec_1267_volume_1349_vsphere_volume_1381[]|null
+    nfs?: Kubernetes_pod_spec_189_volume_271_nfs_295[]|null,
+    persistent_volume_claim?: Kubernetes_pod_spec_189_volume_271_persistent_volume_claim_296[]|null,
+    photon_persistent_disk?: Kubernetes_pod_spec_189_volume_271_photon_persistent_disk_297[]|null,
+    quobyte?: Kubernetes_pod_spec_189_volume_271_quobyte_298[]|null,
+    rbd?: Kubernetes_pod_spec_189_volume_271_rbd_299[]|null,
+    secret?: Kubernetes_pod_spec_189_volume_271_secret_301[]|null,
+    vsphere_volume?: Kubernetes_pod_spec_189_volume_271_vsphere_volume_303[]|null
   }) {
     this.aws_elastic_block_store = aws_elastic_block_store;
     this.azure_disk = azure_disk;
@@ -11917,11 +11917,11 @@ export class Kubernetes_pod_spec_1267_volume_1349 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_aws_elastic_block_store_1350 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_aws_elastic_block_store_272 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -11960,11 +11960,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_aws_elastic_block_store_1350 i
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_aws_elastic_block_store_1350';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_aws_elastic_block_store_272';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_azure_disk_1351 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_azure_disk_273 implements PcoreValue {
   readonly caching_mode: string;
   readonly data_disk_uri: string;
   readonly disk_name: string;
@@ -12006,11 +12006,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_azure_disk_1351 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_azure_disk_1351';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_azure_disk_273';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_azure_file_1352 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_azure_file_274 implements PcoreValue {
   readonly secret_name: string;
   readonly share_name: string;
   readonly read_only: boolean|null;
@@ -12040,16 +12040,16 @@ export class Kubernetes_pod_spec_1267_volume_1349_azure_file_1352 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_azure_file_1352';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_azure_file_274';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_ceph_fs_275 implements PcoreValue {
   readonly monitors: string[];
   readonly path: string|null;
   readonly read_only: boolean|null;
   readonly secret_file: string|null;
-  readonly secret_ref: Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353_secret_ref_1354[]|null;
+  readonly secret_ref: Kubernetes_pod_spec_189_volume_271_ceph_fs_275_secret_ref_276[]|null;
   readonly user: string|null;
 
   constructor({
@@ -12064,7 +12064,7 @@ export class Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353 implements PcoreV
     path?: string|null,
     read_only?: boolean|null,
     secret_file?: string|null,
-    secret_ref?: Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353_secret_ref_1354[]|null,
+    secret_ref?: Kubernetes_pod_spec_189_volume_271_ceph_fs_275_secret_ref_276[]|null,
     user?: string|null
   }) {
     this.monitors = monitors;
@@ -12097,11 +12097,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_ceph_fs_275';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353_secret_ref_1354 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_ceph_fs_275_secret_ref_276 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -12121,11 +12121,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353_secret_ref_1354 i
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_ceph_fs_1353_secret_ref_1354';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_ceph_fs_275_secret_ref_276';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_cinder_1355 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_cinder_277 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly read_only: boolean|null;
@@ -12157,13 +12157,13 @@ export class Kubernetes_pod_spec_1267_volume_1349_cinder_1355 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_cinder_1355';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_cinder_277';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_config_map_1356 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_config_map_278 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_pod_spec_1267_volume_1349_config_map_1356_items_1357[]|null;
+  readonly items: Kubernetes_pod_spec_189_volume_271_config_map_278_items_279[]|null;
   readonly name: string|null;
 
   constructor({
@@ -12172,7 +12172,7 @@ export class Kubernetes_pod_spec_1267_volume_1349_config_map_1356 implements Pco
     name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_pod_spec_1267_volume_1349_config_map_1356_items_1357[]|null,
+    items?: Kubernetes_pod_spec_189_volume_271_config_map_278_items_279[]|null,
     name?: string|null
   }) {
     this.default_mode = default_mode;
@@ -12195,11 +12195,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_config_map_1356 implements Pco
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_config_map_1356';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_config_map_278';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_config_map_1356_items_1357 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_config_map_278_items_279 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -12233,20 +12233,20 @@ export class Kubernetes_pod_spec_1267_volume_1349_config_map_1356_items_1357 imp
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_config_map_1356_items_1357';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_config_map_278_items_279';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_downward_api_280 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359[]|null;
+  readonly items: Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281[]|null;
 
   constructor({
     default_mode = null,
     items = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359[]|null
+    items?: Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281[]|null
   }) {
     this.default_mode = default_mode;
     this.items = items;
@@ -12264,15 +12264,15 @@ export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358 implements P
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_downward_api_1358';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_downward_api_280';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359 implements PcoreValue {
-  readonly field_ref: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_field_ref_1360[];
+export class Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281 implements PcoreValue {
+  readonly field_ref: Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_field_ref_282[];
   readonly path: string;
   readonly mode: number|null;
-  readonly resource_field_ref: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_resource_field_ref_1361[]|null;
+  readonly resource_field_ref: Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_resource_field_ref_283[]|null;
 
   constructor({
     field_ref,
@@ -12280,10 +12280,10 @@ export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359 i
     mode = null,
     resource_field_ref = null
   }: {
-    field_ref: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_field_ref_1360[],
+    field_ref: Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_field_ref_282[],
     path: string,
     mode?: number|null,
-    resource_field_ref?: Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_resource_field_ref_1361[]|null
+    resource_field_ref?: Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_resource_field_ref_283[]|null
   }) {
     this.field_ref = field_ref;
     this.path = path;
@@ -12305,11 +12305,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359 i
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_field_ref_1360 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_field_ref_282 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -12336,11 +12336,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_f
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_field_ref_1360';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_field_ref_282';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_resource_field_ref_1361 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_resource_field_ref_283 implements PcoreValue {
   readonly container_name: string;
   readonly resource: string;
   readonly quantity: string|null;
@@ -12370,11 +12370,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_r
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_downward_api_1358_items_1359_resource_field_ref_1361';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_downward_api_280_items_281_resource_field_ref_283';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_empty_dir_1362 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_empty_dir_284 implements PcoreValue {
   readonly medium: string|null;
 
   constructor({
@@ -12394,11 +12394,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_empty_dir_1362 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_empty_dir_1362';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_empty_dir_284';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_fc_1363 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_fc_285 implements PcoreValue {
   readonly lun: number;
   readonly target_ww_ns: string[];
   readonly fs_type: string|null;
@@ -12435,16 +12435,16 @@ export class Kubernetes_pod_spec_1267_volume_1349_fc_1363 implements PcoreValue 
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_fc_1363';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_fc_285';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_flex_volume_286 implements PcoreValue {
   readonly driver: string;
   readonly fs_type: string|null;
   readonly options: {[s: string]: string}|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364_secret_ref_1365[]|null;
+  readonly secret_ref: Kubernetes_pod_spec_189_volume_271_flex_volume_286_secret_ref_287[]|null;
 
   constructor({
     driver,
@@ -12457,7 +12457,7 @@ export class Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364 implements Pc
     fs_type?: string|null,
     options?: {[s: string]: string}|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364_secret_ref_1365[]|null
+    secret_ref?: Kubernetes_pod_spec_189_volume_271_flex_volume_286_secret_ref_287[]|null
   }) {
     this.driver = driver;
     this.fs_type = fs_type;
@@ -12485,11 +12485,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364 implements Pc
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_flex_volume_286';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364_secret_ref_1365 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_flex_volume_286_secret_ref_287 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -12509,11 +12509,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364_secret_ref_13
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_flex_volume_1364_secret_ref_1365';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_flex_volume_286_secret_ref_287';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_flocker_1366 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_flocker_288 implements PcoreValue {
   readonly dataset_name: string|null;
   readonly dataset_uuid: string|null;
 
@@ -12540,11 +12540,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_flocker_1366 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_flocker_1366';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_flocker_288';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_gce_persistent_disk_1367 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_gce_persistent_disk_289 implements PcoreValue {
   readonly pd_name: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -12583,11 +12583,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_gce_persistent_disk_1367 imple
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_gce_persistent_disk_1367';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_gce_persistent_disk_289';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_git_repo_1368 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_git_repo_290 implements PcoreValue {
   readonly directory: string|null;
   readonly repository: string|null;
   readonly revision: string|null;
@@ -12621,11 +12621,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_git_repo_1368 implements Pcore
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_git_repo_1368';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_git_repo_290';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_glusterfs_1369 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_glusterfs_291 implements PcoreValue {
   readonly endpoints_name: string;
   readonly path: string;
   readonly read_only: boolean|null;
@@ -12655,11 +12655,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_glusterfs_1369 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_glusterfs_1369';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_glusterfs_291';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_host_path_1370 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_host_path_292 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -12679,11 +12679,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_host_path_1370 implements Pcor
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_host_path_1370';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_host_path_292';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_iscsi_1371 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_iscsi_293 implements PcoreValue {
   readonly iqn: string;
   readonly target_portal: string;
   readonly fs_type: string|null;
@@ -12734,11 +12734,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_iscsi_1371 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_iscsi_1371';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_iscsi_293';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_local_1372 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_local_294 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -12758,11 +12758,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_local_1372 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_local_1372';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_local_294';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_nfs_1373 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_nfs_295 implements PcoreValue {
   readonly path: string;
   readonly server: string;
   readonly read_only: boolean|null;
@@ -12792,11 +12792,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_nfs_1373 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_nfs_1373';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_nfs_295';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_persistent_volume_claim_1374 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_persistent_volume_claim_296 implements PcoreValue {
   readonly claim_name: string|null;
   readonly read_only: boolean|null;
 
@@ -12823,11 +12823,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_persistent_volume_claim_1374 i
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_persistent_volume_claim_1374';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_persistent_volume_claim_296';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_photon_persistent_disk_1375 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_photon_persistent_disk_297 implements PcoreValue {
   readonly pd_id: string;
   readonly fs_type: string|null;
 
@@ -12852,11 +12852,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_photon_persistent_disk_1375 im
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_photon_persistent_disk_1375';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_photon_persistent_disk_297';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_quobyte_1376 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_quobyte_298 implements PcoreValue {
   readonly registry: string;
   readonly volume: string;
   readonly group: string|null;
@@ -12900,11 +12900,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_quobyte_1376 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_quobyte_1376';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_quobyte_298';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_rbd_1377 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_rbd_299 implements PcoreValue {
   readonly ceph_monitors: string[];
   readonly rbd_image: string;
   readonly fs_type: string|null;
@@ -12912,7 +12912,7 @@ export class Kubernetes_pod_spec_1267_volume_1349_rbd_1377 implements PcoreValue
   readonly rados_user: string|null;
   readonly rbd_pool: string|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_pod_spec_1267_volume_1349_rbd_1377_secret_ref_1378[]|null;
+  readonly secret_ref: Kubernetes_pod_spec_189_volume_271_rbd_299_secret_ref_300[]|null;
 
   constructor({
     ceph_monitors,
@@ -12931,7 +12931,7 @@ export class Kubernetes_pod_spec_1267_volume_1349_rbd_1377 implements PcoreValue
     rados_user?: string|null,
     rbd_pool?: string|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_pod_spec_1267_volume_1349_rbd_1377_secret_ref_1378[]|null
+    secret_ref?: Kubernetes_pod_spec_189_volume_271_rbd_299_secret_ref_300[]|null
   }) {
     this.ceph_monitors = ceph_monitors;
     this.rbd_image = rbd_image;
@@ -12969,11 +12969,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_rbd_1377 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_rbd_1377';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_rbd_299';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_rbd_1377_secret_ref_1378 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_rbd_299_secret_ref_300 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -12993,13 +12993,13 @@ export class Kubernetes_pod_spec_1267_volume_1349_rbd_1377_secret_ref_1378 imple
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_rbd_1377_secret_ref_1378';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_rbd_299_secret_ref_300';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_secret_1379 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_secret_301 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_pod_spec_1267_volume_1349_secret_1379_items_1380[]|null;
+  readonly items: Kubernetes_pod_spec_189_volume_271_secret_301_items_302[]|null;
   readonly optional: boolean|null;
   readonly secret_name: string|null;
 
@@ -13010,7 +13010,7 @@ export class Kubernetes_pod_spec_1267_volume_1349_secret_1379 implements PcoreVa
     secret_name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_pod_spec_1267_volume_1349_secret_1379_items_1380[]|null,
+    items?: Kubernetes_pod_spec_189_volume_271_secret_301_items_302[]|null,
     optional?: boolean|null,
     secret_name?: string|null
   }) {
@@ -13038,11 +13038,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_secret_1379 implements PcoreVa
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_secret_1379';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_secret_301';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_secret_1379_items_1380 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_secret_301_items_302 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -13076,11 +13076,11 @@ export class Kubernetes_pod_spec_1267_volume_1349_secret_1379_items_1380 impleme
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_secret_1379_items_1380';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_secret_301_items_302';
   }
 }
 
-export class Kubernetes_pod_spec_1267_volume_1349_vsphere_volume_1381 implements PcoreValue {
+export class Kubernetes_pod_spec_189_volume_271_vsphere_volume_303 implements PcoreValue {
   readonly volume_path: string;
   readonly fs_type: string|null;
 
@@ -13105,13 +13105,13 @@ export class Kubernetes_pod_spec_1267_volume_1349_vsphere_volume_1381 implements
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_pod_spec_1267_volume_1349_vsphere_volume_1381';
+    return 'TerraformKubernetes::Kubernetes_pod_spec_189_volume_271_vsphere_volume_303';
   }
 }
 
 export class Kubernetes_replication_controller implements PcoreValue {
-  readonly metadata: Kubernetes_replication_controller_metadata_1382[];
-  readonly spec: Kubernetes_replication_controller_spec_1383[];
+  readonly metadata: Kubernetes_replication_controller_metadata_304[];
+  readonly spec: Kubernetes_replication_controller_spec_305[];
   readonly kubernetes_replication_controller_id: string|null;
 
   constructor({
@@ -13119,8 +13119,8 @@ export class Kubernetes_replication_controller implements PcoreValue {
     spec,
     kubernetes_replication_controller_id = null
   }: {
-    metadata: Kubernetes_replication_controller_metadata_1382[],
-    spec: Kubernetes_replication_controller_spec_1383[],
+    metadata: Kubernetes_replication_controller_metadata_304[],
+    spec: Kubernetes_replication_controller_spec_305[],
     kubernetes_replication_controller_id?: string|null
   }) {
     this.metadata = metadata;
@@ -13153,7 +13153,7 @@ export class Kubernetes_replication_controllerHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_replication_controller_metadata_1382 implements PcoreValue {
+export class Kubernetes_replication_controller_metadata_304 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -13229,13 +13229,13 @@ export class Kubernetes_replication_controller_metadata_1382 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_metadata_1382';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_metadata_304';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305 implements PcoreValue {
   readonly selector: {[s: string]: string};
-  readonly template: Kubernetes_replication_controller_spec_1383_template_1384[];
+  readonly template: Kubernetes_replication_controller_spec_305_template_306[];
   readonly min_ready_seconds: number|null;
   readonly replicas: number|null;
 
@@ -13246,7 +13246,7 @@ export class Kubernetes_replication_controller_spec_1383 implements PcoreValue {
     replicas = null
   }: {
     selector: {[s: string]: string},
-    template: Kubernetes_replication_controller_spec_1383_template_1384[],
+    template: Kubernetes_replication_controller_spec_305_template_306[],
     min_ready_seconds?: number|null,
     replicas?: number|null
   }) {
@@ -13270,30 +13270,30 @@ export class Kubernetes_replication_controller_spec_1383 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306 implements PcoreValue {
   readonly active_deadline_seconds: number|null;
-  readonly container: Kubernetes_replication_controller_spec_1383_template_1384_container_1385[]|null;
+  readonly container: Kubernetes_replication_controller_spec_305_template_306_container_307[]|null;
   readonly dns_policy: string|null;
   readonly host_ipc: boolean|null;
   readonly host_network: boolean|null;
   readonly host_pid: boolean|null;
   readonly hostname: string|null;
-  readonly image_pull_secrets: Kubernetes_replication_controller_spec_1383_template_1384_image_pull_secrets_1424[]|null;
-  readonly init_container: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425[]|null;
-  readonly metadata: Kubernetes_replication_controller_spec_1383_template_1384_metadata_1464[]|null;
+  readonly image_pull_secrets: Kubernetes_replication_controller_spec_305_template_306_image_pull_secrets_346[]|null;
+  readonly init_container: Kubernetes_replication_controller_spec_305_template_306_init_container_347[]|null;
+  readonly metadata: Kubernetes_replication_controller_spec_305_template_306_metadata_386[]|null;
   readonly node_name: string|null;
   readonly node_selector: {[s: string]: string}|null;
   readonly restart_policy: string|null;
-  readonly security_context: Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465[]|null;
+  readonly security_context: Kubernetes_replication_controller_spec_305_template_306_security_context_387[]|null;
   readonly service_account_name: string|null;
-  readonly spec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467[]|null;
+  readonly spec: Kubernetes_replication_controller_spec_305_template_306_spec_389[]|null;
   readonly subdomain: string|null;
   readonly termination_grace_period_seconds: number|null;
-  readonly volume: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582[]|null;
+  readonly volume: Kubernetes_replication_controller_spec_305_template_306_volume_504[]|null;
 
   constructor({
     active_deadline_seconds = null,
@@ -13317,24 +13317,24 @@ export class Kubernetes_replication_controller_spec_1383_template_1384 implement
     volume = null
   }: {
     active_deadline_seconds?: number|null,
-    container?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385[]|null,
+    container?: Kubernetes_replication_controller_spec_305_template_306_container_307[]|null,
     dns_policy?: string|null,
     host_ipc?: boolean|null,
     host_network?: boolean|null,
     host_pid?: boolean|null,
     hostname?: string|null,
-    image_pull_secrets?: Kubernetes_replication_controller_spec_1383_template_1384_image_pull_secrets_1424[]|null,
-    init_container?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425[]|null,
-    metadata?: Kubernetes_replication_controller_spec_1383_template_1384_metadata_1464[]|null,
+    image_pull_secrets?: Kubernetes_replication_controller_spec_305_template_306_image_pull_secrets_346[]|null,
+    init_container?: Kubernetes_replication_controller_spec_305_template_306_init_container_347[]|null,
+    metadata?: Kubernetes_replication_controller_spec_305_template_306_metadata_386[]|null,
     node_name?: string|null,
     node_selector?: {[s: string]: string}|null,
     restart_policy?: string|null,
-    security_context?: Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465[]|null,
+    security_context?: Kubernetes_replication_controller_spec_305_template_306_security_context_387[]|null,
     service_account_name?: string|null,
-    spec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467[]|null,
+    spec?: Kubernetes_replication_controller_spec_305_template_306_spec_389[]|null,
     subdomain?: string|null,
     termination_grace_period_seconds?: number|null,
-    volume?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582[]|null
+    volume?: Kubernetes_replication_controller_spec_305_template_306_volume_504[]|null
   }) {
     this.active_deadline_seconds = active_deadline_seconds;
     this.container = container;
@@ -13420,29 +13420,29 @@ export class Kubernetes_replication_controller_spec_1383_template_1384 implement
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386[]|null;
-  readonly env_from: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392[]|null;
+  readonly env: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308[]|null;
+  readonly env_from: Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395[]|null;
-  readonly liveness_probe: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406[]|null;
-  readonly port: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_port_1411[]|null;
-  readonly readiness_probe: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412[]|null;
-  readonly resources: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417[]|null;
-  readonly security_context: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420[]|null;
+  readonly lifecycle: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317[]|null;
+  readonly liveness_probe: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328[]|null;
+  readonly port: Kubernetes_replication_controller_spec_305_template_306_container_307_port_333[]|null;
+  readonly readiness_probe: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334[]|null;
+  readonly resources: Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339[]|null;
+  readonly security_context: Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_volume_mount_1423[]|null;
+  readonly volume_mount: Kubernetes_replication_controller_spec_305_template_306_container_307_volume_mount_345[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -13469,21 +13469,21 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386[]|null,
-    env_from?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392[]|null,
+    env?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308[]|null,
+    env_from?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395[]|null,
-    liveness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406[]|null,
-    port?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_port_1411[]|null,
-    readiness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412[]|null,
-    resources?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417[]|null,
-    security_context?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420[]|null,
+    lifecycle?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317[]|null,
+    liveness_probe?: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328[]|null,
+    port?: Kubernetes_replication_controller_spec_305_template_306_container_307_port_333[]|null,
+    readiness_probe?: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334[]|null,
+    resources?: Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339[]|null,
+    security_context?: Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_volume_mount_1423[]|null,
+    volume_mount?: Kubernetes_replication_controller_spec_305_template_306_container_307_volume_mount_345[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -13568,14 +13568,14 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_308 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387[]|null;
+  readonly value_from: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309[]|null;
 
   constructor({
     name,
@@ -13584,7 +13584,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387[]|null
+    value_from?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -13604,15 +13604,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_308';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_config_map_key_ref_1388[]|null;
-  readonly field_ref: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_field_ref_1389[]|null;
-  readonly resource_field_ref: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_resource_field_ref_1390[]|null;
-  readonly secret_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_secret_key_ref_1391[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_config_map_key_ref_310[]|null;
+  readonly field_ref: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_field_ref_311[]|null;
+  readonly resource_field_ref: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_resource_field_ref_312[]|null;
+  readonly secret_key_ref: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_secret_key_ref_313[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -13620,10 +13620,10 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_config_map_key_ref_1388[]|null,
-    field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_field_ref_1389[]|null,
-    resource_field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_resource_field_ref_1390[]|null,
-    secret_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_secret_key_ref_1391[]|null
+    config_map_key_ref?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_config_map_key_ref_310[]|null,
+    field_ref?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_field_ref_311[]|null,
+    resource_field_ref?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_resource_field_ref_312[]|null,
+    secret_key_ref?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_secret_key_ref_313[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -13649,11 +13649,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_config_map_key_ref_1388 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_config_map_key_ref_310 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -13680,11 +13680,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_config_map_key_ref_1388';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_config_map_key_ref_310';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_field_ref_1389 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_field_ref_311 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -13711,11 +13711,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_field_ref_1389';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_field_ref_311';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_resource_field_ref_1390 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_resource_field_ref_312 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -13740,11 +13740,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_resource_field_ref_1390';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_resource_field_ref_312';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_secret_key_ref_1391 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_secret_key_ref_313 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -13771,23 +13771,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_1386_value_from_1387_secret_key_ref_1391';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_308_value_from_309_secret_key_ref_313';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_config_map_ref_1393[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_config_map_ref_315[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_secret_ref_1394[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_secret_ref_316[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_config_map_ref_1393[]|null,
+    config_map_ref?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_config_map_ref_315[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_secret_ref_1394[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_secret_ref_316[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -13809,11 +13809,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_config_map_ref_1393 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_config_map_ref_315 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -13838,11 +13838,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_config_map_ref_1393';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_config_map_ref_315';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_secret_ref_1394 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_secret_ref_316 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -13867,20 +13867,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_env_from_1392_secret_ref_1394';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_env_from_314_secret_ref_316';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395 implements PcoreValue {
-  readonly post_start: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396[]|null;
-  readonly pre_stop: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317 implements PcoreValue {
+  readonly post_start: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318[]|null;
+  readonly pre_stop: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396[]|null,
-    pre_stop?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401[]|null
+    post_start?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318[]|null,
+    pre_stop?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -13898,23 +13898,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_exec_1397[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_tcp_socket_1400[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_exec_319[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_tcp_socket_322[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_exec_1397[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_tcp_socket_1400[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_exec_319[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_tcp_socket_322[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -13936,11 +13936,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_exec_1397 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_exec_319 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -13960,13 +13960,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_exec_1397';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_exec_319';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398_http_header_1399[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320_http_header_321[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -13979,7 +13979,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398_http_header_1399[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320_http_header_321[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -14012,11 +14012,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398_http_header_1399 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320_http_header_321 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -14043,11 +14043,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_http_get_1398_http_header_1399';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_http_get_320_http_header_321';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_tcp_socket_1400 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_tcp_socket_322 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -14065,23 +14065,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_post_start_1396_tcp_socket_1400';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_post_start_318_tcp_socket_322';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_exec_1402[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_tcp_socket_1405[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_exec_324[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_tcp_socket_327[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_exec_1402[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_tcp_socket_1405[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_exec_324[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_tcp_socket_327[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -14103,11 +14103,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_exec_1402 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_exec_324 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -14127,13 +14127,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_exec_1402';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_exec_324';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403_http_header_1404[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325_http_header_326[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -14146,7 +14146,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403_http_header_1404[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325_http_header_326[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -14179,11 +14179,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403_http_header_1404 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325_http_header_326 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -14210,11 +14210,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_http_get_1403_http_header_1404';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_http_get_325_http_header_326';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_tcp_socket_1405 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_tcp_socket_327 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -14232,18 +14232,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_lifecycle_1395_pre_stop_1401_tcp_socket_1405';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_lifecycle_317_pre_stop_323_tcp_socket_327';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_exec_1407[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_exec_329[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_tcp_socket_1410[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_tcp_socket_332[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -14256,13 +14256,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_exec_1407[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_exec_329[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_tcp_socket_1410[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_tcp_socket_332[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -14305,11 +14305,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_exec_1407 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_exec_329 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -14329,13 +14329,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_exec_1407';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_exec_329';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408_http_header_1409[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330_http_header_331[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -14348,7 +14348,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408_http_header_1409[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330_http_header_331[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -14381,11 +14381,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408_http_header_1409 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330_http_header_331 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -14412,11 +14412,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_http_get_1408_http_header_1409';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_http_get_330_http_header_331';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_tcp_socket_1410 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_tcp_socket_332 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -14434,11 +14434,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_liveness_probe_1406_tcp_socket_1410';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_liveness_probe_328_tcp_socket_332';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_port_1411 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_port_333 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -14484,18 +14484,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_port_1411';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_port_333';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_exec_1413[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_exec_335[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_tcp_socket_1416[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_tcp_socket_338[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -14508,13 +14508,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_exec_1413[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_exec_335[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_tcp_socket_1416[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_tcp_socket_338[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -14557,11 +14557,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_exec_1413 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_exec_335 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -14581,13 +14581,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_exec_1413';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_exec_335';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414_http_header_1415[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336_http_header_337[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -14600,7 +14600,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414_http_header_1415[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336_http_header_337[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -14633,11 +14633,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414_http_header_1415 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336_http_header_337 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -14664,11 +14664,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_http_get_1414_http_header_1415';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_http_get_336_http_header_337';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_tcp_socket_1416 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_tcp_socket_338 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -14686,20 +14686,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_readiness_probe_1412_tcp_socket_1416';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_readiness_probe_334_tcp_socket_338';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417 implements PcoreValue {
-  readonly limits: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_limits_1418[]|null;
-  readonly requests: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_requests_1419[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339 implements PcoreValue {
+  readonly limits: Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_limits_340[]|null;
+  readonly requests: Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_requests_341[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_limits_1418[]|null,
-    requests?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_requests_1419[]|null
+    limits?: Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_limits_340[]|null,
+    requests?: Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_requests_341[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -14717,11 +14717,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_limits_1418 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_limits_340 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -14748,11 +14748,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_limits_1418';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_limits_340';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_requests_1419 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_requests_341 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -14779,18 +14779,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_resources_1417_requests_1419';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_resources_339_requests_341';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_capabilities_1421[]|null;
+  readonly capabilities: Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_capabilities_343[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_se_linux_options_1422[]|null;
+  readonly se_linux_options: Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_se_linux_options_344[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -14802,12 +14802,12 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_capabilities_1421[]|null,
+    capabilities?: Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_capabilities_343[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_se_linux_options_1422[]|null
+    se_linux_options?: Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_se_linux_options_344[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -14845,11 +14845,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_capabilities_1421 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_capabilities_343 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -14876,11 +14876,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_capabilities_1421';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_capabilities_343';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_se_linux_options_1422 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_se_linux_options_344 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -14921,11 +14921,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_security_context_1420_se_linux_options_1422';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_security_context_342_se_linux_options_344';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_container_1385_volume_mount_1423 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_container_307_volume_mount_345 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -14962,11 +14962,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_container_1385_volume_mount_1423';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_container_307_volume_mount_345';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_image_pull_secrets_1424 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_image_pull_secrets_346 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -14984,29 +14984,29 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_image_pul
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_image_pull_secrets_1424';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_image_pull_secrets_346';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426[]|null;
-  readonly env_from: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432[]|null;
+  readonly env: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348[]|null;
+  readonly env_from: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435[]|null;
-  readonly liveness_probe: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446[]|null;
-  readonly port: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_port_1451[]|null;
-  readonly readiness_probe: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452[]|null;
-  readonly resources: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457[]|null;
-  readonly security_context: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460[]|null;
+  readonly lifecycle: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357[]|null;
+  readonly liveness_probe: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368[]|null;
+  readonly port: Kubernetes_replication_controller_spec_305_template_306_init_container_347_port_373[]|null;
+  readonly readiness_probe: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374[]|null;
+  readonly resources: Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379[]|null;
+  readonly security_context: Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_volume_mount_1463[]|null;
+  readonly volume_mount: Kubernetes_replication_controller_spec_305_template_306_init_container_347_volume_mount_385[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -15033,21 +15033,21 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426[]|null,
-    env_from?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432[]|null,
+    env?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348[]|null,
+    env_from?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435[]|null,
-    liveness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446[]|null,
-    port?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_port_1451[]|null,
-    readiness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452[]|null,
-    resources?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457[]|null,
-    security_context?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460[]|null,
+    lifecycle?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357[]|null,
+    liveness_probe?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368[]|null,
+    port?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_port_373[]|null,
+    readiness_probe?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374[]|null,
+    resources?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379[]|null,
+    security_context?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_volume_mount_1463[]|null,
+    volume_mount?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_volume_mount_385[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -15132,14 +15132,14 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427[]|null;
+  readonly value_from: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349[]|null;
 
   constructor({
     name,
@@ -15148,7 +15148,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427[]|null
+    value_from?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -15168,15 +15168,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_config_map_key_ref_1428[]|null;
-  readonly field_ref: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_field_ref_1429[]|null;
-  readonly resource_field_ref: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_resource_field_ref_1430[]|null;
-  readonly secret_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_secret_key_ref_1431[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_config_map_key_ref_350[]|null;
+  readonly field_ref: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_field_ref_351[]|null;
+  readonly resource_field_ref: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_resource_field_ref_352[]|null;
+  readonly secret_key_ref: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_secret_key_ref_353[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -15184,10 +15184,10 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_config_map_key_ref_1428[]|null,
-    field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_field_ref_1429[]|null,
-    resource_field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_resource_field_ref_1430[]|null,
-    secret_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_secret_key_ref_1431[]|null
+    config_map_key_ref?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_config_map_key_ref_350[]|null,
+    field_ref?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_field_ref_351[]|null,
+    resource_field_ref?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_resource_field_ref_352[]|null,
+    secret_key_ref?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_secret_key_ref_353[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -15213,11 +15213,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_config_map_key_ref_1428 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_config_map_key_ref_350 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -15244,11 +15244,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_config_map_key_ref_1428';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_config_map_key_ref_350';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_field_ref_1429 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_field_ref_351 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -15275,11 +15275,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_field_ref_1429';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_field_ref_351';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_resource_field_ref_1430 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_resource_field_ref_352 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -15304,11 +15304,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_resource_field_ref_1430';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_resource_field_ref_352';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_secret_key_ref_1431 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_secret_key_ref_353 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -15335,23 +15335,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_1426_value_from_1427_secret_key_ref_1431';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_348_value_from_349_secret_key_ref_353';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_config_map_ref_1433[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_config_map_ref_355[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_secret_ref_1434[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_secret_ref_356[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_config_map_ref_1433[]|null,
+    config_map_ref?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_config_map_ref_355[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_secret_ref_1434[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_secret_ref_356[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -15373,11 +15373,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_config_map_ref_1433 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_config_map_ref_355 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -15402,11 +15402,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_config_map_ref_1433';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_config_map_ref_355';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_secret_ref_1434 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_secret_ref_356 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -15431,20 +15431,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_env_from_1432_secret_ref_1434';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_env_from_354_secret_ref_356';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435 implements PcoreValue {
-  readonly post_start: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436[]|null;
-  readonly pre_stop: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357 implements PcoreValue {
+  readonly post_start: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358[]|null;
+  readonly pre_stop: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436[]|null,
-    pre_stop?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441[]|null
+    post_start?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358[]|null,
+    pre_stop?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -15462,23 +15462,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_exec_1437[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_tcp_socket_1440[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_exec_359[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_tcp_socket_362[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_exec_1437[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_tcp_socket_1440[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_exec_359[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_tcp_socket_362[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -15500,11 +15500,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_exec_1437 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_exec_359 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -15524,13 +15524,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_exec_1437';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_exec_359';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438_http_header_1439[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360_http_header_361[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -15543,7 +15543,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438_http_header_1439[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360_http_header_361[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -15576,11 +15576,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438_http_header_1439 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360_http_header_361 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -15607,11 +15607,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_http_get_1438_http_header_1439';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_http_get_360_http_header_361';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_tcp_socket_1440 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_tcp_socket_362 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -15629,23 +15629,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_post_start_1436_tcp_socket_1440';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_post_start_358_tcp_socket_362';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_exec_1442[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_tcp_socket_1445[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_exec_364[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_tcp_socket_367[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_exec_1442[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_tcp_socket_1445[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_exec_364[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_tcp_socket_367[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -15667,11 +15667,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_exec_1442 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_exec_364 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -15691,13 +15691,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_exec_1442';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_exec_364';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443_http_header_1444[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365_http_header_366[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -15710,7 +15710,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443_http_header_1444[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365_http_header_366[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -15743,11 +15743,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443_http_header_1444 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365_http_header_366 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -15774,11 +15774,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_http_get_1443_http_header_1444';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_http_get_365_http_header_366';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_tcp_socket_1445 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_tcp_socket_367 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -15796,18 +15796,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_lifecycle_1435_pre_stop_1441_tcp_socket_1445';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_lifecycle_357_pre_stop_363_tcp_socket_367';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_exec_1447[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_exec_369[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_tcp_socket_1450[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_tcp_socket_372[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -15820,13 +15820,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_exec_1447[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_exec_369[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_tcp_socket_1450[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_tcp_socket_372[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -15869,11 +15869,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_exec_1447 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_exec_369 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -15893,13 +15893,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_exec_1447';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_exec_369';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448_http_header_1449[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370_http_header_371[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -15912,7 +15912,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448_http_header_1449[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370_http_header_371[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -15945,11 +15945,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448_http_header_1449 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370_http_header_371 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -15976,11 +15976,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_http_get_1448_http_header_1449';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_http_get_370_http_header_371';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_tcp_socket_1450 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_tcp_socket_372 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -15998,11 +15998,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_liveness_probe_1446_tcp_socket_1450';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_liveness_probe_368_tcp_socket_372';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_port_1451 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_port_373 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -16048,18 +16048,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_port_1451';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_port_373';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_exec_1453[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_exec_375[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_tcp_socket_1456[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_tcp_socket_378[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -16072,13 +16072,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_exec_1453[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_exec_375[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_tcp_socket_1456[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_tcp_socket_378[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -16121,11 +16121,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_exec_1453 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_exec_375 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -16145,13 +16145,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_exec_1453';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_exec_375';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454_http_header_1455[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376_http_header_377[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -16164,7 +16164,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454_http_header_1455[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376_http_header_377[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -16197,11 +16197,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454_http_header_1455 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376_http_header_377 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -16228,11 +16228,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_http_get_1454_http_header_1455';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_http_get_376_http_header_377';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_tcp_socket_1456 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_tcp_socket_378 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -16250,20 +16250,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_readiness_probe_1452_tcp_socket_1456';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_readiness_probe_374_tcp_socket_378';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457 implements PcoreValue {
-  readonly limits: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_limits_1458[]|null;
-  readonly requests: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_requests_1459[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379 implements PcoreValue {
+  readonly limits: Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_limits_380[]|null;
+  readonly requests: Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_requests_381[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_limits_1458[]|null,
-    requests?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_requests_1459[]|null
+    limits?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_limits_380[]|null,
+    requests?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_requests_381[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -16281,11 +16281,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_limits_1458 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_limits_380 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -16312,11 +16312,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_limits_1458';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_limits_380';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_requests_1459 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_requests_381 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -16343,18 +16343,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_resources_1457_requests_1459';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_resources_379_requests_381';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_capabilities_1461[]|null;
+  readonly capabilities: Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_capabilities_383[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_se_linux_options_1462[]|null;
+  readonly se_linux_options: Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_se_linux_options_384[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -16366,12 +16366,12 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_capabilities_1461[]|null,
+    capabilities?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_capabilities_383[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_se_linux_options_1462[]|null
+    se_linux_options?: Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_se_linux_options_384[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -16409,11 +16409,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_capabilities_1461 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_capabilities_383 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -16440,11 +16440,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_capabilities_1461';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_capabilities_383';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_se_linux_options_1462 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_se_linux_options_384 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -16485,11 +16485,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_security_context_1460_se_linux_options_1462';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_security_context_382_se_linux_options_384';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_volume_mount_1463 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_init_container_347_volume_mount_385 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -16526,11 +16526,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_init_container_1425_volume_mount_1463';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_init_container_347_volume_mount_385';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_metadata_1464 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_metadata_386 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -16606,15 +16606,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_metadata_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_metadata_1464';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_metadata_386';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_security_context_387 implements PcoreValue {
   readonly fs_group: number|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465_se_linux_options_1466[]|null;
+  readonly se_linux_options: Kubernetes_replication_controller_spec_305_template_306_security_context_387_se_linux_options_388[]|null;
   readonly supplemental_groups: number[]|null;
 
   constructor({
@@ -16627,7 +16627,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_security_
     fs_group?: number|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465_se_linux_options_1466[]|null,
+    se_linux_options?: Kubernetes_replication_controller_spec_305_template_306_security_context_387_se_linux_options_388[]|null,
     supplemental_groups?: number[]|null
   }) {
     this.fs_group = fs_group;
@@ -16658,11 +16658,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_security_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_security_context_387';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465_se_linux_options_1466 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_security_context_387_se_linux_options_388 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -16703,28 +16703,28 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_security_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_security_context_1465_se_linux_options_1466';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_security_context_387_se_linux_options_388';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389 implements PcoreValue {
   readonly active_deadline_seconds: number|null;
-  readonly container: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468[]|null;
+  readonly container: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390[]|null;
   readonly dns_policy: string|null;
   readonly host_ipc: boolean|null;
   readonly host_network: boolean|null;
   readonly host_pid: boolean|null;
   readonly hostname: string|null;
-  readonly image_pull_secrets: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_image_pull_secrets_1507[]|null;
-  readonly init_container: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508[]|null;
+  readonly image_pull_secrets: Kubernetes_replication_controller_spec_305_template_306_spec_389_image_pull_secrets_429[]|null;
+  readonly init_container: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430[]|null;
   readonly node_name: string|null;
   readonly node_selector: {[s: string]: string}|null;
   readonly restart_policy: string|null;
-  readonly security_context: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547[]|null;
+  readonly security_context: Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469[]|null;
   readonly service_account_name: string|null;
   readonly subdomain: string|null;
   readonly termination_grace_period_seconds: number|null;
-  readonly volume: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549[]|null;
+  readonly volume: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471[]|null;
 
   constructor({
     active_deadline_seconds = null,
@@ -16746,22 +16746,22 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     volume = null
   }: {
     active_deadline_seconds?: number|null,
-    container?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468[]|null,
+    container?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390[]|null,
     dns_policy?: string|null,
     host_ipc?: boolean|null,
     host_network?: boolean|null,
     host_pid?: boolean|null,
     hostname?: string|null,
-    image_pull_secrets?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_image_pull_secrets_1507[]|null,
-    init_container?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508[]|null,
+    image_pull_secrets?: Kubernetes_replication_controller_spec_305_template_306_spec_389_image_pull_secrets_429[]|null,
+    init_container?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430[]|null,
     node_name?: string|null,
     node_selector?: {[s: string]: string}|null,
     restart_policy?: string|null,
-    security_context?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547[]|null,
+    security_context?: Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469[]|null,
     service_account_name?: string|null,
     subdomain?: string|null,
     termination_grace_period_seconds?: number|null,
-    volume?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549[]|null
+    volume?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471[]|null
   }) {
     this.active_deadline_seconds = active_deadline_seconds;
     this.container = container;
@@ -16839,29 +16839,29 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469[]|null;
-  readonly env_from: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475[]|null;
+  readonly env: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391[]|null;
+  readonly env_from: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478[]|null;
-  readonly liveness_probe: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489[]|null;
-  readonly port: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_port_1494[]|null;
-  readonly readiness_probe: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495[]|null;
-  readonly resources: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500[]|null;
-  readonly security_context: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503[]|null;
+  readonly lifecycle: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400[]|null;
+  readonly liveness_probe: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411[]|null;
+  readonly port: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_port_416[]|null;
+  readonly readiness_probe: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417[]|null;
+  readonly resources: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422[]|null;
+  readonly security_context: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_volume_mount_1506[]|null;
+  readonly volume_mount: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_volume_mount_428[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -16888,21 +16888,21 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469[]|null,
-    env_from?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475[]|null,
+    env?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391[]|null,
+    env_from?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478[]|null,
-    liveness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489[]|null,
-    port?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_port_1494[]|null,
-    readiness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495[]|null,
-    resources?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500[]|null,
-    security_context?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503[]|null,
+    lifecycle?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400[]|null,
+    liveness_probe?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411[]|null,
+    port?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_port_416[]|null,
+    readiness_probe?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417[]|null,
+    resources?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422[]|null,
+    security_context?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_volume_mount_1506[]|null,
+    volume_mount?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_volume_mount_428[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -16987,14 +16987,14 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470[]|null;
+  readonly value_from: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392[]|null;
 
   constructor({
     name,
@@ -17003,7 +17003,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470[]|null
+    value_from?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -17023,15 +17023,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_config_map_key_ref_1471[]|null;
-  readonly field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_field_ref_1472[]|null;
-  readonly resource_field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_resource_field_ref_1473[]|null;
-  readonly secret_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_secret_key_ref_1474[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_config_map_key_ref_393[]|null;
+  readonly field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_field_ref_394[]|null;
+  readonly resource_field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_resource_field_ref_395[]|null;
+  readonly secret_key_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_secret_key_ref_396[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -17039,10 +17039,10 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_config_map_key_ref_1471[]|null,
-    field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_field_ref_1472[]|null,
-    resource_field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_resource_field_ref_1473[]|null,
-    secret_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_secret_key_ref_1474[]|null
+    config_map_key_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_config_map_key_ref_393[]|null,
+    field_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_field_ref_394[]|null,
+    resource_field_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_resource_field_ref_395[]|null,
+    secret_key_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_secret_key_ref_396[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -17068,11 +17068,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_config_map_key_ref_1471 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_config_map_key_ref_393 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -17099,11 +17099,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_config_map_key_ref_1471';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_config_map_key_ref_393';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_field_ref_1472 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_field_ref_394 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -17130,11 +17130,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_field_ref_1472';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_field_ref_394';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_resource_field_ref_1473 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_resource_field_ref_395 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -17159,11 +17159,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_resource_field_ref_1473';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_resource_field_ref_395';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_secret_key_ref_1474 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_secret_key_ref_396 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -17190,23 +17190,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_1469_value_from_1470_secret_key_ref_1474';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_391_value_from_392_secret_key_ref_396';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_config_map_ref_1476[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_config_map_ref_398[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_secret_ref_1477[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_secret_ref_399[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_config_map_ref_1476[]|null,
+    config_map_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_config_map_ref_398[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_secret_ref_1477[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_secret_ref_399[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -17228,11 +17228,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_config_map_ref_1476 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_config_map_ref_398 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -17257,11 +17257,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_config_map_ref_1476';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_config_map_ref_398';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_secret_ref_1477 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_secret_ref_399 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -17286,20 +17286,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_env_from_1475_secret_ref_1477';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_env_from_397_secret_ref_399';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478 implements PcoreValue {
-  readonly post_start: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479[]|null;
-  readonly pre_stop: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400 implements PcoreValue {
+  readonly post_start: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401[]|null;
+  readonly pre_stop: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479[]|null,
-    pre_stop?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484[]|null
+    post_start?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401[]|null,
+    pre_stop?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -17317,23 +17317,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_exec_1480[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_tcp_socket_1483[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_exec_402[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_tcp_socket_405[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_exec_1480[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_tcp_socket_1483[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_exec_402[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_tcp_socket_405[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -17355,11 +17355,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_exec_1480 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_exec_402 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -17379,13 +17379,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_exec_1480';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_exec_402';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481_http_header_1482[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403_http_header_404[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -17398,7 +17398,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481_http_header_1482[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403_http_header_404[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -17431,11 +17431,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481_http_header_1482 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403_http_header_404 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -17462,11 +17462,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_http_get_1481_http_header_1482';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_http_get_403_http_header_404';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_tcp_socket_1483 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_tcp_socket_405 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -17484,23 +17484,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_post_start_1479_tcp_socket_1483';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_post_start_401_tcp_socket_405';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_exec_1485[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_tcp_socket_1488[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_exec_407[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_tcp_socket_410[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_exec_1485[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_tcp_socket_1488[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_exec_407[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_tcp_socket_410[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -17522,11 +17522,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_exec_1485 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_exec_407 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -17546,13 +17546,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_exec_1485';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_exec_407';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486_http_header_1487[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408_http_header_409[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -17565,7 +17565,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486_http_header_1487[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408_http_header_409[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -17598,11 +17598,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486_http_header_1487 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408_http_header_409 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -17629,11 +17629,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_http_get_1486_http_header_1487';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_http_get_408_http_header_409';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_tcp_socket_1488 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_tcp_socket_410 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -17651,18 +17651,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_lifecycle_1478_pre_stop_1484_tcp_socket_1488';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_lifecycle_400_pre_stop_406_tcp_socket_410';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_exec_1490[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_exec_412[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_tcp_socket_1493[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_tcp_socket_415[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -17675,13 +17675,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_exec_1490[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_exec_412[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_tcp_socket_1493[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_tcp_socket_415[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -17724,11 +17724,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_exec_1490 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_exec_412 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -17748,13 +17748,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_exec_1490';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_exec_412';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491_http_header_1492[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413_http_header_414[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -17767,7 +17767,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491_http_header_1492[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413_http_header_414[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -17800,11 +17800,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491_http_header_1492 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413_http_header_414 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -17831,11 +17831,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_http_get_1491_http_header_1492';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_http_get_413_http_header_414';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_tcp_socket_1493 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_tcp_socket_415 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -17853,11 +17853,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_liveness_probe_1489_tcp_socket_1493';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_liveness_probe_411_tcp_socket_415';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_port_1494 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_port_416 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -17903,18 +17903,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_port_1494';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_port_416';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_exec_1496[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_exec_418[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_tcp_socket_1499[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_tcp_socket_421[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -17927,13 +17927,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_exec_1496[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_exec_418[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_tcp_socket_1499[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_tcp_socket_421[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -17976,11 +17976,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_exec_1496 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_exec_418 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -18000,13 +18000,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_exec_1496';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_exec_418';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497_http_header_1498[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419_http_header_420[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -18019,7 +18019,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497_http_header_1498[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419_http_header_420[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -18052,11 +18052,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497_http_header_1498 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419_http_header_420 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -18083,11 +18083,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_http_get_1497_http_header_1498';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_http_get_419_http_header_420';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_tcp_socket_1499 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_tcp_socket_421 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -18105,20 +18105,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_readiness_probe_1495_tcp_socket_1499';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_readiness_probe_417_tcp_socket_421';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500 implements PcoreValue {
-  readonly limits: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_limits_1501[]|null;
-  readonly requests: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_requests_1502[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422 implements PcoreValue {
+  readonly limits: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_limits_423[]|null;
+  readonly requests: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_requests_424[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_limits_1501[]|null,
-    requests?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_requests_1502[]|null
+    limits?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_limits_423[]|null,
+    requests?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_requests_424[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -18136,11 +18136,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_limits_1501 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_limits_423 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -18167,11 +18167,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_limits_1501';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_limits_423';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_requests_1502 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_requests_424 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -18198,18 +18198,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_resources_1500_requests_1502';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_resources_422_requests_424';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_capabilities_1504[]|null;
+  readonly capabilities: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_capabilities_426[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_se_linux_options_1505[]|null;
+  readonly se_linux_options: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_se_linux_options_427[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -18221,12 +18221,12 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_capabilities_1504[]|null,
+    capabilities?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_capabilities_426[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_se_linux_options_1505[]|null
+    se_linux_options?: Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_se_linux_options_427[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -18264,11 +18264,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_capabilities_1504 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_capabilities_426 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -18295,11 +18295,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_capabilities_1504';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_capabilities_426';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_se_linux_options_1505 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_se_linux_options_427 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -18340,11 +18340,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_security_context_1503_se_linux_options_1505';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_security_context_425_se_linux_options_427';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_volume_mount_1506 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_volume_mount_428 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -18381,11 +18381,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_container_1468_volume_mount_1506';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_container_390_volume_mount_428';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_image_pull_secrets_1507 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_image_pull_secrets_429 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -18403,29 +18403,29 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_image_pull_secrets_1507';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_image_pull_secrets_429';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509[]|null;
-  readonly env_from: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515[]|null;
+  readonly env: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431[]|null;
+  readonly env_from: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518[]|null;
-  readonly liveness_probe: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529[]|null;
-  readonly port: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_port_1534[]|null;
-  readonly readiness_probe: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535[]|null;
-  readonly resources: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540[]|null;
-  readonly security_context: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543[]|null;
+  readonly lifecycle: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440[]|null;
+  readonly liveness_probe: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451[]|null;
+  readonly port: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_port_456[]|null;
+  readonly readiness_probe: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457[]|null;
+  readonly resources: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462[]|null;
+  readonly security_context: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_volume_mount_1546[]|null;
+  readonly volume_mount: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_volume_mount_468[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -18452,21 +18452,21 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509[]|null,
-    env_from?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515[]|null,
+    env?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431[]|null,
+    env_from?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518[]|null,
-    liveness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529[]|null,
-    port?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_port_1534[]|null,
-    readiness_probe?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535[]|null,
-    resources?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540[]|null,
-    security_context?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543[]|null,
+    lifecycle?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440[]|null,
+    liveness_probe?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451[]|null,
+    port?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_port_456[]|null,
+    readiness_probe?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457[]|null,
+    resources?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462[]|null,
+    security_context?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_volume_mount_1546[]|null,
+    volume_mount?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_volume_mount_468[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -18551,14 +18551,14 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510[]|null;
+  readonly value_from: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432[]|null;
 
   constructor({
     name,
@@ -18567,7 +18567,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510[]|null
+    value_from?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -18587,15 +18587,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_config_map_key_ref_1511[]|null;
-  readonly field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_field_ref_1512[]|null;
-  readonly resource_field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_resource_field_ref_1513[]|null;
-  readonly secret_key_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_secret_key_ref_1514[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_config_map_key_ref_433[]|null;
+  readonly field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_field_ref_434[]|null;
+  readonly resource_field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_resource_field_ref_435[]|null;
+  readonly secret_key_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_secret_key_ref_436[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -18603,10 +18603,10 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_config_map_key_ref_1511[]|null,
-    field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_field_ref_1512[]|null,
-    resource_field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_resource_field_ref_1513[]|null,
-    secret_key_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_secret_key_ref_1514[]|null
+    config_map_key_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_config_map_key_ref_433[]|null,
+    field_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_field_ref_434[]|null,
+    resource_field_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_resource_field_ref_435[]|null,
+    secret_key_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_secret_key_ref_436[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -18632,11 +18632,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_config_map_key_ref_1511 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_config_map_key_ref_433 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -18663,11 +18663,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_config_map_key_ref_1511';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_config_map_key_ref_433';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_field_ref_1512 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_field_ref_434 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -18694,11 +18694,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_field_ref_1512';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_field_ref_434';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_resource_field_ref_1513 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_resource_field_ref_435 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -18723,11 +18723,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_resource_field_ref_1513';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_resource_field_ref_435';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_secret_key_ref_1514 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_secret_key_ref_436 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -18754,23 +18754,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_1509_value_from_1510_secret_key_ref_1514';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_431_value_from_432_secret_key_ref_436';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_config_map_ref_1516[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_config_map_ref_438[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_secret_ref_1517[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_secret_ref_439[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_config_map_ref_1516[]|null,
+    config_map_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_config_map_ref_438[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_secret_ref_1517[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_secret_ref_439[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -18792,11 +18792,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_config_map_ref_1516 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_config_map_ref_438 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -18821,11 +18821,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_config_map_ref_1516';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_config_map_ref_438';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_secret_ref_1517 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_secret_ref_439 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -18850,20 +18850,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_env_from_1515_secret_ref_1517';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_env_from_437_secret_ref_439';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518 implements PcoreValue {
-  readonly post_start: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519[]|null;
-  readonly pre_stop: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440 implements PcoreValue {
+  readonly post_start: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441[]|null;
+  readonly pre_stop: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519[]|null,
-    pre_stop?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524[]|null
+    post_start?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441[]|null,
+    pre_stop?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -18881,23 +18881,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_exec_1520[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_tcp_socket_1523[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_exec_442[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_tcp_socket_445[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_exec_1520[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_tcp_socket_1523[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_exec_442[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_tcp_socket_445[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -18919,11 +18919,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_exec_1520 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_exec_442 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -18943,13 +18943,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_exec_1520';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_exec_442';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521_http_header_1522[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443_http_header_444[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -18962,7 +18962,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521_http_header_1522[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443_http_header_444[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -18995,11 +18995,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521_http_header_1522 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443_http_header_444 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -19026,11 +19026,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_http_get_1521_http_header_1522';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_http_get_443_http_header_444';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_tcp_socket_1523 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_tcp_socket_445 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -19048,23 +19048,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_post_start_1519_tcp_socket_1523';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_post_start_441_tcp_socket_445';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_exec_1525[]|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526[]|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_tcp_socket_1528[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_exec_447[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_tcp_socket_450[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_exec_1525[]|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526[]|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_tcp_socket_1528[]|null
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_exec_447[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_tcp_socket_450[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -19086,11 +19086,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_exec_1525 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_exec_447 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -19110,13 +19110,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_exec_1525';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_exec_447';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526_http_header_1527[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448_http_header_449[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -19129,7 +19129,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526_http_header_1527[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448_http_header_449[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -19162,11 +19162,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526_http_header_1527 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448_http_header_449 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -19193,11 +19193,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_http_get_1526_http_header_1527';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_http_get_448_http_header_449';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_tcp_socket_1528 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_tcp_socket_450 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -19215,18 +19215,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_lifecycle_1518_pre_stop_1524_tcp_socket_1528';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_lifecycle_440_pre_stop_446_tcp_socket_450';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_exec_1530[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_exec_452[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_tcp_socket_1533[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_tcp_socket_455[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -19239,13 +19239,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_exec_1530[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_exec_452[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_tcp_socket_1533[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_tcp_socket_455[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -19288,11 +19288,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_exec_1530 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_exec_452 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -19312,13 +19312,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_exec_1530';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_exec_452';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531_http_header_1532[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453_http_header_454[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -19331,7 +19331,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531_http_header_1532[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453_http_header_454[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -19364,11 +19364,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531_http_header_1532 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453_http_header_454 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -19395,11 +19395,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_http_get_1531_http_header_1532';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_http_get_453_http_header_454';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_tcp_socket_1533 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_tcp_socket_455 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -19417,11 +19417,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_liveness_probe_1529_tcp_socket_1533';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_liveness_probe_451_tcp_socket_455';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_port_1534 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_port_456 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -19467,18 +19467,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_port_1534';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_port_456';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535 implements PcoreValue {
-  readonly exec: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_exec_1536[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457 implements PcoreValue {
+  readonly exec: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_exec_458[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537[]|null;
+  readonly http_get: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_tcp_socket_1539[]|null;
+  readonly tcp_socket: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_tcp_socket_461[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -19491,13 +19491,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_exec_1536[]|null,
+    exec?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_exec_458[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537[]|null,
+    http_get?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_tcp_socket_1539[]|null,
+    tcp_socket?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_tcp_socket_461[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -19540,11 +19540,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_exec_1536 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_exec_458 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -19564,13 +19564,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_exec_1536';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_exec_458';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537_http_header_1538[]|null;
+  readonly http_header: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459_http_header_460[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -19583,7 +19583,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537_http_header_1538[]|null,
+    http_header?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459_http_header_460[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -19616,11 +19616,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537_http_header_1538 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459_http_header_460 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -19647,11 +19647,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_http_get_1537_http_header_1538';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_http_get_459_http_header_460';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_tcp_socket_1539 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_tcp_socket_461 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -19669,20 +19669,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_readiness_probe_1535_tcp_socket_1539';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_readiness_probe_457_tcp_socket_461';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540 implements PcoreValue {
-  readonly limits: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_limits_1541[]|null;
-  readonly requests: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_requests_1542[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462 implements PcoreValue {
+  readonly limits: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_limits_463[]|null;
+  readonly requests: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_requests_464[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_limits_1541[]|null,
-    requests?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_requests_1542[]|null
+    limits?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_limits_463[]|null,
+    requests?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_requests_464[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -19700,11 +19700,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_limits_1541 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_limits_463 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -19731,11 +19731,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_limits_1541';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_limits_463';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_requests_1542 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_requests_464 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -19762,18 +19762,18 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_resources_1540_requests_1542';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_resources_462_requests_464';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_capabilities_1544[]|null;
+  readonly capabilities: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_capabilities_466[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_se_linux_options_1545[]|null;
+  readonly se_linux_options: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_se_linux_options_467[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -19785,12 +19785,12 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_capabilities_1544[]|null,
+    capabilities?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_capabilities_466[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_se_linux_options_1545[]|null
+    se_linux_options?: Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_se_linux_options_467[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -19828,11 +19828,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_capabilities_1544 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_capabilities_466 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -19859,11 +19859,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_capabilities_1544';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_capabilities_466';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_se_linux_options_1545 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_se_linux_options_467 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -19904,11 +19904,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_security_context_1543_se_linux_options_1545';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_security_context_465_se_linux_options_467';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_volume_mount_1546 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_volume_mount_468 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -19945,15 +19945,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_init_container_1508_volume_mount_1546';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_init_container_430_volume_mount_468';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469 implements PcoreValue {
   readonly fs_group: number|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547_se_linux_options_1548[]|null;
+  readonly se_linux_options: Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469_se_linux_options_470[]|null;
   readonly supplemental_groups: number[]|null;
 
   constructor({
@@ -19966,7 +19966,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     fs_group?: number|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547_se_linux_options_1548[]|null,
+    se_linux_options?: Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469_se_linux_options_470[]|null,
     supplemental_groups?: number[]|null
   }) {
     this.fs_group = fs_group;
@@ -19997,11 +19997,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547_se_linux_options_1548 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469_se_linux_options_470 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -20042,36 +20042,36 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_security_context_1547_se_linux_options_1548';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_security_context_469_se_linux_options_470';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549 implements PcoreValue {
-  readonly aws_elastic_block_store: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_aws_elastic_block_store_1550[]|null;
-  readonly azure_disk: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_disk_1551[]|null;
-  readonly azure_file: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_file_1552[]|null;
-  readonly ceph_fs: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553[]|null;
-  readonly cinder: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_cinder_1555[]|null;
-  readonly config_map: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556[]|null;
-  readonly downward_api: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558[]|null;
-  readonly empty_dir: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_empty_dir_1562[]|null;
-  readonly fc: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_fc_1563[]|null;
-  readonly flex_volume: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564[]|null;
-  readonly flocker: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flocker_1566[]|null;
-  readonly gce_persistent_disk: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_gce_persistent_disk_1567[]|null;
-  readonly git_repo: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_git_repo_1568[]|null;
-  readonly glusterfs: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_glusterfs_1569[]|null;
-  readonly host_path: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_host_path_1570[]|null;
-  readonly iscsi: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_iscsi_1571[]|null;
-  readonly local: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_local_1572[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471 implements PcoreValue {
+  readonly aws_elastic_block_store: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_aws_elastic_block_store_472[]|null;
+  readonly azure_disk: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_disk_473[]|null;
+  readonly azure_file: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_file_474[]|null;
+  readonly ceph_fs: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475[]|null;
+  readonly cinder: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_cinder_477[]|null;
+  readonly config_map: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478[]|null;
+  readonly downward_api: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480[]|null;
+  readonly empty_dir: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_empty_dir_484[]|null;
+  readonly fc: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_fc_485[]|null;
+  readonly flex_volume: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486[]|null;
+  readonly flocker: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flocker_488[]|null;
+  readonly gce_persistent_disk: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_gce_persistent_disk_489[]|null;
+  readonly git_repo: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_git_repo_490[]|null;
+  readonly glusterfs: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_glusterfs_491[]|null;
+  readonly host_path: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_host_path_492[]|null;
+  readonly iscsi: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_iscsi_493[]|null;
+  readonly local: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_local_494[]|null;
   readonly name: string|null;
-  readonly nfs: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_nfs_1573[]|null;
-  readonly persistent_volume_claim: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_persistent_volume_claim_1574[]|null;
-  readonly photon_persistent_disk: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_photon_persistent_disk_1575[]|null;
-  readonly quobyte: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_quobyte_1576[]|null;
-  readonly rbd: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577[]|null;
-  readonly secret: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579[]|null;
-  readonly vsphere_volume: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_vsphere_volume_1581[]|null;
+  readonly nfs: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_nfs_495[]|null;
+  readonly persistent_volume_claim: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_persistent_volume_claim_496[]|null;
+  readonly photon_persistent_disk: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_photon_persistent_disk_497[]|null;
+  readonly quobyte: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_quobyte_498[]|null;
+  readonly rbd: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499[]|null;
+  readonly secret: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501[]|null;
+  readonly vsphere_volume: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_vsphere_volume_503[]|null;
 
   constructor({
     aws_elastic_block_store = null,
@@ -20100,31 +20100,31 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     secret = null,
     vsphere_volume = null
   }: {
-    aws_elastic_block_store?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_aws_elastic_block_store_1550[]|null,
-    azure_disk?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_disk_1551[]|null,
-    azure_file?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_file_1552[]|null,
-    ceph_fs?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553[]|null,
-    cinder?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_cinder_1555[]|null,
-    config_map?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556[]|null,
-    downward_api?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558[]|null,
-    empty_dir?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_empty_dir_1562[]|null,
-    fc?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_fc_1563[]|null,
-    flex_volume?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564[]|null,
-    flocker?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flocker_1566[]|null,
-    gce_persistent_disk?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_gce_persistent_disk_1567[]|null,
-    git_repo?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_git_repo_1568[]|null,
-    glusterfs?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_glusterfs_1569[]|null,
-    host_path?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_host_path_1570[]|null,
-    iscsi?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_iscsi_1571[]|null,
-    local?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_local_1572[]|null,
+    aws_elastic_block_store?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_aws_elastic_block_store_472[]|null,
+    azure_disk?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_disk_473[]|null,
+    azure_file?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_file_474[]|null,
+    ceph_fs?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475[]|null,
+    cinder?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_cinder_477[]|null,
+    config_map?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478[]|null,
+    downward_api?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480[]|null,
+    empty_dir?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_empty_dir_484[]|null,
+    fc?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_fc_485[]|null,
+    flex_volume?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486[]|null,
+    flocker?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flocker_488[]|null,
+    gce_persistent_disk?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_gce_persistent_disk_489[]|null,
+    git_repo?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_git_repo_490[]|null,
+    glusterfs?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_glusterfs_491[]|null,
+    host_path?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_host_path_492[]|null,
+    iscsi?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_iscsi_493[]|null,
+    local?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_local_494[]|null,
     name?: string|null,
-    nfs?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_nfs_1573[]|null,
-    persistent_volume_claim?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_persistent_volume_claim_1574[]|null,
-    photon_persistent_disk?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_photon_persistent_disk_1575[]|null,
-    quobyte?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_quobyte_1576[]|null,
-    rbd?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577[]|null,
-    secret?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579[]|null,
-    vsphere_volume?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_vsphere_volume_1581[]|null
+    nfs?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_nfs_495[]|null,
+    persistent_volume_claim?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_persistent_volume_claim_496[]|null,
+    photon_persistent_disk?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_photon_persistent_disk_497[]|null,
+    quobyte?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_quobyte_498[]|null,
+    rbd?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499[]|null,
+    secret?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501[]|null,
+    vsphere_volume?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_vsphere_volume_503[]|null
   }) {
     this.aws_elastic_block_store = aws_elastic_block_store;
     this.azure_disk = azure_disk;
@@ -20234,11 +20234,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_aws_elastic_block_store_1550 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_aws_elastic_block_store_472 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -20277,11 +20277,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_aws_elastic_block_store_1550';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_aws_elastic_block_store_472';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_disk_1551 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_disk_473 implements PcoreValue {
   readonly caching_mode: string;
   readonly data_disk_uri: string;
   readonly disk_name: string;
@@ -20323,11 +20323,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_disk_1551';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_disk_473';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_file_1552 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_file_474 implements PcoreValue {
   readonly secret_name: string;
   readonly share_name: string;
   readonly read_only: boolean|null;
@@ -20357,16 +20357,16 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_azure_file_1552';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_azure_file_474';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475 implements PcoreValue {
   readonly monitors: string[];
   readonly path: string|null;
   readonly read_only: boolean|null;
   readonly secret_file: string|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553_secret_ref_1554[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475_secret_ref_476[]|null;
   readonly user: string|null;
 
   constructor({
@@ -20381,7 +20381,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     path?: string|null,
     read_only?: boolean|null,
     secret_file?: string|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553_secret_ref_1554[]|null,
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475_secret_ref_476[]|null,
     user?: string|null
   }) {
     this.monitors = monitors;
@@ -20414,11 +20414,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553_secret_ref_1554 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475_secret_ref_476 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -20438,11 +20438,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_ceph_fs_1553_secret_ref_1554';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_ceph_fs_475_secret_ref_476';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_cinder_1555 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_cinder_477 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly read_only: boolean|null;
@@ -20474,13 +20474,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_cinder_1555';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_cinder_477';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556_items_1557[]|null;
+  readonly items: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478_items_479[]|null;
   readonly name: string|null;
 
   constructor({
@@ -20489,7 +20489,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556_items_1557[]|null,
+    items?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478_items_479[]|null,
     name?: string|null
   }) {
     this.default_mode = default_mode;
@@ -20512,11 +20512,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556_items_1557 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478_items_479 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -20550,20 +20550,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_config_map_1556_items_1557';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_config_map_478_items_479';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559[]|null;
+  readonly items: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481[]|null;
 
   constructor({
     default_mode = null,
     items = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559[]|null
+    items?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481[]|null
   }) {
     this.default_mode = default_mode;
     this.items = items;
@@ -20581,15 +20581,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559 implements PcoreValue {
-  readonly field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_field_ref_1560[];
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481 implements PcoreValue {
+  readonly field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_field_ref_482[];
   readonly path: string;
   readonly mode: number|null;
-  readonly resource_field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_resource_field_ref_1561[]|null;
+  readonly resource_field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_resource_field_ref_483[]|null;
 
   constructor({
     field_ref,
@@ -20597,10 +20597,10 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     mode = null,
     resource_field_ref = null
   }: {
-    field_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_field_ref_1560[],
+    field_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_field_ref_482[],
     path: string,
     mode?: number|null,
-    resource_field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_resource_field_ref_1561[]|null
+    resource_field_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_resource_field_ref_483[]|null
   }) {
     this.field_ref = field_ref;
     this.path = path;
@@ -20622,11 +20622,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_field_ref_1560 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_field_ref_482 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -20653,11 +20653,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_field_ref_1560';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_field_ref_482';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_resource_field_ref_1561 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_resource_field_ref_483 implements PcoreValue {
   readonly container_name: string;
   readonly resource: string;
   readonly quantity: string|null;
@@ -20687,11 +20687,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_downward_api_1558_items_1559_resource_field_ref_1561';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_downward_api_480_items_481_resource_field_ref_483';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_empty_dir_1562 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_empty_dir_484 implements PcoreValue {
   readonly medium: string|null;
 
   constructor({
@@ -20711,11 +20711,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_empty_dir_1562';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_empty_dir_484';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_fc_1563 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_fc_485 implements PcoreValue {
   readonly lun: number;
   readonly target_ww_ns: string[];
   readonly fs_type: string|null;
@@ -20752,16 +20752,16 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_fc_1563';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_fc_485';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486 implements PcoreValue {
   readonly driver: string;
   readonly fs_type: string|null;
   readonly options: {[s: string]: string}|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564_secret_ref_1565[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486_secret_ref_487[]|null;
 
   constructor({
     driver,
@@ -20774,7 +20774,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     fs_type?: string|null,
     options?: {[s: string]: string}|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564_secret_ref_1565[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486_secret_ref_487[]|null
   }) {
     this.driver = driver;
     this.fs_type = fs_type;
@@ -20802,11 +20802,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564_secret_ref_1565 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486_secret_ref_487 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -20826,11 +20826,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flex_volume_1564_secret_ref_1565';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flex_volume_486_secret_ref_487';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flocker_1566 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flocker_488 implements PcoreValue {
   readonly dataset_name: string|null;
   readonly dataset_uuid: string|null;
 
@@ -20857,11 +20857,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_flocker_1566';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_flocker_488';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_gce_persistent_disk_1567 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_gce_persistent_disk_489 implements PcoreValue {
   readonly pd_name: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -20900,11 +20900,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_gce_persistent_disk_1567';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_gce_persistent_disk_489';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_git_repo_1568 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_git_repo_490 implements PcoreValue {
   readonly directory: string|null;
   readonly repository: string|null;
   readonly revision: string|null;
@@ -20938,11 +20938,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_git_repo_1568';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_git_repo_490';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_glusterfs_1569 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_glusterfs_491 implements PcoreValue {
   readonly endpoints_name: string;
   readonly path: string;
   readonly read_only: boolean|null;
@@ -20972,11 +20972,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_glusterfs_1569';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_glusterfs_491';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_host_path_1570 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_host_path_492 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -20996,11 +20996,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_host_path_1570';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_host_path_492';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_iscsi_1571 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_iscsi_493 implements PcoreValue {
   readonly iqn: string;
   readonly target_portal: string;
   readonly fs_type: string|null;
@@ -21051,11 +21051,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_iscsi_1571';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_iscsi_493';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_local_1572 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_local_494 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -21075,11 +21075,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_local_1572';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_local_494';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_nfs_1573 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_nfs_495 implements PcoreValue {
   readonly path: string;
   readonly server: string;
   readonly read_only: boolean|null;
@@ -21109,11 +21109,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_nfs_1573';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_nfs_495';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_persistent_volume_claim_1574 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_persistent_volume_claim_496 implements PcoreValue {
   readonly claim_name: string|null;
   readonly read_only: boolean|null;
 
@@ -21140,11 +21140,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_persistent_volume_claim_1574';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_persistent_volume_claim_496';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_photon_persistent_disk_1575 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_photon_persistent_disk_497 implements PcoreValue {
   readonly pd_id: string;
   readonly fs_type: string|null;
 
@@ -21169,11 +21169,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_photon_persistent_disk_1575';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_photon_persistent_disk_497';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_quobyte_1576 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_quobyte_498 implements PcoreValue {
   readonly registry: string;
   readonly volume: string;
   readonly group: string|null;
@@ -21217,11 +21217,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_quobyte_1576';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_quobyte_498';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499 implements PcoreValue {
   readonly ceph_monitors: string[];
   readonly rbd_image: string;
   readonly fs_type: string|null;
@@ -21229,7 +21229,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   readonly rados_user: string|null;
   readonly rbd_pool: string|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577_secret_ref_1578[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499_secret_ref_500[]|null;
 
   constructor({
     ceph_monitors,
@@ -21248,7 +21248,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     rados_user?: string|null,
     rbd_pool?: string|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577_secret_ref_1578[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499_secret_ref_500[]|null
   }) {
     this.ceph_monitors = ceph_monitors;
     this.rbd_image = rbd_image;
@@ -21286,11 +21286,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577_secret_ref_1578 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499_secret_ref_500 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -21310,13 +21310,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_rbd_1577_secret_ref_1578';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_rbd_499_secret_ref_500';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579_items_1580[]|null;
+  readonly items: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501_items_502[]|null;
   readonly optional: boolean|null;
   readonly secret_name: string|null;
 
@@ -21327,7 +21327,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
     secret_name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579_items_1580[]|null,
+    items?: Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501_items_502[]|null,
     optional?: boolean|null,
     secret_name?: string|null
   }) {
@@ -21355,11 +21355,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579_items_1580 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501_items_502 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -21393,11 +21393,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_secret_1579_items_1580';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_secret_501_items_502';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_vsphere_volume_1581 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_vsphere_volume_503 implements PcoreValue {
   readonly volume_path: string;
   readonly fs_type: string|null;
 
@@ -21422,36 +21422,36 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_spec_1467
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_spec_1467_volume_1549_vsphere_volume_1581';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_spec_389_volume_471_vsphere_volume_503';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582 implements PcoreValue {
-  readonly aws_elastic_block_store: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_aws_elastic_block_store_1583[]|null;
-  readonly azure_disk: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_disk_1584[]|null;
-  readonly azure_file: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_file_1585[]|null;
-  readonly ceph_fs: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586[]|null;
-  readonly cinder: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_cinder_1588[]|null;
-  readonly config_map: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589[]|null;
-  readonly downward_api: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591[]|null;
-  readonly empty_dir: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_empty_dir_1595[]|null;
-  readonly fc: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_fc_1596[]|null;
-  readonly flex_volume: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597[]|null;
-  readonly flocker: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flocker_1599[]|null;
-  readonly gce_persistent_disk: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_gce_persistent_disk_1600[]|null;
-  readonly git_repo: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_git_repo_1601[]|null;
-  readonly glusterfs: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_glusterfs_1602[]|null;
-  readonly host_path: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_host_path_1603[]|null;
-  readonly iscsi: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_iscsi_1604[]|null;
-  readonly local: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_local_1605[]|null;
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504 implements PcoreValue {
+  readonly aws_elastic_block_store: Kubernetes_replication_controller_spec_305_template_306_volume_504_aws_elastic_block_store_505[]|null;
+  readonly azure_disk: Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_disk_506[]|null;
+  readonly azure_file: Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_file_507[]|null;
+  readonly ceph_fs: Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508[]|null;
+  readonly cinder: Kubernetes_replication_controller_spec_305_template_306_volume_504_cinder_510[]|null;
+  readonly config_map: Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511[]|null;
+  readonly downward_api: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513[]|null;
+  readonly empty_dir: Kubernetes_replication_controller_spec_305_template_306_volume_504_empty_dir_517[]|null;
+  readonly fc: Kubernetes_replication_controller_spec_305_template_306_volume_504_fc_518[]|null;
+  readonly flex_volume: Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519[]|null;
+  readonly flocker: Kubernetes_replication_controller_spec_305_template_306_volume_504_flocker_521[]|null;
+  readonly gce_persistent_disk: Kubernetes_replication_controller_spec_305_template_306_volume_504_gce_persistent_disk_522[]|null;
+  readonly git_repo: Kubernetes_replication_controller_spec_305_template_306_volume_504_git_repo_523[]|null;
+  readonly glusterfs: Kubernetes_replication_controller_spec_305_template_306_volume_504_glusterfs_524[]|null;
+  readonly host_path: Kubernetes_replication_controller_spec_305_template_306_volume_504_host_path_525[]|null;
+  readonly iscsi: Kubernetes_replication_controller_spec_305_template_306_volume_504_iscsi_526[]|null;
+  readonly local: Kubernetes_replication_controller_spec_305_template_306_volume_504_local_527[]|null;
   readonly name: string|null;
-  readonly nfs: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_nfs_1606[]|null;
-  readonly persistent_volume_claim: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_persistent_volume_claim_1607[]|null;
-  readonly photon_persistent_disk: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_photon_persistent_disk_1608[]|null;
-  readonly quobyte: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_quobyte_1609[]|null;
-  readonly rbd: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610[]|null;
-  readonly secret: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612[]|null;
-  readonly vsphere_volume: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_vsphere_volume_1614[]|null;
+  readonly nfs: Kubernetes_replication_controller_spec_305_template_306_volume_504_nfs_528[]|null;
+  readonly persistent_volume_claim: Kubernetes_replication_controller_spec_305_template_306_volume_504_persistent_volume_claim_529[]|null;
+  readonly photon_persistent_disk: Kubernetes_replication_controller_spec_305_template_306_volume_504_photon_persistent_disk_530[]|null;
+  readonly quobyte: Kubernetes_replication_controller_spec_305_template_306_volume_504_quobyte_531[]|null;
+  readonly rbd: Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532[]|null;
+  readonly secret: Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534[]|null;
+  readonly vsphere_volume: Kubernetes_replication_controller_spec_305_template_306_volume_504_vsphere_volume_536[]|null;
 
   constructor({
     aws_elastic_block_store = null,
@@ -21480,31 +21480,31 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     secret = null,
     vsphere_volume = null
   }: {
-    aws_elastic_block_store?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_aws_elastic_block_store_1583[]|null,
-    azure_disk?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_disk_1584[]|null,
-    azure_file?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_file_1585[]|null,
-    ceph_fs?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586[]|null,
-    cinder?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_cinder_1588[]|null,
-    config_map?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589[]|null,
-    downward_api?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591[]|null,
-    empty_dir?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_empty_dir_1595[]|null,
-    fc?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_fc_1596[]|null,
-    flex_volume?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597[]|null,
-    flocker?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flocker_1599[]|null,
-    gce_persistent_disk?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_gce_persistent_disk_1600[]|null,
-    git_repo?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_git_repo_1601[]|null,
-    glusterfs?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_glusterfs_1602[]|null,
-    host_path?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_host_path_1603[]|null,
-    iscsi?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_iscsi_1604[]|null,
-    local?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_local_1605[]|null,
+    aws_elastic_block_store?: Kubernetes_replication_controller_spec_305_template_306_volume_504_aws_elastic_block_store_505[]|null,
+    azure_disk?: Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_disk_506[]|null,
+    azure_file?: Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_file_507[]|null,
+    ceph_fs?: Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508[]|null,
+    cinder?: Kubernetes_replication_controller_spec_305_template_306_volume_504_cinder_510[]|null,
+    config_map?: Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511[]|null,
+    downward_api?: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513[]|null,
+    empty_dir?: Kubernetes_replication_controller_spec_305_template_306_volume_504_empty_dir_517[]|null,
+    fc?: Kubernetes_replication_controller_spec_305_template_306_volume_504_fc_518[]|null,
+    flex_volume?: Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519[]|null,
+    flocker?: Kubernetes_replication_controller_spec_305_template_306_volume_504_flocker_521[]|null,
+    gce_persistent_disk?: Kubernetes_replication_controller_spec_305_template_306_volume_504_gce_persistent_disk_522[]|null,
+    git_repo?: Kubernetes_replication_controller_spec_305_template_306_volume_504_git_repo_523[]|null,
+    glusterfs?: Kubernetes_replication_controller_spec_305_template_306_volume_504_glusterfs_524[]|null,
+    host_path?: Kubernetes_replication_controller_spec_305_template_306_volume_504_host_path_525[]|null,
+    iscsi?: Kubernetes_replication_controller_spec_305_template_306_volume_504_iscsi_526[]|null,
+    local?: Kubernetes_replication_controller_spec_305_template_306_volume_504_local_527[]|null,
     name?: string|null,
-    nfs?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_nfs_1606[]|null,
-    persistent_volume_claim?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_persistent_volume_claim_1607[]|null,
-    photon_persistent_disk?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_photon_persistent_disk_1608[]|null,
-    quobyte?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_quobyte_1609[]|null,
-    rbd?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610[]|null,
-    secret?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612[]|null,
-    vsphere_volume?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_vsphere_volume_1614[]|null
+    nfs?: Kubernetes_replication_controller_spec_305_template_306_volume_504_nfs_528[]|null,
+    persistent_volume_claim?: Kubernetes_replication_controller_spec_305_template_306_volume_504_persistent_volume_claim_529[]|null,
+    photon_persistent_disk?: Kubernetes_replication_controller_spec_305_template_306_volume_504_photon_persistent_disk_530[]|null,
+    quobyte?: Kubernetes_replication_controller_spec_305_template_306_volume_504_quobyte_531[]|null,
+    rbd?: Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532[]|null,
+    secret?: Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534[]|null,
+    vsphere_volume?: Kubernetes_replication_controller_spec_305_template_306_volume_504_vsphere_volume_536[]|null
   }) {
     this.aws_elastic_block_store = aws_elastic_block_store;
     this.azure_disk = azure_disk;
@@ -21614,11 +21614,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_aws_elastic_block_store_1583 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_aws_elastic_block_store_505 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -21657,11 +21657,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_aws_elastic_block_store_1583';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_aws_elastic_block_store_505';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_disk_1584 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_disk_506 implements PcoreValue {
   readonly caching_mode: string;
   readonly data_disk_uri: string;
   readonly disk_name: string;
@@ -21703,11 +21703,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_disk_1584';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_disk_506';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_file_1585 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_file_507 implements PcoreValue {
   readonly secret_name: string;
   readonly share_name: string;
   readonly read_only: boolean|null;
@@ -21737,16 +21737,16 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_azure_file_1585';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_azure_file_507';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508 implements PcoreValue {
   readonly monitors: string[];
   readonly path: string|null;
   readonly read_only: boolean|null;
   readonly secret_file: string|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586_secret_ref_1587[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508_secret_ref_509[]|null;
   readonly user: string|null;
 
   constructor({
@@ -21761,7 +21761,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     path?: string|null,
     read_only?: boolean|null,
     secret_file?: string|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586_secret_ref_1587[]|null,
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508_secret_ref_509[]|null,
     user?: string|null
   }) {
     this.monitors = monitors;
@@ -21794,11 +21794,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586_secret_ref_1587 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508_secret_ref_509 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -21818,11 +21818,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_ceph_fs_1586_secret_ref_1587';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_ceph_fs_508_secret_ref_509';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_cinder_1588 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_cinder_510 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly read_only: boolean|null;
@@ -21854,13 +21854,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_cinder_1588';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_cinder_510';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589_items_1590[]|null;
+  readonly items: Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511_items_512[]|null;
   readonly name: string|null;
 
   constructor({
@@ -21869,7 +21869,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589_items_1590[]|null,
+    items?: Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511_items_512[]|null,
     name?: string|null
   }) {
     this.default_mode = default_mode;
@@ -21892,11 +21892,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589_items_1590 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511_items_512 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -21930,20 +21930,20 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_config_map_1589_items_1590';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_config_map_511_items_512';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592[]|null;
+  readonly items: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514[]|null;
 
   constructor({
     default_mode = null,
     items = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592[]|null
+    items?: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514[]|null
   }) {
     this.default_mode = default_mode;
     this.items = items;
@@ -21961,15 +21961,15 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592 implements PcoreValue {
-  readonly field_ref: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_field_ref_1593[];
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514 implements PcoreValue {
+  readonly field_ref: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_field_ref_515[];
   readonly path: string;
   readonly mode: number|null;
-  readonly resource_field_ref: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_resource_field_ref_1594[]|null;
+  readonly resource_field_ref: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_resource_field_ref_516[]|null;
 
   constructor({
     field_ref,
@@ -21977,10 +21977,10 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     mode = null,
     resource_field_ref = null
   }: {
-    field_ref: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_field_ref_1593[],
+    field_ref: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_field_ref_515[],
     path: string,
     mode?: number|null,
-    resource_field_ref?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_resource_field_ref_1594[]|null
+    resource_field_ref?: Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_resource_field_ref_516[]|null
   }) {
     this.field_ref = field_ref;
     this.path = path;
@@ -22002,11 +22002,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_field_ref_1593 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_field_ref_515 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -22033,11 +22033,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_field_ref_1593';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_field_ref_515';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_resource_field_ref_1594 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_resource_field_ref_516 implements PcoreValue {
   readonly container_name: string;
   readonly resource: string;
   readonly quantity: string|null;
@@ -22067,11 +22067,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_downward_api_1591_items_1592_resource_field_ref_1594';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_downward_api_513_items_514_resource_field_ref_516';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_empty_dir_1595 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_empty_dir_517 implements PcoreValue {
   readonly medium: string|null;
 
   constructor({
@@ -22091,11 +22091,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_empty_dir_1595';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_empty_dir_517';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_fc_1596 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_fc_518 implements PcoreValue {
   readonly lun: number;
   readonly target_ww_ns: string[];
   readonly fs_type: string|null;
@@ -22132,16 +22132,16 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_fc_1596';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_fc_518';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519 implements PcoreValue {
   readonly driver: string;
   readonly fs_type: string|null;
   readonly options: {[s: string]: string}|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597_secret_ref_1598[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519_secret_ref_520[]|null;
 
   constructor({
     driver,
@@ -22154,7 +22154,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     fs_type?: string|null,
     options?: {[s: string]: string}|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597_secret_ref_1598[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519_secret_ref_520[]|null
   }) {
     this.driver = driver;
     this.fs_type = fs_type;
@@ -22182,11 +22182,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597_secret_ref_1598 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519_secret_ref_520 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -22206,11 +22206,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flex_volume_1597_secret_ref_1598';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_flex_volume_519_secret_ref_520';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flocker_1599 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_flocker_521 implements PcoreValue {
   readonly dataset_name: string|null;
   readonly dataset_uuid: string|null;
 
@@ -22237,11 +22237,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_flocker_1599';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_flocker_521';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_gce_persistent_disk_1600 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_gce_persistent_disk_522 implements PcoreValue {
   readonly pd_name: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -22280,11 +22280,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_gce_persistent_disk_1600';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_gce_persistent_disk_522';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_git_repo_1601 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_git_repo_523 implements PcoreValue {
   readonly directory: string|null;
   readonly repository: string|null;
   readonly revision: string|null;
@@ -22318,11 +22318,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_git_repo_1601';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_git_repo_523';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_glusterfs_1602 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_glusterfs_524 implements PcoreValue {
   readonly endpoints_name: string;
   readonly path: string;
   readonly read_only: boolean|null;
@@ -22352,11 +22352,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_glusterfs_1602';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_glusterfs_524';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_host_path_1603 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_host_path_525 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -22376,11 +22376,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_host_path_1603';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_host_path_525';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_iscsi_1604 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_iscsi_526 implements PcoreValue {
   readonly iqn: string;
   readonly target_portal: string;
   readonly fs_type: string|null;
@@ -22431,11 +22431,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_iscsi_1604';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_iscsi_526';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_local_1605 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_local_527 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -22455,11 +22455,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_local_1605';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_local_527';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_nfs_1606 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_nfs_528 implements PcoreValue {
   readonly path: string;
   readonly server: string;
   readonly read_only: boolean|null;
@@ -22489,11 +22489,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_nfs_1606';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_nfs_528';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_persistent_volume_claim_1607 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_persistent_volume_claim_529 implements PcoreValue {
   readonly claim_name: string|null;
   readonly read_only: boolean|null;
 
@@ -22520,11 +22520,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_persistent_volume_claim_1607';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_persistent_volume_claim_529';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_photon_persistent_disk_1608 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_photon_persistent_disk_530 implements PcoreValue {
   readonly pd_id: string;
   readonly fs_type: string|null;
 
@@ -22549,11 +22549,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_photon_persistent_disk_1608';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_photon_persistent_disk_530';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_quobyte_1609 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_quobyte_531 implements PcoreValue {
   readonly registry: string;
   readonly volume: string;
   readonly group: string|null;
@@ -22597,11 +22597,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_quobyte_1609';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_quobyte_531';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532 implements PcoreValue {
   readonly ceph_monitors: string[];
   readonly rbd_image: string;
   readonly fs_type: string|null;
@@ -22609,7 +22609,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   readonly rados_user: string|null;
   readonly rbd_pool: string|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610_secret_ref_1611[]|null;
+  readonly secret_ref: Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532_secret_ref_533[]|null;
 
   constructor({
     ceph_monitors,
@@ -22628,7 +22628,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     rados_user?: string|null,
     rbd_pool?: string|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610_secret_ref_1611[]|null
+    secret_ref?: Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532_secret_ref_533[]|null
   }) {
     this.ceph_monitors = ceph_monitors;
     this.rbd_image = rbd_image;
@@ -22666,11 +22666,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610_secret_ref_1611 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532_secret_ref_533 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -22690,13 +22690,13 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_rbd_1610_secret_ref_1611';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_rbd_532_secret_ref_533';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612_items_1613[]|null;
+  readonly items: Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534_items_535[]|null;
   readonly optional: boolean|null;
   readonly secret_name: string|null;
 
@@ -22707,7 +22707,7 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
     secret_name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612_items_1613[]|null,
+    items?: Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534_items_535[]|null,
     optional?: boolean|null,
     secret_name?: string|null
   }) {
@@ -22735,11 +22735,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612_items_1613 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534_items_535 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -22773,11 +22773,11 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_secret_1612_items_1613';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_secret_534_items_535';
   }
 }
 
-export class Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_vsphere_volume_1614 implements PcoreValue {
+export class Kubernetes_replication_controller_spec_305_template_306_volume_504_vsphere_volume_536 implements PcoreValue {
   readonly volume_path: string;
   readonly fs_type: string|null;
 
@@ -22802,23 +22802,23 @@ export class Kubernetes_replication_controller_spec_1383_template_1384_volume_15
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_1383_template_1384_volume_1582_vsphere_volume_1614';
+    return 'TerraformKubernetes::Kubernetes_replication_controller_spec_305_template_306_volume_504_vsphere_volume_536';
   }
 }
 
 export class Kubernetes_resource_quota implements PcoreValue {
-  readonly metadata: Kubernetes_resource_quota_metadata_1615[];
+  readonly metadata: Kubernetes_resource_quota_metadata_537[];
   readonly kubernetes_resource_quota_id: string|null;
-  readonly spec: Kubernetes_resource_quota_spec_1616[]|null;
+  readonly spec: Kubernetes_resource_quota_spec_538[]|null;
 
   constructor({
     metadata,
     kubernetes_resource_quota_id = null,
     spec = null
   }: {
-    metadata: Kubernetes_resource_quota_metadata_1615[],
+    metadata: Kubernetes_resource_quota_metadata_537[],
     kubernetes_resource_quota_id?: string|null,
-    spec?: Kubernetes_resource_quota_spec_1616[]|null
+    spec?: Kubernetes_resource_quota_spec_538[]|null
   }) {
     this.metadata = metadata;
     this.kubernetes_resource_quota_id = kubernetes_resource_quota_id;
@@ -22852,7 +22852,7 @@ export class Kubernetes_resource_quotaHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_resource_quota_metadata_1615 implements PcoreValue {
+export class Kubernetes_resource_quota_metadata_537 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -22928,11 +22928,11 @@ export class Kubernetes_resource_quota_metadata_1615 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_resource_quota_metadata_1615';
+    return 'TerraformKubernetes::Kubernetes_resource_quota_metadata_537';
   }
 }
 
-export class Kubernetes_resource_quota_spec_1616 implements PcoreValue {
+export class Kubernetes_resource_quota_spec_538 implements PcoreValue {
   readonly hard: {[s: string]: string}|null;
   readonly scopes: string[]|null;
 
@@ -22959,13 +22959,13 @@ export class Kubernetes_resource_quota_spec_1616 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_resource_quota_spec_1616';
+    return 'TerraformKubernetes::Kubernetes_resource_quota_spec_538';
   }
 }
 
 export class Kubernetes_role implements PcoreValue {
-  readonly metadata: Kubernetes_role_metadata_1617[];
-  readonly rule: Kubernetes_role_rule_1618[];
+  readonly metadata: Kubernetes_role_metadata_539[];
+  readonly rule: Kubernetes_role_rule_540[];
   readonly kubernetes_role_id: string|null;
 
   constructor({
@@ -22973,8 +22973,8 @@ export class Kubernetes_role implements PcoreValue {
     rule,
     kubernetes_role_id = null
   }: {
-    metadata: Kubernetes_role_metadata_1617[],
-    rule: Kubernetes_role_rule_1618[],
+    metadata: Kubernetes_role_metadata_539[],
+    rule: Kubernetes_role_rule_540[],
     kubernetes_role_id?: string|null
   }) {
     this.metadata = metadata;
@@ -23008,9 +23008,9 @@ export class Kubernetes_roleHandler implements PcoreValue {
 }
 
 export class Kubernetes_role_binding implements PcoreValue {
-  readonly metadata: Kubernetes_role_binding_metadata_1619[];
+  readonly metadata: Kubernetes_role_binding_metadata_541[];
   readonly role_ref: {[s: string]: string};
-  readonly subject: Kubernetes_role_binding_subject_1620[];
+  readonly subject: Kubernetes_role_binding_subject_542[];
   readonly kubernetes_role_binding_id: string|null;
 
   constructor({
@@ -23019,9 +23019,9 @@ export class Kubernetes_role_binding implements PcoreValue {
     subject,
     kubernetes_role_binding_id = null
   }: {
-    metadata: Kubernetes_role_binding_metadata_1619[],
+    metadata: Kubernetes_role_binding_metadata_541[],
     role_ref: {[s: string]: string},
-    subject: Kubernetes_role_binding_subject_1620[],
+    subject: Kubernetes_role_binding_subject_542[],
     kubernetes_role_binding_id?: string|null
   }) {
     this.metadata = metadata;
@@ -23056,7 +23056,7 @@ export class Kubernetes_role_bindingHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_role_binding_metadata_1619 implements PcoreValue {
+export class Kubernetes_role_binding_metadata_541 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generation: number|null;
   readonly labels: {[s: string]: string}|null;
@@ -23125,11 +23125,11 @@ export class Kubernetes_role_binding_metadata_1619 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_role_binding_metadata_1619';
+    return 'TerraformKubernetes::Kubernetes_role_binding_metadata_541';
   }
 }
 
-export class Kubernetes_role_binding_subject_1620 implements PcoreValue {
+export class Kubernetes_role_binding_subject_542 implements PcoreValue {
   readonly kind: string;
   readonly name: string;
   readonly api_group: string|null;
@@ -23166,11 +23166,11 @@ export class Kubernetes_role_binding_subject_1620 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_role_binding_subject_1620';
+    return 'TerraformKubernetes::Kubernetes_role_binding_subject_542';
   }
 }
 
-export class Kubernetes_role_metadata_1617 implements PcoreValue {
+export class Kubernetes_role_metadata_539 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -23246,11 +23246,11 @@ export class Kubernetes_role_metadata_1617 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_role_metadata_1617';
+    return 'TerraformKubernetes::Kubernetes_role_metadata_539';
   }
 }
 
-export class Kubernetes_role_rule_1618 implements PcoreValue {
+export class Kubernetes_role_rule_540 implements PcoreValue {
   readonly api_groups: string[];
   readonly resources: string[];
   readonly verbs: string[];
@@ -23285,12 +23285,12 @@ export class Kubernetes_role_rule_1618 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_role_rule_1618';
+    return 'TerraformKubernetes::Kubernetes_role_rule_540';
   }
 }
 
 export class Kubernetes_secret implements PcoreValue {
-  readonly metadata: Kubernetes_secret_metadata_1621[];
+  readonly metadata: Kubernetes_secret_metadata_543[];
   readonly kubernetes_secret_id: string|null;
   readonly data: {[s: string]: string}|null;
   readonly type: string|null;
@@ -23301,7 +23301,7 @@ export class Kubernetes_secret implements PcoreValue {
     data = null,
     type = null
   }: {
-    metadata: Kubernetes_secret_metadata_1621[],
+    metadata: Kubernetes_secret_metadata_543[],
     kubernetes_secret_id?: string|null,
     data?: {[s: string]: string}|null,
     type?: string|null
@@ -23342,7 +23342,7 @@ export class Kubernetes_secretHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_secret_metadata_1621 implements PcoreValue {
+export class Kubernetes_secret_metadata_543 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -23418,15 +23418,15 @@ export class Kubernetes_secret_metadata_1621 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_secret_metadata_1621';
+    return 'TerraformKubernetes::Kubernetes_secret_metadata_543';
   }
 }
 
 export class Kubernetes_service implements PcoreValue {
-  readonly metadata: Kubernetes_service_metadata_1623[];
-  readonly spec: Kubernetes_service_spec_1624[];
+  readonly metadata: Kubernetes_service_metadata_545[];
+  readonly spec: Kubernetes_service_spec_546[];
   readonly kubernetes_service_id: string|null;
-  readonly load_balancer_ingress: Kubernetes_service_load_balancer_ingress_1622[]|null;
+  readonly load_balancer_ingress: Kubernetes_service_load_balancer_ingress_544[]|null;
 
   constructor({
     metadata,
@@ -23434,10 +23434,10 @@ export class Kubernetes_service implements PcoreValue {
     kubernetes_service_id = null,
     load_balancer_ingress = null
   }: {
-    metadata: Kubernetes_service_metadata_1623[],
-    spec: Kubernetes_service_spec_1624[],
+    metadata: Kubernetes_service_metadata_545[],
+    spec: Kubernetes_service_spec_546[],
     kubernetes_service_id?: string|null,
-    load_balancer_ingress?: Kubernetes_service_load_balancer_ingress_1622[]|null
+    load_balancer_ingress?: Kubernetes_service_load_balancer_ingress_544[]|null
   }) {
     this.metadata = metadata;
     this.spec = spec;
@@ -23474,12 +23474,12 @@ export class Kubernetes_serviceHandler implements PcoreValue {
 }
 
 export class Kubernetes_service_account implements PcoreValue {
-  readonly metadata: Kubernetes_service_account_metadata_1627[];
+  readonly metadata: Kubernetes_service_account_metadata_549[];
   readonly kubernetes_service_account_id: string|null;
   readonly automount_service_account_token: boolean|null;
   readonly default_secret_name: string|null;
-  readonly image_pull_secret: Kubernetes_service_account_image_pull_secret_1626[]|null;
-  readonly secret: Kubernetes_service_account_secret_1628[]|null;
+  readonly image_pull_secret: Kubernetes_service_account_image_pull_secret_548[]|null;
+  readonly secret: Kubernetes_service_account_secret_550[]|null;
 
   constructor({
     metadata,
@@ -23489,12 +23489,12 @@ export class Kubernetes_service_account implements PcoreValue {
     image_pull_secret = null,
     secret = null
   }: {
-    metadata: Kubernetes_service_account_metadata_1627[],
+    metadata: Kubernetes_service_account_metadata_549[],
     kubernetes_service_account_id?: string|null,
     automount_service_account_token?: boolean|null,
     default_secret_name?: string|null,
-    image_pull_secret?: Kubernetes_service_account_image_pull_secret_1626[]|null,
-    secret?: Kubernetes_service_account_secret_1628[]|null
+    image_pull_secret?: Kubernetes_service_account_image_pull_secret_548[]|null,
+    secret?: Kubernetes_service_account_secret_550[]|null
   }) {
     this.metadata = metadata;
     this.kubernetes_service_account_id = kubernetes_service_account_id;
@@ -23540,7 +23540,7 @@ export class Kubernetes_service_accountHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_service_account_image_pull_secret_1626 implements PcoreValue {
+export class Kubernetes_service_account_image_pull_secret_548 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -23560,11 +23560,11 @@ export class Kubernetes_service_account_image_pull_secret_1626 implements PcoreV
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_account_image_pull_secret_1626';
+    return 'TerraformKubernetes::Kubernetes_service_account_image_pull_secret_548';
   }
 }
 
-export class Kubernetes_service_account_metadata_1627 implements PcoreValue {
+export class Kubernetes_service_account_metadata_549 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -23640,11 +23640,11 @@ export class Kubernetes_service_account_metadata_1627 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_account_metadata_1627';
+    return 'TerraformKubernetes::Kubernetes_service_account_metadata_549';
   }
 }
 
-export class Kubernetes_service_account_secret_1628 implements PcoreValue {
+export class Kubernetes_service_account_secret_550 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -23664,11 +23664,11 @@ export class Kubernetes_service_account_secret_1628 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_account_secret_1628';
+    return 'TerraformKubernetes::Kubernetes_service_account_secret_550';
   }
 }
 
-export class Kubernetes_service_load_balancer_ingress_1622 implements PcoreValue {
+export class Kubernetes_service_load_balancer_ingress_544 implements PcoreValue {
   readonly hostname: string|null;
   readonly ip: string|null;
 
@@ -23695,11 +23695,11 @@ export class Kubernetes_service_load_balancer_ingress_1622 implements PcoreValue
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_load_balancer_ingress_1622';
+    return 'TerraformKubernetes::Kubernetes_service_load_balancer_ingress_544';
   }
 }
 
-export class Kubernetes_service_metadata_1623 implements PcoreValue {
+export class Kubernetes_service_metadata_545 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -23775,17 +23775,17 @@ export class Kubernetes_service_metadata_1623 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_metadata_1623';
+    return 'TerraformKubernetes::Kubernetes_service_metadata_545';
   }
 }
 
-export class Kubernetes_service_spec_1624 implements PcoreValue {
+export class Kubernetes_service_spec_546 implements PcoreValue {
   readonly cluster_ip: string|null;
   readonly external_ips: string[]|null;
   readonly external_name: string|null;
   readonly load_balancer_ip: string|null;
   readonly load_balancer_source_ranges: string[]|null;
-  readonly port: Kubernetes_service_spec_1624_port_1625[]|null;
+  readonly port: Kubernetes_service_spec_546_port_547[]|null;
   readonly selector: {[s: string]: string}|null;
   readonly session_affinity: string|null;
   readonly type: string|null;
@@ -23806,7 +23806,7 @@ export class Kubernetes_service_spec_1624 implements PcoreValue {
     external_name?: string|null,
     load_balancer_ip?: string|null,
     load_balancer_source_ranges?: string[]|null,
-    port?: Kubernetes_service_spec_1624_port_1625[]|null,
+    port?: Kubernetes_service_spec_546_port_547[]|null,
     selector?: {[s: string]: string}|null,
     session_affinity?: string|null,
     type?: string|null
@@ -23855,11 +23855,11 @@ export class Kubernetes_service_spec_1624 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_spec_1624';
+    return 'TerraformKubernetes::Kubernetes_service_spec_546';
   }
 }
 
-export class Kubernetes_service_spec_1624_port_1625 implements PcoreValue {
+export class Kubernetes_service_spec_546_port_547 implements PcoreValue {
   readonly port: number;
   readonly name: string|null;
   readonly node_port: number|null;
@@ -23905,13 +23905,13 @@ export class Kubernetes_service_spec_1624_port_1625 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_service_spec_1624_port_1625';
+    return 'TerraformKubernetes::Kubernetes_service_spec_546_port_547';
   }
 }
 
 export class Kubernetes_stateful_set implements PcoreValue {
-  readonly metadata: Kubernetes_stateful_set_metadata_1629[];
-  readonly spec: Kubernetes_stateful_set_spec_1630[];
+  readonly metadata: Kubernetes_stateful_set_metadata_551[];
+  readonly spec: Kubernetes_stateful_set_spec_552[];
   readonly kubernetes_stateful_set_id: string|null;
 
   constructor({
@@ -23919,8 +23919,8 @@ export class Kubernetes_stateful_set implements PcoreValue {
     spec,
     kubernetes_stateful_set_id = null
   }: {
-    metadata: Kubernetes_stateful_set_metadata_1629[],
-    spec: Kubernetes_stateful_set_spec_1630[],
+    metadata: Kubernetes_stateful_set_metadata_551[],
+    spec: Kubernetes_stateful_set_spec_552[],
     kubernetes_stateful_set_id?: string|null
   }) {
     this.metadata = metadata;
@@ -23953,7 +23953,7 @@ export class Kubernetes_stateful_setHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_stateful_set_metadata_1629 implements PcoreValue {
+export class Kubernetes_stateful_set_metadata_551 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -24029,19 +24029,19 @@ export class Kubernetes_stateful_set_metadata_1629 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_metadata_1629';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_metadata_551';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630 implements PcoreValue {
-  readonly selector: Kubernetes_stateful_set_spec_1630_selector_1631[];
+export class Kubernetes_stateful_set_spec_552 implements PcoreValue {
+  readonly selector: Kubernetes_stateful_set_spec_552_selector_553[];
   readonly service_name: string;
-  readonly template: Kubernetes_stateful_set_spec_1630_template_1633[];
+  readonly template: Kubernetes_stateful_set_spec_552_template_555[];
   readonly pod_management_policy: string|null;
   readonly replicas: number|null;
   readonly revision_history_limit: number|null;
-  readonly update_strategy: Kubernetes_stateful_set_spec_1630_update_strategy_1750[]|null;
-  readonly volume_claim_template: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752[]|null;
+  readonly update_strategy: Kubernetes_stateful_set_spec_552_update_strategy_672[]|null;
+  readonly volume_claim_template: Kubernetes_stateful_set_spec_552_volume_claim_template_674[]|null;
 
   constructor({
     selector,
@@ -24053,14 +24053,14 @@ export class Kubernetes_stateful_set_spec_1630 implements PcoreValue {
     update_strategy = null,
     volume_claim_template = null
   }: {
-    selector: Kubernetes_stateful_set_spec_1630_selector_1631[],
+    selector: Kubernetes_stateful_set_spec_552_selector_553[],
     service_name: string,
-    template: Kubernetes_stateful_set_spec_1630_template_1633[],
+    template: Kubernetes_stateful_set_spec_552_template_555[],
     pod_management_policy?: string|null,
     replicas?: number|null,
     revision_history_limit?: number|null,
-    update_strategy?: Kubernetes_stateful_set_spec_1630_update_strategy_1750[]|null,
-    volume_claim_template?: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752[]|null
+    update_strategy?: Kubernetes_stateful_set_spec_552_update_strategy_672[]|null,
+    volume_claim_template?: Kubernetes_stateful_set_spec_552_volume_claim_template_674[]|null
   }) {
     this.selector = selector;
     this.service_name = service_name;
@@ -24096,19 +24096,19 @@ export class Kubernetes_stateful_set_spec_1630 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_selector_1631 implements PcoreValue {
-  readonly match_expressions: Kubernetes_stateful_set_spec_1630_selector_1631_match_expressions_1632[]|null;
+export class Kubernetes_stateful_set_spec_552_selector_553 implements PcoreValue {
+  readonly match_expressions: Kubernetes_stateful_set_spec_552_selector_553_match_expressions_554[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_stateful_set_spec_1630_selector_1631_match_expressions_1632[]|null,
+    match_expressions?: Kubernetes_stateful_set_spec_552_selector_553_match_expressions_554[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -24127,11 +24127,11 @@ export class Kubernetes_stateful_set_spec_1630_selector_1631 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_selector_1631';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_selector_553';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_selector_1631_match_expressions_1632 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_selector_553_match_expressions_554 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -24165,20 +24165,20 @@ export class Kubernetes_stateful_set_spec_1630_selector_1631_match_expressions_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_selector_1631_match_expressions_1632';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_selector_553_match_expressions_554';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633 implements PcoreValue {
-  readonly metadata: Kubernetes_stateful_set_spec_1630_template_1633_metadata_1634[];
-  readonly spec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555 implements PcoreValue {
+  readonly metadata: Kubernetes_stateful_set_spec_552_template_555_metadata_556[];
+  readonly spec: Kubernetes_stateful_set_spec_552_template_555_spec_557[]|null;
 
   constructor({
     metadata,
     spec = null
   }: {
-    metadata: Kubernetes_stateful_set_spec_1630_template_1633_metadata_1634[],
-    spec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635[]|null
+    metadata: Kubernetes_stateful_set_spec_552_template_555_metadata_556[],
+    spec?: Kubernetes_stateful_set_spec_552_template_555_spec_557[]|null
   }) {
     this.metadata = metadata;
     this.spec = spec;
@@ -24194,11 +24194,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633 implements PcoreVal
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_metadata_1634 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_metadata_556 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -24267,28 +24267,28 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_metadata_1634 imple
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_metadata_1634';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_metadata_556';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557 implements PcoreValue {
   readonly active_deadline_seconds: number|null;
-  readonly container: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636[]|null;
+  readonly container: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558[]|null;
   readonly dns_policy: string|null;
   readonly host_ipc: boolean|null;
   readonly host_network: boolean|null;
   readonly host_pid: boolean|null;
   readonly hostname: string|null;
-  readonly image_pull_secrets: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_image_pull_secrets_1675[]|null;
-  readonly init_container: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676[]|null;
+  readonly image_pull_secrets: Kubernetes_stateful_set_spec_552_template_555_spec_557_image_pull_secrets_597[]|null;
+  readonly init_container: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598[]|null;
   readonly node_name: string|null;
   readonly node_selector: {[s: string]: string}|null;
   readonly restart_policy: string|null;
-  readonly security_context: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715[]|null;
+  readonly security_context: Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637[]|null;
   readonly service_account_name: string|null;
   readonly subdomain: string|null;
   readonly termination_grace_period_seconds: number|null;
-  readonly volume: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717[]|null;
+  readonly volume: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639[]|null;
 
   constructor({
     active_deadline_seconds = null,
@@ -24310,22 +24310,22 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635 implement
     volume = null
   }: {
     active_deadline_seconds?: number|null,
-    container?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636[]|null,
+    container?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558[]|null,
     dns_policy?: string|null,
     host_ipc?: boolean|null,
     host_network?: boolean|null,
     host_pid?: boolean|null,
     hostname?: string|null,
-    image_pull_secrets?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_image_pull_secrets_1675[]|null,
-    init_container?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676[]|null,
+    image_pull_secrets?: Kubernetes_stateful_set_spec_552_template_555_spec_557_image_pull_secrets_597[]|null,
+    init_container?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598[]|null,
     node_name?: string|null,
     node_selector?: {[s: string]: string}|null,
     restart_policy?: string|null,
-    security_context?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715[]|null,
+    security_context?: Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637[]|null,
     service_account_name?: string|null,
     subdomain?: string|null,
     termination_grace_period_seconds?: number|null,
-    volume?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717[]|null
+    volume?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639[]|null
   }) {
     this.active_deadline_seconds = active_deadline_seconds;
     this.container = container;
@@ -24403,29 +24403,29 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635 implement
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637[]|null;
-  readonly env_from: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643[]|null;
+  readonly env: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559[]|null;
+  readonly env_from: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646[]|null;
-  readonly liveness_probe: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657[]|null;
-  readonly port: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_port_1662[]|null;
-  readonly readiness_probe: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663[]|null;
-  readonly resources: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668[]|null;
-  readonly security_context: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671[]|null;
+  readonly lifecycle: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568[]|null;
+  readonly liveness_probe: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579[]|null;
+  readonly port: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_port_584[]|null;
+  readonly readiness_probe: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585[]|null;
+  readonly resources: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590[]|null;
+  readonly security_context: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_volume_mount_1674[]|null;
+  readonly volume_mount: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_volume_mount_596[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -24452,21 +24452,21 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637[]|null,
-    env_from?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643[]|null,
+    env?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559[]|null,
+    env_from?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646[]|null,
-    liveness_probe?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657[]|null,
-    port?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_port_1662[]|null,
-    readiness_probe?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663[]|null,
-    resources?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668[]|null,
-    security_context?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671[]|null,
+    lifecycle?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568[]|null,
+    liveness_probe?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579[]|null,
+    port?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_port_584[]|null,
+    readiness_probe?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585[]|null,
+    resources?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590[]|null,
+    security_context?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_volume_mount_1674[]|null,
+    volume_mount?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_volume_mount_596[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -24551,14 +24551,14 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638[]|null;
+  readonly value_from: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560[]|null;
 
   constructor({
     name,
@@ -24567,7 +24567,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638[]|null
+    value_from?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -24587,15 +24587,15 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_config_map_key_ref_1639[]|null;
-  readonly field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_field_ref_1640[]|null;
-  readonly resource_field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_resource_field_ref_1641[]|null;
-  readonly secret_key_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_secret_key_ref_1642[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_config_map_key_ref_561[]|null;
+  readonly field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_field_ref_562[]|null;
+  readonly resource_field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_resource_field_ref_563[]|null;
+  readonly secret_key_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_secret_key_ref_564[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -24603,10 +24603,10 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_config_map_key_ref_1639[]|null,
-    field_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_field_ref_1640[]|null,
-    resource_field_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_resource_field_ref_1641[]|null,
-    secret_key_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_secret_key_ref_1642[]|null
+    config_map_key_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_config_map_key_ref_561[]|null,
+    field_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_field_ref_562[]|null,
+    resource_field_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_resource_field_ref_563[]|null,
+    secret_key_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_secret_key_ref_564[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -24632,11 +24632,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_config_map_key_ref_1639 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_config_map_key_ref_561 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -24663,11 +24663,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_config_map_key_ref_1639';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_config_map_key_ref_561';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_field_ref_1640 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_field_ref_562 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -24694,11 +24694,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_field_ref_1640';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_field_ref_562';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_resource_field_ref_1641 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_resource_field_ref_563 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -24723,11 +24723,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_resource_field_ref_1641';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_resource_field_ref_563';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_secret_key_ref_1642 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_secret_key_ref_564 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -24754,23 +24754,23 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_1637_value_from_1638_secret_key_ref_1642';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_559_value_from_560_secret_key_ref_564';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_config_map_ref_1644[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_config_map_ref_566[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_secret_ref_1645[]|null;
+  readonly secret_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_secret_ref_567[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_config_map_ref_1644[]|null,
+    config_map_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_config_map_ref_566[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_secret_ref_1645[]|null
+    secret_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_secret_ref_567[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -24792,11 +24792,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_config_map_ref_1644 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_config_map_ref_566 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -24821,11 +24821,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_config_map_ref_1644';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_config_map_ref_566';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_secret_ref_1645 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_secret_ref_567 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -24850,20 +24850,20 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_env_from_1643_secret_ref_1645';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_env_from_565_secret_ref_567';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646 implements PcoreValue {
-  readonly post_start: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647[]|null;
-  readonly pre_stop: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568 implements PcoreValue {
+  readonly post_start: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569[]|null;
+  readonly pre_stop: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647[]|null,
-    pre_stop?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652[]|null
+    post_start?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569[]|null,
+    pre_stop?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -24881,23 +24881,23 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_exec_1648[]|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649[]|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_tcp_socket_1651[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_exec_570[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_tcp_socket_573[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_exec_1648[]|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649[]|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_tcp_socket_1651[]|null
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_exec_570[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_tcp_socket_573[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -24919,11 +24919,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_exec_1648 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_exec_570 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -24943,13 +24943,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_exec_1648';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_exec_570';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649_http_header_1650[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571_http_header_572[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -24962,7 +24962,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649_http_header_1650[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571_http_header_572[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -24995,11 +24995,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649_http_header_1650 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571_http_header_572 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -25026,11 +25026,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_http_get_1649_http_header_1650';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_http_get_571_http_header_572';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_tcp_socket_1651 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_tcp_socket_573 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -25048,23 +25048,23 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_post_start_1647_tcp_socket_1651';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_post_start_569_tcp_socket_573';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_exec_1653[]|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654[]|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_tcp_socket_1656[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_exec_575[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_tcp_socket_578[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_exec_1653[]|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654[]|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_tcp_socket_1656[]|null
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_exec_575[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_tcp_socket_578[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -25086,11 +25086,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_exec_1653 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_exec_575 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -25110,13 +25110,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_exec_1653';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_exec_575';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654_http_header_1655[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576_http_header_577[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -25129,7 +25129,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654_http_header_1655[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576_http_header_577[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -25162,11 +25162,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654_http_header_1655 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576_http_header_577 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -25193,11 +25193,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_http_get_1654_http_header_1655';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_http_get_576_http_header_577';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_tcp_socket_1656 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_tcp_socket_578 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -25215,18 +25215,18 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_lifecycle_1646_pre_stop_1652_tcp_socket_1656';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_lifecycle_568_pre_stop_574_tcp_socket_578';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_exec_1658[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_exec_580[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_tcp_socket_1661[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_tcp_socket_583[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -25239,13 +25239,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_exec_1658[]|null,
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_exec_580[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_tcp_socket_1661[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_tcp_socket_583[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -25288,11 +25288,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_exec_1658 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_exec_580 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -25312,13 +25312,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_exec_1658';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_exec_580';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659_http_header_1660[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581_http_header_582[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -25331,7 +25331,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659_http_header_1660[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581_http_header_582[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -25364,11 +25364,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659_http_header_1660 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581_http_header_582 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -25395,11 +25395,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_http_get_1659_http_header_1660';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_http_get_581_http_header_582';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_tcp_socket_1661 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_tcp_socket_583 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -25417,11 +25417,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_liveness_probe_1657_tcp_socket_1661';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_liveness_probe_579_tcp_socket_583';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_port_1662 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_port_584 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -25467,18 +25467,18 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_port_1662';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_port_584';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_exec_1664[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_exec_586[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_tcp_socket_1667[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_tcp_socket_589[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -25491,13 +25491,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_exec_1664[]|null,
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_exec_586[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_tcp_socket_1667[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_tcp_socket_589[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -25540,11 +25540,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_exec_1664 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_exec_586 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -25564,13 +25564,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_exec_1664';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_exec_586';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665_http_header_1666[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587_http_header_588[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -25583,7 +25583,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665_http_header_1666[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587_http_header_588[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -25616,11 +25616,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665_http_header_1666 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587_http_header_588 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -25647,11 +25647,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_http_get_1665_http_header_1666';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_http_get_587_http_header_588';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_tcp_socket_1667 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_tcp_socket_589 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -25669,20 +25669,20 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_readiness_probe_1663_tcp_socket_1667';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_readiness_probe_585_tcp_socket_589';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668 implements PcoreValue {
-  readonly limits: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_limits_1669[]|null;
-  readonly requests: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_requests_1670[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590 implements PcoreValue {
+  readonly limits: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_limits_591[]|null;
+  readonly requests: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_requests_592[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_limits_1669[]|null,
-    requests?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_requests_1670[]|null
+    limits?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_limits_591[]|null,
+    requests?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_requests_592[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -25700,11 +25700,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_limits_1669 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_limits_591 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -25731,11 +25731,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_limits_1669';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_limits_591';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_requests_1670 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_requests_592 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -25762,18 +25762,18 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_resources_1668_requests_1670';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_resources_590_requests_592';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_capabilities_1672[]|null;
+  readonly capabilities: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_capabilities_594[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_se_linux_options_1673[]|null;
+  readonly se_linux_options: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_se_linux_options_595[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -25785,12 +25785,12 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_capabilities_1672[]|null,
+    capabilities?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_capabilities_594[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_se_linux_options_1673[]|null
+    se_linux_options?: Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_se_linux_options_595[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -25828,11 +25828,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_capabilities_1672 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_capabilities_594 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -25859,11 +25859,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_capabilities_1672';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_capabilities_594';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_se_linux_options_1673 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_se_linux_options_595 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -25904,11 +25904,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_security_context_1671_se_linux_options_1673';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_security_context_593_se_linux_options_595';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_volume_mount_1674 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_volume_mount_596 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -25945,11 +25945,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_container_1636_volume_mount_1674';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_container_558_volume_mount_596';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_image_pull_secrets_1675 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_image_pull_secrets_597 implements PcoreValue {
   readonly name: string;
 
   constructor({
@@ -25967,29 +25967,29 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_image_pul
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_image_pull_secrets_1675';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_image_pull_secrets_597';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598 implements PcoreValue {
   readonly name: string;
   readonly args: string[]|null;
   readonly command: string[]|null;
-  readonly env: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677[]|null;
-  readonly env_from: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683[]|null;
+  readonly env: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599[]|null;
+  readonly env_from: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605[]|null;
   readonly image: string|null;
   readonly image_pull_policy: string|null;
-  readonly lifecycle: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686[]|null;
-  readonly liveness_probe: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697[]|null;
-  readonly port: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_port_1702[]|null;
-  readonly readiness_probe: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703[]|null;
-  readonly resources: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708[]|null;
-  readonly security_context: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711[]|null;
+  readonly lifecycle: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608[]|null;
+  readonly liveness_probe: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619[]|null;
+  readonly port: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_port_624[]|null;
+  readonly readiness_probe: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625[]|null;
+  readonly resources: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630[]|null;
+  readonly security_context: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633[]|null;
   readonly stdin: boolean|null;
   readonly stdin_once: boolean|null;
   readonly termination_message_path: string|null;
   readonly tty: boolean|null;
-  readonly volume_mount: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_volume_mount_1714[]|null;
+  readonly volume_mount: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_volume_mount_636[]|null;
   readonly working_dir: string|null;
 
   constructor({
@@ -26016,21 +26016,21 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     name: string,
     args?: string[]|null,
     command?: string[]|null,
-    env?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677[]|null,
-    env_from?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683[]|null,
+    env?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599[]|null,
+    env_from?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605[]|null,
     image?: string|null,
     image_pull_policy?: string|null,
-    lifecycle?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686[]|null,
-    liveness_probe?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697[]|null,
-    port?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_port_1702[]|null,
-    readiness_probe?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703[]|null,
-    resources?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708[]|null,
-    security_context?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711[]|null,
+    lifecycle?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608[]|null,
+    liveness_probe?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619[]|null,
+    port?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_port_624[]|null,
+    readiness_probe?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625[]|null,
+    resources?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630[]|null,
+    security_context?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633[]|null,
     stdin?: boolean|null,
     stdin_once?: boolean|null,
     termination_message_path?: string|null,
     tty?: boolean|null,
-    volume_mount?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_volume_mount_1714[]|null,
+    volume_mount?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_volume_mount_636[]|null,
     working_dir?: string|null
   }) {
     this.name = name;
@@ -26115,14 +26115,14 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599 implements PcoreValue {
   readonly name: string;
   readonly value: string|null;
-  readonly value_from: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678[]|null;
+  readonly value_from: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600[]|null;
 
   constructor({
     name,
@@ -26131,7 +26131,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }: {
     name: string,
     value?: string|null,
-    value_from?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678[]|null
+    value_from?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600[]|null
   }) {
     this.name = name;
     this.value = value;
@@ -26151,15 +26151,15 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678 implements PcoreValue {
-  readonly config_map_key_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_config_map_key_ref_1679[]|null;
-  readonly field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_field_ref_1680[]|null;
-  readonly resource_field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_resource_field_ref_1681[]|null;
-  readonly secret_key_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_secret_key_ref_1682[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600 implements PcoreValue {
+  readonly config_map_key_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_config_map_key_ref_601[]|null;
+  readonly field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_field_ref_602[]|null;
+  readonly resource_field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_resource_field_ref_603[]|null;
+  readonly secret_key_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_secret_key_ref_604[]|null;
 
   constructor({
     config_map_key_ref = null,
@@ -26167,10 +26167,10 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     resource_field_ref = null,
     secret_key_ref = null
   }: {
-    config_map_key_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_config_map_key_ref_1679[]|null,
-    field_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_field_ref_1680[]|null,
-    resource_field_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_resource_field_ref_1681[]|null,
-    secret_key_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_secret_key_ref_1682[]|null
+    config_map_key_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_config_map_key_ref_601[]|null,
+    field_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_field_ref_602[]|null,
+    resource_field_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_resource_field_ref_603[]|null,
+    secret_key_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_secret_key_ref_604[]|null
   }) {
     this.config_map_key_ref = config_map_key_ref;
     this.field_ref = field_ref;
@@ -26196,11 +26196,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_config_map_key_ref_1679 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_config_map_key_ref_601 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -26227,11 +26227,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_config_map_key_ref_1679';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_config_map_key_ref_601';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_field_ref_1680 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_field_ref_602 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -26258,11 +26258,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_field_ref_1680';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_field_ref_602';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_resource_field_ref_1681 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_resource_field_ref_603 implements PcoreValue {
   readonly resource: string;
   readonly container_name: string|null;
 
@@ -26287,11 +26287,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_resource_field_ref_1681';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_resource_field_ref_603';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_secret_key_ref_1682 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_secret_key_ref_604 implements PcoreValue {
   readonly key: string|null;
   readonly name: string|null;
 
@@ -26318,23 +26318,23 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_1677_value_from_1678_secret_key_ref_1682';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_599_value_from_600_secret_key_ref_604';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683 implements PcoreValue {
-  readonly config_map_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_config_map_ref_1684[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605 implements PcoreValue {
+  readonly config_map_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_config_map_ref_606[]|null;
   readonly prefix: string|null;
-  readonly secret_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_secret_ref_1685[]|null;
+  readonly secret_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_secret_ref_607[]|null;
 
   constructor({
     config_map_ref = null,
     prefix = null,
     secret_ref = null
   }: {
-    config_map_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_config_map_ref_1684[]|null,
+    config_map_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_config_map_ref_606[]|null,
     prefix?: string|null,
-    secret_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_secret_ref_1685[]|null
+    secret_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_secret_ref_607[]|null
   }) {
     this.config_map_ref = config_map_ref;
     this.prefix = prefix;
@@ -26356,11 +26356,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_config_map_ref_1684 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_config_map_ref_606 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -26385,11 +26385,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_config_map_ref_1684';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_config_map_ref_606';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_secret_ref_1685 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_secret_ref_607 implements PcoreValue {
   readonly name: string;
   readonly optional: boolean|null;
 
@@ -26414,20 +26414,20 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_env_from_1683_secret_ref_1685';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_env_from_605_secret_ref_607';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686 implements PcoreValue {
-  readonly post_start: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687[]|null;
-  readonly pre_stop: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608 implements PcoreValue {
+  readonly post_start: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609[]|null;
+  readonly pre_stop: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614[]|null;
 
   constructor({
     post_start = null,
     pre_stop = null
   }: {
-    post_start?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687[]|null,
-    pre_stop?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692[]|null
+    post_start?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609[]|null,
+    pre_stop?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614[]|null
   }) {
     this.post_start = post_start;
     this.pre_stop = pre_stop;
@@ -26445,23 +26445,23 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_exec_1688[]|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689[]|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_tcp_socket_1691[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_exec_610[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_tcp_socket_613[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_exec_1688[]|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689[]|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_tcp_socket_1691[]|null
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_exec_610[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_tcp_socket_613[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -26483,11 +26483,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_exec_1688 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_exec_610 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -26507,13 +26507,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_exec_1688';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_exec_610';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689_http_header_1690[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611_http_header_612[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -26526,7 +26526,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689_http_header_1690[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611_http_header_612[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -26559,11 +26559,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689_http_header_1690 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611_http_header_612 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -26590,11 +26590,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_http_get_1689_http_header_1690';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_http_get_611_http_header_612';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_tcp_socket_1691 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_tcp_socket_613 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -26612,23 +26612,23 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_post_start_1687_tcp_socket_1691';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_post_start_609_tcp_socket_613';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_exec_1693[]|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694[]|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_tcp_socket_1696[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_exec_615[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_tcp_socket_618[]|null;
 
   constructor({
     exec = null,
     http_get = null,
     tcp_socket = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_exec_1693[]|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694[]|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_tcp_socket_1696[]|null
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_exec_615[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_tcp_socket_618[]|null
   }) {
     this.exec = exec;
     this.http_get = http_get;
@@ -26650,11 +26650,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_exec_1693 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_exec_615 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -26674,13 +26674,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_exec_1693';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_exec_615';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694_http_header_1695[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616_http_header_617[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -26693,7 +26693,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694_http_header_1695[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616_http_header_617[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -26726,11 +26726,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694_http_header_1695 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616_http_header_617 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -26757,11 +26757,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_http_get_1694_http_header_1695';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_http_get_616_http_header_617';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_tcp_socket_1696 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_tcp_socket_618 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -26779,18 +26779,18 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_lifecycle_1686_pre_stop_1692_tcp_socket_1696';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_lifecycle_608_pre_stop_614_tcp_socket_618';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_exec_1698[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_exec_620[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_tcp_socket_1701[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_tcp_socket_623[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -26803,13 +26803,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_exec_1698[]|null,
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_exec_620[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_tcp_socket_1701[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_tcp_socket_623[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -26852,11 +26852,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_exec_1698 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_exec_620 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -26876,13 +26876,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_exec_1698';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_exec_620';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699_http_header_1700[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621_http_header_622[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -26895,7 +26895,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699_http_header_1700[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621_http_header_622[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -26928,11 +26928,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699_http_header_1700 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621_http_header_622 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -26959,11 +26959,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_http_get_1699_http_header_1700';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_http_get_621_http_header_622';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_tcp_socket_1701 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_tcp_socket_623 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -26981,11 +26981,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_liveness_probe_1697_tcp_socket_1701';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_liveness_probe_619_tcp_socket_623';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_port_1702 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_port_624 implements PcoreValue {
   readonly container_port: number;
   readonly host_ip: string|null;
   readonly host_port: number|null;
@@ -27031,18 +27031,18 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_port_1702';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_port_624';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703 implements PcoreValue {
-  readonly exec: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_exec_1704[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625 implements PcoreValue {
+  readonly exec: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_exec_626[]|null;
   readonly failure_threshold: number|null;
-  readonly http_get: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705[]|null;
+  readonly http_get: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627[]|null;
   readonly initial_delay_seconds: number|null;
   readonly period_seconds: number|null;
   readonly success_threshold: number|null;
-  readonly tcp_socket: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_tcp_socket_1707[]|null;
+  readonly tcp_socket: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_tcp_socket_629[]|null;
   readonly timeout_seconds: number|null;
 
   constructor({
@@ -27055,13 +27055,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     tcp_socket = null,
     timeout_seconds = null
   }: {
-    exec?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_exec_1704[]|null,
+    exec?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_exec_626[]|null,
     failure_threshold?: number|null,
-    http_get?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705[]|null,
+    http_get?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627[]|null,
     initial_delay_seconds?: number|null,
     period_seconds?: number|null,
     success_threshold?: number|null,
-    tcp_socket?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_tcp_socket_1707[]|null,
+    tcp_socket?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_tcp_socket_629[]|null,
     timeout_seconds?: number|null
   }) {
     this.exec = exec;
@@ -27104,11 +27104,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_exec_1704 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_exec_626 implements PcoreValue {
   readonly command: string[]|null;
 
   constructor({
@@ -27128,13 +27128,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_exec_1704';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_exec_626';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627 implements PcoreValue {
   readonly host: string|null;
-  readonly http_header: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705_http_header_1706[]|null;
+  readonly http_header: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627_http_header_628[]|null;
   readonly path: string|null;
   readonly port: string|null;
   readonly scheme: string|null;
@@ -27147,7 +27147,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     scheme = null
   }: {
     host?: string|null,
-    http_header?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705_http_header_1706[]|null,
+    http_header?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627_http_header_628[]|null,
     path?: string|null,
     port?: string|null,
     scheme?: string|null
@@ -27180,11 +27180,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705_http_header_1706 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627_http_header_628 implements PcoreValue {
   readonly name: string|null;
   readonly value: string|null;
 
@@ -27211,11 +27211,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_http_get_1705_http_header_1706';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_http_get_627_http_header_628';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_tcp_socket_1707 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_tcp_socket_629 implements PcoreValue {
   readonly port: string;
 
   constructor({
@@ -27233,20 +27233,20 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_readiness_probe_1703_tcp_socket_1707';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_readiness_probe_625_tcp_socket_629';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708 implements PcoreValue {
-  readonly limits: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_limits_1709[]|null;
-  readonly requests: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_requests_1710[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630 implements PcoreValue {
+  readonly limits: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_limits_631[]|null;
+  readonly requests: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_requests_632[]|null;
 
   constructor({
     limits = null,
     requests = null
   }: {
-    limits?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_limits_1709[]|null,
-    requests?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_requests_1710[]|null
+    limits?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_limits_631[]|null,
+    requests?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_requests_632[]|null
   }) {
     this.limits = limits;
     this.requests = requests;
@@ -27264,11 +27264,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_limits_1709 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_limits_631 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -27295,11 +27295,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_limits_1709';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_limits_631';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_requests_1710 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_requests_632 implements PcoreValue {
   readonly cpu: string|null;
   readonly memory: string|null;
 
@@ -27326,18 +27326,18 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_resources_1708_requests_1710';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_resources_630_requests_632';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633 implements PcoreValue {
   readonly allow_privilege_escalation: boolean|null;
-  readonly capabilities: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_capabilities_1712[]|null;
+  readonly capabilities: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_capabilities_634[]|null;
   readonly privileged: boolean|null;
   readonly read_only_root_filesystem: boolean|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_se_linux_options_1713[]|null;
+  readonly se_linux_options: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_se_linux_options_635[]|null;
 
   constructor({
     allow_privilege_escalation = null,
@@ -27349,12 +27349,12 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
     se_linux_options = null
   }: {
     allow_privilege_escalation?: boolean|null,
-    capabilities?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_capabilities_1712[]|null,
+    capabilities?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_capabilities_634[]|null,
     privileged?: boolean|null,
     read_only_root_filesystem?: boolean|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_se_linux_options_1713[]|null
+    se_linux_options?: Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_se_linux_options_635[]|null
   }) {
     this.allow_privilege_escalation = allow_privilege_escalation;
     this.capabilities = capabilities;
@@ -27392,11 +27392,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_capabilities_1712 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_capabilities_634 implements PcoreValue {
   readonly add: string[]|null;
   readonly drop: string[]|null;
 
@@ -27423,11 +27423,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_capabilities_1712';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_capabilities_634';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_se_linux_options_1713 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_se_linux_options_635 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -27468,11 +27468,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_security_context_1711_se_linux_options_1713';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_security_context_633_se_linux_options_635';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_volume_mount_1714 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_volume_mount_636 implements PcoreValue {
   readonly mount_path: string;
   readonly name: string;
   readonly read_only: boolean|null;
@@ -27509,15 +27509,15 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_cont
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_init_container_1676_volume_mount_1714';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_init_container_598_volume_mount_636';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637 implements PcoreValue {
   readonly fs_group: number|null;
   readonly run_as_non_root: boolean|null;
   readonly run_as_user: number|null;
-  readonly se_linux_options: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715_se_linux_options_1716[]|null;
+  readonly se_linux_options: Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637_se_linux_options_638[]|null;
   readonly supplemental_groups: number[]|null;
 
   constructor({
@@ -27530,7 +27530,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_
     fs_group?: number|null,
     run_as_non_root?: boolean|null,
     run_as_user?: number|null,
-    se_linux_options?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715_se_linux_options_1716[]|null,
+    se_linux_options?: Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637_se_linux_options_638[]|null,
     supplemental_groups?: number[]|null
   }) {
     this.fs_group = fs_group;
@@ -27561,11 +27561,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715_se_linux_options_1716 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637_se_linux_options_638 implements PcoreValue {
   readonly level: string|null;
   readonly role: string|null;
   readonly type: string|null;
@@ -27606,36 +27606,36 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_security_context_1715_se_linux_options_1716';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_security_context_637_se_linux_options_638';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717 implements PcoreValue {
-  readonly aws_elastic_block_store: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_aws_elastic_block_store_1718[]|null;
-  readonly azure_disk: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_disk_1719[]|null;
-  readonly azure_file: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_file_1720[]|null;
-  readonly ceph_fs: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721[]|null;
-  readonly cinder: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_cinder_1723[]|null;
-  readonly config_map: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724[]|null;
-  readonly downward_api: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726[]|null;
-  readonly empty_dir: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_empty_dir_1730[]|null;
-  readonly fc: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_fc_1731[]|null;
-  readonly flex_volume: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732[]|null;
-  readonly flocker: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flocker_1734[]|null;
-  readonly gce_persistent_disk: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_gce_persistent_disk_1735[]|null;
-  readonly git_repo: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_git_repo_1736[]|null;
-  readonly glusterfs: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_glusterfs_1737[]|null;
-  readonly host_path: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_host_path_1738[]|null;
-  readonly iscsi: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_iscsi_1739[]|null;
-  readonly local: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_local_1740[]|null;
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639 implements PcoreValue {
+  readonly aws_elastic_block_store: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_aws_elastic_block_store_640[]|null;
+  readonly azure_disk: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_disk_641[]|null;
+  readonly azure_file: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_file_642[]|null;
+  readonly ceph_fs: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643[]|null;
+  readonly cinder: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_cinder_645[]|null;
+  readonly config_map: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646[]|null;
+  readonly downward_api: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648[]|null;
+  readonly empty_dir: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_empty_dir_652[]|null;
+  readonly fc: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_fc_653[]|null;
+  readonly flex_volume: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654[]|null;
+  readonly flocker: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flocker_656[]|null;
+  readonly gce_persistent_disk: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_gce_persistent_disk_657[]|null;
+  readonly git_repo: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_git_repo_658[]|null;
+  readonly glusterfs: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_glusterfs_659[]|null;
+  readonly host_path: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_host_path_660[]|null;
+  readonly iscsi: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_iscsi_661[]|null;
+  readonly local: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_local_662[]|null;
   readonly name: string|null;
-  readonly nfs: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_nfs_1741[]|null;
-  readonly persistent_volume_claim: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_persistent_volume_claim_1742[]|null;
-  readonly photon_persistent_disk: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_photon_persistent_disk_1743[]|null;
-  readonly quobyte: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_quobyte_1744[]|null;
-  readonly rbd: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745[]|null;
-  readonly secret: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747[]|null;
-  readonly vsphere_volume: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_vsphere_volume_1749[]|null;
+  readonly nfs: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_nfs_663[]|null;
+  readonly persistent_volume_claim: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_persistent_volume_claim_664[]|null;
+  readonly photon_persistent_disk: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_photon_persistent_disk_665[]|null;
+  readonly quobyte: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_quobyte_666[]|null;
+  readonly rbd: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667[]|null;
+  readonly secret: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669[]|null;
+  readonly vsphere_volume: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_vsphere_volume_671[]|null;
 
   constructor({
     aws_elastic_block_store = null,
@@ -27664,31 +27664,31 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     secret = null,
     vsphere_volume = null
   }: {
-    aws_elastic_block_store?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_aws_elastic_block_store_1718[]|null,
-    azure_disk?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_disk_1719[]|null,
-    azure_file?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_file_1720[]|null,
-    ceph_fs?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721[]|null,
-    cinder?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_cinder_1723[]|null,
-    config_map?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724[]|null,
-    downward_api?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726[]|null,
-    empty_dir?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_empty_dir_1730[]|null,
-    fc?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_fc_1731[]|null,
-    flex_volume?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732[]|null,
-    flocker?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flocker_1734[]|null,
-    gce_persistent_disk?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_gce_persistent_disk_1735[]|null,
-    git_repo?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_git_repo_1736[]|null,
-    glusterfs?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_glusterfs_1737[]|null,
-    host_path?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_host_path_1738[]|null,
-    iscsi?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_iscsi_1739[]|null,
-    local?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_local_1740[]|null,
+    aws_elastic_block_store?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_aws_elastic_block_store_640[]|null,
+    azure_disk?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_disk_641[]|null,
+    azure_file?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_file_642[]|null,
+    ceph_fs?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643[]|null,
+    cinder?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_cinder_645[]|null,
+    config_map?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646[]|null,
+    downward_api?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648[]|null,
+    empty_dir?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_empty_dir_652[]|null,
+    fc?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_fc_653[]|null,
+    flex_volume?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654[]|null,
+    flocker?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flocker_656[]|null,
+    gce_persistent_disk?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_gce_persistent_disk_657[]|null,
+    git_repo?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_git_repo_658[]|null,
+    glusterfs?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_glusterfs_659[]|null,
+    host_path?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_host_path_660[]|null,
+    iscsi?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_iscsi_661[]|null,
+    local?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_local_662[]|null,
     name?: string|null,
-    nfs?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_nfs_1741[]|null,
-    persistent_volume_claim?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_persistent_volume_claim_1742[]|null,
-    photon_persistent_disk?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_photon_persistent_disk_1743[]|null,
-    quobyte?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_quobyte_1744[]|null,
-    rbd?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745[]|null,
-    secret?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747[]|null,
-    vsphere_volume?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_vsphere_volume_1749[]|null
+    nfs?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_nfs_663[]|null,
+    persistent_volume_claim?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_persistent_volume_claim_664[]|null,
+    photon_persistent_disk?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_photon_persistent_disk_665[]|null,
+    quobyte?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_quobyte_666[]|null,
+    rbd?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667[]|null,
+    secret?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669[]|null,
+    vsphere_volume?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_vsphere_volume_671[]|null
   }) {
     this.aws_elastic_block_store = aws_elastic_block_store;
     this.azure_disk = azure_disk;
@@ -27798,11 +27798,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_aws_elastic_block_store_1718 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_aws_elastic_block_store_640 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -27841,11 +27841,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_aws_elastic_block_store_1718';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_aws_elastic_block_store_640';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_disk_1719 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_disk_641 implements PcoreValue {
   readonly caching_mode: string;
   readonly data_disk_uri: string;
   readonly disk_name: string;
@@ -27887,11 +27887,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_disk_1719';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_disk_641';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_file_1720 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_file_642 implements PcoreValue {
   readonly secret_name: string;
   readonly share_name: string;
   readonly read_only: boolean|null;
@@ -27921,16 +27921,16 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_azure_file_1720';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_azure_file_642';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643 implements PcoreValue {
   readonly monitors: string[];
   readonly path: string|null;
   readonly read_only: boolean|null;
   readonly secret_file: string|null;
-  readonly secret_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721_secret_ref_1722[]|null;
+  readonly secret_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643_secret_ref_644[]|null;
   readonly user: string|null;
 
   constructor({
@@ -27945,7 +27945,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     path?: string|null,
     read_only?: boolean|null,
     secret_file?: string|null,
-    secret_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721_secret_ref_1722[]|null,
+    secret_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643_secret_ref_644[]|null,
     user?: string|null
   }) {
     this.monitors = monitors;
@@ -27978,11 +27978,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721_secret_ref_1722 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643_secret_ref_644 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -28002,11 +28002,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_ceph_fs_1721_secret_ref_1722';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_ceph_fs_643_secret_ref_644';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_cinder_1723 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_cinder_645 implements PcoreValue {
   readonly volume_id: string;
   readonly fs_type: string|null;
   readonly read_only: boolean|null;
@@ -28038,13 +28038,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_cinder_1723';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_cinder_645';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724_items_1725[]|null;
+  readonly items: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646_items_647[]|null;
   readonly name: string|null;
 
   constructor({
@@ -28053,7 +28053,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724_items_1725[]|null,
+    items?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646_items_647[]|null,
     name?: string|null
   }) {
     this.default_mode = default_mode;
@@ -28076,11 +28076,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724_items_1725 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646_items_647 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -28114,20 +28114,20 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_config_map_1724_items_1725';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_config_map_646_items_647';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727[]|null;
+  readonly items: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649[]|null;
 
   constructor({
     default_mode = null,
     items = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727[]|null
+    items?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649[]|null
   }) {
     this.default_mode = default_mode;
     this.items = items;
@@ -28145,15 +28145,15 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727 implements PcoreValue {
-  readonly field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_field_ref_1728[];
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649 implements PcoreValue {
+  readonly field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_field_ref_650[];
   readonly path: string;
   readonly mode: number|null;
-  readonly resource_field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_resource_field_ref_1729[]|null;
+  readonly resource_field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_resource_field_ref_651[]|null;
 
   constructor({
     field_ref,
@@ -28161,10 +28161,10 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     mode = null,
     resource_field_ref = null
   }: {
-    field_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_field_ref_1728[],
+    field_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_field_ref_650[],
     path: string,
     mode?: number|null,
-    resource_field_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_resource_field_ref_1729[]|null
+    resource_field_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_resource_field_ref_651[]|null
   }) {
     this.field_ref = field_ref;
     this.path = path;
@@ -28186,11 +28186,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_field_ref_1728 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_field_ref_650 implements PcoreValue {
   readonly api_version: string|null;
   readonly field_path: string|null;
 
@@ -28217,11 +28217,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_field_ref_1728';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_field_ref_650';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_resource_field_ref_1729 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_resource_field_ref_651 implements PcoreValue {
   readonly container_name: string;
   readonly resource: string;
   readonly quantity: string|null;
@@ -28251,11 +28251,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_downward_api_1726_items_1727_resource_field_ref_1729';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_downward_api_648_items_649_resource_field_ref_651';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_empty_dir_1730 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_empty_dir_652 implements PcoreValue {
   readonly medium: string|null;
 
   constructor({
@@ -28275,11 +28275,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_empty_dir_1730';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_empty_dir_652';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_fc_1731 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_fc_653 implements PcoreValue {
   readonly lun: number;
   readonly target_ww_ns: string[];
   readonly fs_type: string|null;
@@ -28316,16 +28316,16 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_fc_1731';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_fc_653';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654 implements PcoreValue {
   readonly driver: string;
   readonly fs_type: string|null;
   readonly options: {[s: string]: string}|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732_secret_ref_1733[]|null;
+  readonly secret_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654_secret_ref_655[]|null;
 
   constructor({
     driver,
@@ -28338,7 +28338,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     fs_type?: string|null,
     options?: {[s: string]: string}|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732_secret_ref_1733[]|null
+    secret_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654_secret_ref_655[]|null
   }) {
     this.driver = driver;
     this.fs_type = fs_type;
@@ -28366,11 +28366,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732_secret_ref_1733 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654_secret_ref_655 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -28390,11 +28390,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flex_volume_1732_secret_ref_1733';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flex_volume_654_secret_ref_655';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flocker_1734 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flocker_656 implements PcoreValue {
   readonly dataset_name: string|null;
   readonly dataset_uuid: string|null;
 
@@ -28421,11 +28421,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_flocker_1734';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_flocker_656';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_gce_persistent_disk_1735 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_gce_persistent_disk_657 implements PcoreValue {
   readonly pd_name: string;
   readonly fs_type: string|null;
   readonly partition: number|null;
@@ -28464,11 +28464,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_gce_persistent_disk_1735';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_gce_persistent_disk_657';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_git_repo_1736 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_git_repo_658 implements PcoreValue {
   readonly directory: string|null;
   readonly repository: string|null;
   readonly revision: string|null;
@@ -28502,11 +28502,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_git_repo_1736';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_git_repo_658';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_glusterfs_1737 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_glusterfs_659 implements PcoreValue {
   readonly endpoints_name: string;
   readonly path: string;
   readonly read_only: boolean|null;
@@ -28536,11 +28536,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_glusterfs_1737';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_glusterfs_659';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_host_path_1738 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_host_path_660 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -28560,11 +28560,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_host_path_1738';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_host_path_660';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_iscsi_1739 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_iscsi_661 implements PcoreValue {
   readonly iqn: string;
   readonly target_portal: string;
   readonly fs_type: string|null;
@@ -28615,11 +28615,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_iscsi_1739';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_iscsi_661';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_local_1740 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_local_662 implements PcoreValue {
   readonly path: string|null;
 
   constructor({
@@ -28639,11 +28639,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_local_1740';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_local_662';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_nfs_1741 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_nfs_663 implements PcoreValue {
   readonly path: string;
   readonly server: string;
   readonly read_only: boolean|null;
@@ -28673,11 +28673,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_nfs_1741';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_nfs_663';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_persistent_volume_claim_1742 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_persistent_volume_claim_664 implements PcoreValue {
   readonly claim_name: string|null;
   readonly read_only: boolean|null;
 
@@ -28704,11 +28704,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_persistent_volume_claim_1742';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_persistent_volume_claim_664';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_photon_persistent_disk_1743 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_photon_persistent_disk_665 implements PcoreValue {
   readonly pd_id: string;
   readonly fs_type: string|null;
 
@@ -28733,11 +28733,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_photon_persistent_disk_1743';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_photon_persistent_disk_665';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_quobyte_1744 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_quobyte_666 implements PcoreValue {
   readonly registry: string;
   readonly volume: string;
   readonly group: string|null;
@@ -28781,11 +28781,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_quobyte_1744';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_quobyte_666';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667 implements PcoreValue {
   readonly ceph_monitors: string[];
   readonly rbd_image: string;
   readonly fs_type: string|null;
@@ -28793,7 +28793,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   readonly rados_user: string|null;
   readonly rbd_pool: string|null;
   readonly read_only: boolean|null;
-  readonly secret_ref: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745_secret_ref_1746[]|null;
+  readonly secret_ref: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667_secret_ref_668[]|null;
 
   constructor({
     ceph_monitors,
@@ -28812,7 +28812,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     rados_user?: string|null,
     rbd_pool?: string|null,
     read_only?: boolean|null,
-    secret_ref?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745_secret_ref_1746[]|null
+    secret_ref?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667_secret_ref_668[]|null
   }) {
     this.ceph_monitors = ceph_monitors;
     this.rbd_image = rbd_image;
@@ -28850,11 +28850,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745_secret_ref_1746 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667_secret_ref_668 implements PcoreValue {
   readonly name: string|null;
 
   constructor({
@@ -28874,13 +28874,13 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_rbd_1745_secret_ref_1746';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_rbd_667_secret_ref_668';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669 implements PcoreValue {
   readonly default_mode: number|null;
-  readonly items: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747_items_1748[]|null;
+  readonly items: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669_items_670[]|null;
   readonly optional: boolean|null;
   readonly secret_name: string|null;
 
@@ -28891,7 +28891,7 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
     secret_name = null
   }: {
     default_mode?: number|null,
-    items?: Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747_items_1748[]|null,
+    items?: Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669_items_670[]|null,
     optional?: boolean|null,
     secret_name?: string|null
   }) {
@@ -28919,11 +28919,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747_items_1748 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669_items_670 implements PcoreValue {
   readonly key: string|null;
   readonly mode: number|null;
   readonly path: string|null;
@@ -28957,11 +28957,11 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_secret_1747_items_1748';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_secret_669_items_670';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_vsphere_volume_1749 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_vsphere_volume_671 implements PcoreValue {
   readonly volume_path: string;
   readonly fs_type: string|null;
 
@@ -28986,19 +28986,19 @@ export class Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_17
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_template_1633_spec_1635_volume_1717_vsphere_volume_1749';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_template_555_spec_557_volume_639_vsphere_volume_671';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_update_strategy_1750 implements PcoreValue {
-  readonly rolling_update: Kubernetes_stateful_set_spec_1630_update_strategy_1750_rolling_update_1751[]|null;
+export class Kubernetes_stateful_set_spec_552_update_strategy_672 implements PcoreValue {
+  readonly rolling_update: Kubernetes_stateful_set_spec_552_update_strategy_672_rolling_update_673[]|null;
   readonly type: string|null;
 
   constructor({
     rolling_update = null,
     type = null
   }: {
-    rolling_update?: Kubernetes_stateful_set_spec_1630_update_strategy_1750_rolling_update_1751[]|null,
+    rolling_update?: Kubernetes_stateful_set_spec_552_update_strategy_672_rolling_update_673[]|null,
     type?: string|null
   }) {
     this.rolling_update = rolling_update;
@@ -29017,11 +29017,11 @@ export class Kubernetes_stateful_set_spec_1630_update_strategy_1750 implements P
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_update_strategy_1750';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_update_strategy_672';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_update_strategy_1750_rolling_update_1751 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_update_strategy_672_rolling_update_673 implements PcoreValue {
   readonly partition: number|null;
 
   constructor({
@@ -29041,20 +29041,20 @@ export class Kubernetes_stateful_set_spec_1630_update_strategy_1750_rolling_upda
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_update_strategy_1750_rolling_update_1751';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_update_strategy_672_rolling_update_673';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752 implements PcoreValue {
-  readonly metadata: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_metadata_1753[];
-  readonly spec: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754[];
+export class Kubernetes_stateful_set_spec_552_volume_claim_template_674 implements PcoreValue {
+  readonly metadata: Kubernetes_stateful_set_spec_552_volume_claim_template_674_metadata_675[];
+  readonly spec: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676[];
 
   constructor({
     metadata,
     spec
   }: {
-    metadata: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_metadata_1753[],
-    spec: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754[]
+    metadata: Kubernetes_stateful_set_spec_552_volume_claim_template_674_metadata_675[],
+    spec: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676[]
   }) {
     this.metadata = metadata;
     this.spec = spec;
@@ -29068,11 +29068,11 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752 implem
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_volume_claim_template_1752';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_volume_claim_template_674';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_metadata_1753 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_volume_claim_template_674_metadata_675 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -29148,14 +29148,14 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_metada
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_metadata_1753';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_volume_claim_template_674_metadata_675';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676 implements PcoreValue {
   readonly access_modes: string[];
-  readonly resources: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_resources_1755[];
-  readonly selector: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756[]|null;
+  readonly resources: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_resources_677[];
+  readonly selector: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678[]|null;
   readonly storage_class_name: string|null;
   readonly volume_name: string|null;
 
@@ -29167,8 +29167,8 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1
     volume_name = null
   }: {
     access_modes: string[],
-    resources: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_resources_1755[],
-    selector?: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756[]|null,
+    resources: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_resources_677[],
+    selector?: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678[]|null,
     storage_class_name?: string|null,
     volume_name?: string|null
   }) {
@@ -29196,11 +29196,11 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_resources_1755 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_resources_677 implements PcoreValue {
   readonly limits: {[s: string]: string}|null;
   readonly requests: {[s: string]: string}|null;
 
@@ -29227,19 +29227,19 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_resources_1755';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_resources_677';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756 implements PcoreValue {
-  readonly match_expressions: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756_match_expressions_1757[]|null;
+export class Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678 implements PcoreValue {
+  readonly match_expressions: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678_match_expressions_679[]|null;
   readonly match_labels: {[s: string]: string}|null;
 
   constructor({
     match_expressions = null,
     match_labels = null
   }: {
-    match_expressions?: Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756_match_expressions_1757[]|null,
+    match_expressions?: Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678_match_expressions_679[]|null,
     match_labels?: {[s: string]: string}|null
   }) {
     this.match_expressions = match_expressions;
@@ -29258,11 +29258,11 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678';
   }
 }
 
-export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756_match_expressions_1757 implements PcoreValue {
+export class Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678_match_expressions_679 implements PcoreValue {
   readonly key: string|null;
   readonly operator: string|null;
   readonly values: string[]|null;
@@ -29296,12 +29296,12 @@ export class Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_1630_volume_claim_template_1752_spec_1754_selector_1756_match_expressions_1757';
+    return 'TerraformKubernetes::Kubernetes_stateful_set_spec_552_volume_claim_template_674_spec_676_selector_678_match_expressions_679';
   }
 }
 
 export class Kubernetes_storage_class implements PcoreValue {
-  readonly metadata: Kubernetes_storage_class_metadata_1758[];
+  readonly metadata: Kubernetes_storage_class_metadata_680[];
   readonly storage_provisioner: string;
   readonly kubernetes_storage_class_id: string|null;
   readonly parameters: {[s: string]: string}|null;
@@ -29316,7 +29316,7 @@ export class Kubernetes_storage_class implements PcoreValue {
     reclaim_policy = null,
     volume_binding_mode = null
   }: {
-    metadata: Kubernetes_storage_class_metadata_1758[],
+    metadata: Kubernetes_storage_class_metadata_680[],
     storage_provisioner: string,
     kubernetes_storage_class_id?: string|null,
     parameters?: {[s: string]: string}|null,
@@ -29365,7 +29365,7 @@ export class Kubernetes_storage_classHandler implements PcoreValue {
   }
 }
 
-export class Kubernetes_storage_class_metadata_1758 implements PcoreValue {
+export class Kubernetes_storage_class_metadata_680 implements PcoreValue {
   readonly annotations: {[s: string]: string}|null;
   readonly generate_name: string|null;
   readonly generation: number|null;
@@ -29434,6 +29434,6 @@ export class Kubernetes_storage_class_metadata_1758 implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'TerraformKubernetes::Kubernetes_storage_class_metadata_1758';
+    return 'TerraformKubernetes::Kubernetes_storage_class_metadata_680';
   }
 }

--- a/workflows/azure_virtual_machine_ts.ll
+++ b/workflows/azure_virtual_machine_ts.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: 'examples/ts-samples/dist/azure_virtual_machine_ts.js'

--- a/workflows/github_repository_ts.ll
+++ b/workflows/github_repository_ts.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: 'examples/ts-samples/dist/github_repository_ts.js'

--- a/workflows/google_compute_instance_ts.ll
+++ b/workflows/google_compute_instance_ts.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: 'examples/ts-samples/dist/google_compute_instance_ts.js'

--- a/workflows/k8s_namespace_service_ts.ll
+++ b/workflows/k8s_namespace_service_ts.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: 'examples/ts-samples/dist/k8s_namespace_service_ts.js'

--- a/workflows/sample_ts.ll
+++ b/workflows/sample_ts.ll
@@ -1,0 +1,2 @@
+executable: node
+arguments: 'examples/ts-samples/dist/sample_ts.js'


### PR DESCRIPTION
This commit adds a typescript example and a `smoke-test-ts` make target to run this.  To facilitate this, `make generate-ts` outputs TypeScript types to the `examples/ts-samples/src/types` and runs `npm install` to resolve dependencies and transpile TypeScript to JavaScript.

It also adds a k8s example in TypeScript.
