### PR TITLE
Fix npm warnings and suppress some Makefile output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ smoke-test: lyra plugins
 	@build/lyra apply sample || (echo "Failed applying sample $$?"; exit 1)
 
 smoke-test-ts: check-node generate-ts
-	build/lyra apply sample_ts || (echo "Failed apply typescript sample $$?"; exit 1)
+	@build/lyra apply sample_ts || (echo "Failed apply typescript sample $$?"; exit 1)
 
 generate-ts:
 	@build/lyra generate typescript --target-directory examples/ts-samples/src/types
-	cd examples/ts-samples && npm install
+	@cd examples/ts-samples && npm install
 
 define build
 	echo "🔘 Building - $(1) (`date '+%H:%M:%S'`)"

--- a/examples/ts-samples/package-lock.json
+++ b/examples/ts-samples/package-lock.json
@@ -1310,9 +1310,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/examples/ts-samples/package.json
+++ b/examples/ts-samples/package.json
@@ -1,11 +1,15 @@
 {
   "name": "ts-samples",
   "version": "0.0.0",
-  "description": "",
+  "description": "Sample Lyra workflow",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lyraproj/lyra"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "check": "gts check",


### PR DESCRIPTION
Fixes the npm/vulnerability warnings:

```
> ts-samples@0.0.0 compile /home/travis/gopath/src/github.com/lyraproj/lyra/examples/ts-samples
> tsc -p .
npm WARN ts-samples@0.0.0 No description
npm WARN ts-samples@0.0.0 No repository field.
added 307 packages from 161 contributors and audited 489 packages in 25.298s
found 1 moderate severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details
build/lyra apply sample_ts || (echo "Failed apply typescript sample $?"; exit 1)
```