### PR TITLE
Ensure that errors from lyra executable include stacktrace

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"sync"
 
+	"github.com/lyraproj/issue/issue"
+
 	hclog "github.com/hashicorp/go-hclog"
 )
 
@@ -40,6 +42,7 @@ func Initialise(spec Spec) hclog.Logger {
 			hclog.DefaultOptions.Output = spec.Output
 		}
 		l := hclog.Default()
+		issue.IncludeStacktrace(l.IsDebug())
 		logger = l
 	})
 	return logger


### PR DESCRIPTION
This commit will make the lyra executable include a stacktrace in
issue.Reported errors when debug logging is active.