### PR TITLE
Ensure that all typespace and type entries follow name convention

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995
 	github.com/lyraproj/lyra-operator v0.0.0-20190315160732-5cae8a9bc88d
 	github.com/lyraproj/pcore v0.0.0-20190408134742-7ef8f288585f
-	github.com/lyraproj/puppet-workflow v0.0.0-20190408135127-39314d42d0f4
+	github.com/lyraproj/puppet-workflow v0.0.0-20190410092735-55ac4c00a8c6
 	github.com/lyraproj/servicesdk v0.0.0-20190408134916-985421696619
 	github.com/lyraproj/terraform-bridge v0.0.0-20190408135359-a8c691855a82
 	github.com/lyraproj/wfe v0.0.0-20190408135039-be57c7687d8f

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995
 	github.com/lyraproj/lyra-operator v0.0.0-20190315160732-5cae8a9bc88d
 	github.com/lyraproj/pcore v0.0.0-20190408134742-7ef8f288585f
-	github.com/lyraproj/puppet-workflow v0.0.0-20190410092735-55ac4c00a8c6
+	github.com/lyraproj/puppet-workflow v0.0.0-20190410094537-05995e9f9f3d
 	github.com/lyraproj/servicesdk v0.0.0-20190408134916-985421696619
 	github.com/lyraproj/terraform-bridge v0.0.0-20190408135359-a8c691855a82
 	github.com/lyraproj/wfe v0.0.0-20190408135039-be57c7687d8f

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/lyraproj/puppet-workflow v0.0.0-20190408135127-39314d42d0f4 h1:J2Ij4B
 github.com/lyraproj/puppet-workflow v0.0.0-20190408135127-39314d42d0f4/go.mod h1:MtAUoRQr0GKHfONnOlYD+UifcOG6RBa7RXRJFWZz1j8=
 github.com/lyraproj/puppet-workflow v0.0.0-20190410092735-55ac4c00a8c6 h1:RqT4PH9QOHO+906ItnFNv5kFbdbE1dXzdlecjlOqVNg=
 github.com/lyraproj/puppet-workflow v0.0.0-20190410092735-55ac4c00a8c6/go.mod h1:MtAUoRQr0GKHfONnOlYD+UifcOG6RBa7RXRJFWZz1j8=
+github.com/lyraproj/puppet-workflow v0.0.0-20190410094537-05995e9f9f3d h1:pRemLDDrjjEdpB0J7ypWFd+SIYia/BVf3L65HltOElI=
+github.com/lyraproj/puppet-workflow v0.0.0-20190410094537-05995e9f9f3d/go.mod h1:MtAUoRQr0GKHfONnOlYD+UifcOG6RBa7RXRJFWZz1j8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/lyraproj/servicesdk v0.0.0-20190319214040-e12463a5bc49/go.mod h1:++0wnIhGpy7fvoBYFoMuhhByKJikXas4segsbrdJP90=

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/lyraproj/puppet-workflow v0.0.0-20190408082948-872a8ff7f1ae h1:Gqgv1f
 github.com/lyraproj/puppet-workflow v0.0.0-20190408082948-872a8ff7f1ae/go.mod h1:SHCYMXTOFnAiOup5G2pMvIJuTNkGyE5z3+wn+DskwmU=
 github.com/lyraproj/puppet-workflow v0.0.0-20190408135127-39314d42d0f4 h1:J2Ij4BTdv0by3D1H/PnOrcFQMM7n6YUFIssA6RPd6pE=
 github.com/lyraproj/puppet-workflow v0.0.0-20190408135127-39314d42d0f4/go.mod h1:MtAUoRQr0GKHfONnOlYD+UifcOG6RBa7RXRJFWZz1j8=
+github.com/lyraproj/puppet-workflow v0.0.0-20190410092735-55ac4c00a8c6 h1:RqT4PH9QOHO+906ItnFNv5kFbdbE1dXzdlecjlOqVNg=
+github.com/lyraproj/puppet-workflow v0.0.0-20190410092735-55ac4c00a8c6/go.mod h1:MtAUoRQr0GKHfONnOlYD+UifcOG6RBa7RXRJFWZz1j8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/lyraproj/servicesdk v0.0.0-20190319214040-e12463a5bc49/go.mod h1:++0wnIhGpy7fvoBYFoMuhhByKJikXas4segsbrdJP90=

--- a/workflows/aws.yaml
+++ b/workflows/aws.yaml
@@ -78,7 +78,7 @@ aws:
             cidr_blocks: ["0.0.0.0/0"]
 
     subnet1:
-      type:  Aws::subnet
+      type:  Aws::Subnet
       output:
         subnet_id1: subnet_id
       state:
@@ -89,7 +89,7 @@ aws:
           created_by: lyra
 
     subnet2:
-      type:  Aws::subnet
+      type:  Aws::Subnet
       output:
         subnet_id2: subnet_id
       state:
@@ -100,7 +100,7 @@ aws:
           created_by: lyra
 
     instance1:
-      type:  Aws::instance
+      type:  Aws::Instance
       state:
         instance_type: 't2.nano'
         ami: 'ami-f90a4880'
@@ -110,7 +110,7 @@ aws:
           created_by: lyra
 
     instance2:
-      type:  Aws::instance
+      type:  Aws::Instance
       state:
         instance_type: 't2.nano'
         ami: 'ami-f90a4880'

--- a/workflows/foobernetes.yaml
+++ b/workflows/foobernetes.yaml
@@ -78,8 +78,8 @@ foobernetes:
     # present in the actual state of the resource returned by the "loadbalancer"
     # state handler. The two inputs are implicit and can be identified by the use of
     # a dollar sign ($) i.e. appServerID1 and appServerID2.
-    web-server1:
-      type: Foobernetes::webserver
+    web-servers:
+      type: Foobernetes::Webserver
       output:
         webServerID1: webServerID
       state:
@@ -91,7 +91,7 @@ foobernetes:
     # need to be unique across the entire workflow and so again the "webServerID"
     # field from the actual resource state is aliased.
     web-server2:
-      type: Foobernetes::webserver
+      type: Foobernetes::Webserver
       output:
         webServerID2: webServerID
       state:
@@ -116,7 +116,7 @@ foobernetes:
     # activity name must be unique. The activity also declares its inputs
     # explicitly, which is never necessary in yaml but can aid clarity.
     secondary-loadbalancer:
-      type: Foobernetes::loadbalancer
+      type: Foobernetes::Loadbalancer
       input: [webServerID1, webServerID2]
       output:
         secondaryLoadBalancerID: loadBalancerID
@@ -132,7 +132,7 @@ foobernetes:
     # The state section of an activity can be arbitrarily nested as shown in the
     # "config" section.
     app-server1:
-      type: Foobernetes::instance
+      type: Foobernetes::Instance
       output:
         appServerID1: instanceID
       state:
@@ -145,7 +145,7 @@ foobernetes:
         memory: 8G
 
     app-server2:
-      type: Foobernetes::instance
+      type: Foobernetes::Instance
       output:
         appServerID2: instanceID
       state:
@@ -158,7 +158,7 @@ foobernetes:
         memory: 8G
 
     database:
-      type: Foobernetes::instance
+      type: Foobernetes::Instance
       output:
         databaseID: instanceID
       state:


### PR DESCRIPTION
A pcore type name must consist of one to many capitalized segments
separated by double colon.

Relates to lyraproj/lyra#226