### PR TITLE
Support docker-based builds in the Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,16 @@ RUN GO111MODULE=on go mod download
 COPY . .
 RUN make lyra plugins
 # Copy binaries over to a new container
-FROM golang:latest
+FROM alpine
 WORKDIR /src/lyra/
+<<<<<<< HEAD
 ENV PATH /src/lyra/build/bin:$PATH
 COPY --from=builder /src/lyra/build/bin/lyra /src/lyra/build/bin/lyra
+=======
+ENV PATH /src/lyra/build:$PATH
+RUN apk add ca-certificates
+COPY --from=builder /src/lyra/build/lyra /src/lyra/build/lyra
+>>>>>>> Use alpine instead of golang container for runtime
 COPY --from=builder /src/lyra/build/goplugins /src/lyra/build/goplugins
 COPY --from=builder /src/lyra/workflows /src/lyra/workflows
 COPY --from=builder /src/lyra/examples /src/lyra/examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.mod .
 COPY go.sum .
 RUN GO111MODULE=on go mod download
 COPY . .
-RUN make lyra plugins
+RUN make docker-build
 # Copy binaries over to a new container
 FROM alpine
 WORKDIR /src/lyra/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,10 @@ RUN make docker-build
 # Copy binaries over to a new container
 FROM alpine
 WORKDIR /src/lyra/
-<<<<<<< HEAD
 ENV PATH /src/lyra/build/bin:$PATH
 COPY --from=builder /src/lyra/build/bin/lyra /src/lyra/build/bin/lyra
-=======
-ENV PATH /src/lyra/build:$PATH
 RUN apk add ca-certificates
-COPY --from=builder /src/lyra/build/lyra /src/lyra/build/lyra
->>>>>>> Use alpine instead of golang container for runtime
+RUN mkdir /src/lyra/local
 COPY --from=builder /src/lyra/build/goplugins /src/lyra/build/goplugins
 COPY --from=builder /src/lyra/workflows /src/lyra/workflows
 COPY --from=builder /src/lyra/examples /src/lyra/examples


### PR DESCRIPTION
Use a different minimal container instead of golang:latest
for the runtime.

For Lyra to run inside a minimal Alpine container, it needs
to be built with special arguments. This change adds a
BUILDARGS variable, prepended to relevant build/test steps,
so that the new 'make docker-build' target runs successfully
without impacting native-host builds.