### PR TITLE
Ensure that the generate command terminates all plugins

### DIFF
--- a/cmd/lyra/cmd/generate.go
+++ b/cmd/lyra/cmd/generate.go
@@ -36,12 +36,9 @@ func NewGenerateCmd() *cobra.Command {
 }
 
 func runGenerateCmd(cmd *cobra.Command, args []string) {
-	language := args[0]
-	err := generate.Generate(language, targetDirectory)
-	if err != nil {
-		ui.Message("error", err)
-		os.Exit(1)
+	exitCode := generate.Generate(args[0], targetDirectory)
+	if exitCode == 0 {
+		ui.ShowMessage("Generation complete")
 	}
-	ui.ShowMessage("Generation complete")
-	os.Exit(0)
+	os.Exit(exitCode)
 }

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"github.com/lyraproj/lyra/pkg/loader"
+	"github.com/lyraproj/lyra/pkg/util"
 	"github.com/lyraproj/pcore/pcore"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/servicesdk/lang/typegen"
@@ -11,30 +12,31 @@ import (
 // Generate generates typeset files in the given language for all types exported from known services
 // into the given targetDirectory. If the targetDirectory is the empty string, it will default to
 // plugins/types relative to the current working directory.
-func Generate(language, targetDirectory string) error {
-	pcore.Do(func(c px.Context) {
-		generator := typegen.GetGenerator(language)
+func Generate(language, targetDirectory string) int {
+	return util.RunCommand(func() int {
+		pcore.Do(func(c px.Context) {
+			generator := typegen.GetGenerator(language)
 
-		c.DoWithLoader(loader.New(c.Loader()), func() {
-			loader.LoadPlugins(c)
+			c.DoWithLoader(loader.New(c.Loader()), func() {
+				loader.LoadPlugins(c)
 
-			sNames := c.Loader().Discover(c, func(tn px.TypedName) bool {
-				return tn.Namespace() == px.NsService
-			})
+				sNames := c.Loader().Discover(c, func(tn px.TypedName) bool {
+					return tn.Namespace() == px.NsService
+				})
 
-			if targetDirectory == `` {
-				targetDirectory = "types"
-			}
-			for _, sName := range sNames {
-				if v, ok := px.Load(c, sName); ok {
-					typeSet, _ := v.(serviceapi.Service).Metadata(c)
-					if typeSet != nil && typeSet.Types().Len() > 0 {
-						generator.GenerateTypes(typeSet, targetDirectory)
+				if targetDirectory == `` {
+					targetDirectory = "types"
+				}
+				for _, sName := range sNames {
+					if v, ok := px.Load(c, sName); ok {
+						typeSet, _ := v.(serviceapi.Service).Metadata(c)
+						if typeSet != nil && typeSet.Types().Len() > 0 {
+							generator.GenerateTypes(typeSet, targetDirectory)
+						}
 					}
 				}
-			}
+			})
 		})
+		return 0
 	})
-
-	return nil
 }

--- a/pkg/util/command.go
+++ b/pkg/util/command.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/lyraproj/lyra/cmd/lyra/ui"
+	"github.com/lyraproj/lyra/pkg/logger"
+)
+
+type CmdError string
+
+func (e CmdError) Error() string {
+	return string(e)
+}
+
+// RunCommand calls the given cmdFunc returns its exit value. It ensures that:
+//
+// A CmdError is logged using an ui.Message (changes exitCode to 1)
+// SIGINT and SIGTERM are handled (changes exitCode to 1)
+// All started plugins are cleaned up
+func RunCommand(cmdFunc func() int) (exitCode int) {
+	sgs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+
+	// Spawn signal handler routine. It will get called explicitly by the deferred func
+	// below this one unless it is called when a signal is trapped.
+	go func() {
+		sig := <-sgs
+		plugin.CleanupClients()
+		logger.Get().Debug("all plugins cleaned up")
+		if sig != syscall.SIGUSR1 {
+			exitCode = 1
+		}
+		done <- true
+	}()
+	signal.Notify(sgs, syscall.SIGINT, syscall.SIGTERM)
+
+	defer func() {
+		if e := recover(); e != nil {
+			exitCode = 1
+			if err, ok := e.(CmdError); ok {
+				ui.Message("error", err)
+			} else {
+				ui.Message("fatal", e)
+			}
+		}
+		sgs <- syscall.SIGUSR1 // Our own
+		<-done
+	}()
+	return cmdFunc()
+}


### PR DESCRIPTION
This commit moves the signal handler and the top-level error recovery
into a utility function so that the same logic can be used by both
the apply/delete and the generate commands. This also makes it possible
to use the same cleanup for future commands.

Closes #134