### PR TITLE
Update pp and yaml examples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995
 	github.com/lyraproj/lyra-operator v0.0.0-20190412150939-82bb153789bc
 	github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569
-	github.com/lyraproj/puppet-workflow v0.0.0-20190430133822-68528441a2e9
+	github.com/lyraproj/puppet-workflow v0.0.0-20190501130808-fde06007b4e2
 	github.com/lyraproj/servicesdk v0.0.0-20190430133733-68a5a13f9111
 	github.com/lyraproj/terraform-bridge v0.0.0-20190430134352-33bd7e9b457a
 	github.com/lyraproj/wfe v0.0.0-20190430133906-65404dfd97a1

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.1.1-0.20171002171727-8ebdfab36c66/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-github v16.0.0+incompatible h1:omSHCJqM3CNG6RFFfGmIqGVbdQS2U3QVQSqACgwV1PY=
 github.com/google/go-github v16.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -310,6 +311,8 @@ github.com/lyraproj/puppet-parser v0.0.0-20190430133542-e2f2062b9126 h1:7GRijiOD
 github.com/lyraproj/puppet-parser v0.0.0-20190430133542-e2f2062b9126/go.mod h1:SBAnx/uxMMKy29qME9jFlgHtVJOLI4q7dVMu0UTcIk0=
 github.com/lyraproj/puppet-workflow v0.0.0-20190430133822-68528441a2e9 h1:zciBbuAStfzklcuWoJMVwSWVFmSS0z1Tx8WjxK2cDHU=
 github.com/lyraproj/puppet-workflow v0.0.0-20190430133822-68528441a2e9/go.mod h1:0tpPWeJ96bs/sxyEQVMrPY0qb2LTONN2M9fRXxLXVFQ=
+github.com/lyraproj/puppet-workflow v0.0.0-20190501130808-fde06007b4e2 h1:vzpsdSbYhBUJplVOzXxXDxATyUh3CRGpkTv8vh+ZUZc=
+github.com/lyraproj/puppet-workflow v0.0.0-20190501130808-fde06007b4e2/go.mod h1:0tpPWeJ96bs/sxyEQVMrPY0qb2LTONN2M9fRXxLXVFQ=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/lyraproj/servicesdk v0.0.0-20190430133733-68a5a13f9111 h1:1ldNNnnK/Rb2myLgSk/hE/4TV8BOUzmGw+on4RV2Dl8=

--- a/workflows/aws.yaml
+++ b/workflows/aws.yaml
@@ -1,120 +1,114 @@
-aws:
-  typespace: Aws
-  parameters:
-    tags:
-      type: Hash[String,String]
-      lookup: aws.tags
-  returns:
-    vpc_id: String
-  steps:
+parameters:
+  tags:
+    type: Hash[String,String]
+    lookup: aws.tags
+returns:
+  vpc_id: String
+steps:
 
-    iam_role:
-      state:
-        name: lyra-iam-role
-        assume_role_policy: |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                  "Action": "sts:AssumeRoleWithSAML",
-                  "Effect": "Allow",
-                  "Condition": {
-                    "StringEquals": {
-                        "SAML:aud": "https://signin.aws.amazon.com/saml"
-                    }
-                  },
-                  "Principal": {
-                    "Federated": "arn:aws:iam::1234567890:saml-provider/myidp"
+  iam_role:
+    Aws::Iam_role:
+      name: lyra-iam-role
+      assume_role_policy: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+                "Action": "sts:AssumeRoleWithSAML",
+                "Effect": "Allow",
+                "Condition": {
+                  "StringEquals": {
+                      "SAML:aud": "https://signin.aws.amazon.com/saml"
                   }
-              }
-            ]
-          }
+                },
+                "Principal": {
+                  "Federated": "arn:aws:iam::1234567890:saml-provider/myidp"
+                }
+            }
+          ]
+        }
 
-    #
-    # Application of key_pair succeeds on the first run then fails: see https://github.com/lyraproj/lyra/issues/203
-    #
-    # key_pair:
-    #   state:
-    #     key_name: lyra-test-keypair
-    #     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCX363gh/q6DGSL963/LlYcILkYKtEjrq5Ze4gr1BJdY0pqLMIKFt/VMJ5UTyx85N4Chjb/jEQhZzlWGC1SMsXOQ+EnY72fYrpOV0wZ4VraxZAz3WASikEglHJYALTQtsL8RGPxlBhIv0HpgevBkDlHvR+QGFaEQCaUhXCWDtLWYw== nyx-test-keypair-nopassword"
+  #
+  # Application of key_pair succeeds on the first run then fails: see https://github.com/lyraproj/lyra/issues/203
+  #
+  # key_pair:
+  #   Aws::Key_pair:
+  #     key_name: lyra-test-keypair
+  #     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCX363gh/q6DGSL963/LlYcILkYKtEjrq5Ze4gr1BJdY0pqLMIKFt/VMJ5UTyx85N4Chjb/jEQhZzlWGC1SMsXOQ+EnY72fYrpOV0wZ4VraxZAz3WASikEglHJYALTQtsL8RGPxlBhIv0HpgevBkDlHvR+QGFaEQCaUhXCWDtLWYw== nyx-test-keypair-nopassword"
 
-    vpc:
-      # type is implicit and is derived from the
-      # step name, in contrast to subnets below
-      returns: vpc_id
-      state:
-        cidr_block: 192.168.0.0/16
-        instance_tenancy: default
-        tags: $tags
+  vpc:
+    # type is implicit and is derived from the
+    # step name, in contrast to subnets below
+    returns: vpc_id
+    Aws::Vpc:
+      cidr_block: 192.168.0.0/16
+      instance_tenancy: default
+      tags: $tags
 
-    route_table:
-      state:
-        vpc_id: $vpc_id
-        tags:
-          name: lyra-routetable
-          created_by: lyra
+  route_table:
+    Aws::Route_table:
+      vpc_id: $vpc_id
+      tags:
+        name: lyra-routetable
+        created_by: lyra
 
-    #
-    # Deletion of internet_gateway fails: see https://github.com/lyraproj/lyra/issues/204
-    #
-    # internet_gateway:
-    #   state:
-    #     vpc_id: $vpc_id
+  #
+  # Deletion of internet_gateway fails: see https://github.com/lyraproj/lyra/issues/204
+  #
+  # internet_gateway:
+  #   Aws::Internet_gateway:
+  #     vpc_id: $vpc_id
 
-    security_group:
-      state:
-        name: "lyra"
-        description: "lyra security group"
-        vpc_id: $vpc_id
-        ingress:
-          - from_port: 0
-            to_port: 0
-            protocol: "-1"
-            cidr_blocks: ["0.0.0.0/0"]
-        egress:
-          - from_port: 0
-            to_port: 0
-            protocol: "-1"
-            cidr_blocks: ["0.0.0.0/0"]
+  security_group:
+    Aws::Security_group:
+      name: "lyra"
+      description: "lyra security group"
+      vpc_id: $vpc_id
+      ingress:
+        - from_port: 0
+          to_port: 0
+          protocol: "-1"
+          cidr_blocks: ["0.0.0.0/0"]
+      egress:
+        - from_port: 0
+          to_port: 0
+          protocol: "-1"
+          cidr_blocks: ["0.0.0.0/0"]
 
-    subnet1:
-      type:  Aws::Subnet
-      returns:
-        subnet_id1: subnet_id
-      state:
-        vpc_id: $vpc_id
-        cidr_block: 192.168.1.0/24
-        tags:
-          name: lyra-subnet-1
-          created_by: lyra
+  subnet1:
+    returns:
+      subnet_id1: subnet_id
+    Aws::Subnet:
+      vpc_id: $vpc_id
+      cidr_block: 192.168.1.0/24
+      tags:
+        name: lyra-subnet-1
+        created_by: lyra
 
-    subnet2:
-      type:  Aws::Subnet
-      returns:
-        subnet_id2: subnet_id
-      state:
-        vpc_id: $vpc_id
-        cidr_block: 192.168.2.0/24
-        tags:
-          name: lyra-subnet-2
-          created_by: lyra
+  subnet2:
+    returns:
+      subnet_id2: subnet_id
+    Aws::Subnet:
+      vpc_id: $vpc_id
+      cidr_block: 192.168.2.0/24
+      tags:
+        name: lyra-subnet-2
+        created_by: lyra
 
-    instance1:
-      type:  Aws::Instance
-      state:
-        instance_type: 't2.nano'
-        ami: 'ami-f90a4880'
-        subnet_id: $subnet_id1
-        tags:
-          name: lyra-instance-1
-          created_by: lyra
+  instance1:
+    Aws::Instance:
+      instance_type: 't2.nano'
+      ami: 'ami-f90a4880'
+      subnet_id: $subnet_id1
+      tags:
+        name: lyra-instance-1
+        created_by: lyra
 
-    instance2:
-      type:  Aws::Instance
-      state:
-        instance_type: 't2.nano'
-        ami: 'ami-f90a4880'
-        subnet_id: $subnet_id2
-        tags:
-          name: lyra-instance-2
-          created_by: lyra
+  instance2:
+    Aws::Instance:
+      instance_type: 't2.nano'
+      ami: 'ami-f90a4880'
+      subnet_id: $subnet_id2
+      tags:
+        name: lyra-instance-2
+        created_by: lyra

--- a/workflows/aws_pp.pp
+++ b/workflows/aws_pp.pp
@@ -1,5 +1,4 @@
 workflow aws_pp {
-  typespace => 'Aws',
   parameters => (
     Hash[String,String] $tags = lookup('aws.tags'),
   ),
@@ -9,6 +8,7 @@ workflow aws_pp {
 } {
 
   resource iam_role {
+    type => Aws::Iam_role
   } {
     name => 'lyra-iam-role',
     assume_role_policy => '{
@@ -42,6 +42,7 @@ workflow aws_pp {
   resource vpc {
     # type is implicit and is derived from the
     # step name, in contrast to subnets below
+    type => Aws::Vpc,
     parameters  => ($tags),
     returns => ($vpc_id)
   }{
@@ -51,7 +52,8 @@ workflow aws_pp {
   }
 
   resource route_table {
-    parameters  => ($vpc_id),
+    type => Aws::Route_table,
+    parameters  => ($vpc_id)
   } {
     vpc_id => $vpc_id,
     tags => {
@@ -70,7 +72,8 @@ workflow aws_pp {
   # }
 
   resource security_group {
-    parameters  => ($vpc_id),
+    type => Aws::Security_group,
+    parameters  => ($vpc_id)
   }{
     name => "lyra",
     description => "lyra security group",
@@ -90,9 +93,9 @@ workflow aws_pp {
   }
 
   resource subnet1 {
-    type =>  'Aws::Subnet',
+    type => Aws::Subnet,
     parameters  => ($vpc_id),
-    returns => ($subnet_id1 = subnet_id)
+    returns => ($subnet_id1 = subnet_id),
   }{
     vpc_id => $vpc_id,
     cidr_block => '192.168.1.0/24',
@@ -103,7 +106,7 @@ workflow aws_pp {
   }
 
   resource subnet2 {
-    type =>  'Aws::Subnet',
+    type => Aws::Subnet,
     parameters  => ($vpc_id),
     returns => ($subnet_id2 = subnet_id)
   }{
@@ -116,7 +119,7 @@ workflow aws_pp {
   }
 
   resource instance1 {
-    type =>  'Aws::Instance',
+    type => Aws::Instance,
     parameters  => ($subnet_id1)
   }{
     instance_type => 't2.nano',
@@ -129,7 +132,7 @@ workflow aws_pp {
   }
 
   resource instance2 {
-    type =>  'Aws::Instance',
+    type => Aws::Instance,
     parameters  => ($subnet_id2)
   }{
     instance_type => 't2.nano',

--- a/workflows/azure.yaml
+++ b/workflows/azure.yaml
@@ -1,90 +1,87 @@
 # You will need to authenticate with Azure using the "az login" command
-
-azure:
-  typespace: AzureRM
-  steps:
-    resource_group:
-      returns:
-        resource_group_name: name
-      state:
-        name: lyra
-        location: ukwest
-        tags:
-          environment: "Lyra Example"
-    virtual_network:
-      returns:
-        virtual_network_name: name
-      state:
-        name: lyraVnet
-        address_space: [10.0.0.0/16]
-        location: ukwest
-        resource_group_name: $resource_group_name
-    subnet:
-      returns: subnet_id
-      state:
-        name: lyraSubnet
-        resource_group_name: $resource_group_name
-        virtual_network_name: $virtual_network_name
-        address_prefix: 10.0.1.0/24
-    public_ip:
-      returns: public_ip_id
-      state:
-        name: lyraPublicIP
-        location: ukwest
-        resource_group_name: $resource_group_name
-        allocation_method: dynamic
-    network_security_group:
-      returns: network_security_group_id
-      state:
-        name: lyraNetworkSecurityGroup
-        location: ukwest
-        resource_group_name: $resource_group_name
-        security_rule:
-          - name: SSH
-            priority: 1001
-            direction: Inbound
-            access: Allow
-            protocol: Tcp
-            source_port_range: "*"
-            destination_port_range: "22"
-            source_address_prefix: "*"
-            destination_address_prefix: "*"
-    network_interface:
-      returns: network_interface_id
-      state:
-        name: lyraNIC
-        location: ukwest
-        resource_group_name: $resource_group_name
-        network_security_group_id: $network_security_group_id
-        ip_configuration:
-          - name: lyraNicConfiguration
-            subnet_id: $subnet_id
-            private_ip_address_allocation: dynamic
-            public_ip_address_id: $public_ip_id
-    virtual_machine:
-      state:
-        name: lyraVirtualMachine
-        location: UK West
-        resource_group_name: $resource_group_name
-        network_interface_ids: [$network_interface_id]
-        vm_size: Standard_B1s
-        storage_image_reference:
-          publisher: Canonical
-          offer: UbuntuServer
-          sku: 18.04-LTS
-          version: latest
-        storage_os_disk:
-          name: lyraosdisk1
-          caching: ReadWrite
-          create_option: FromImage
-          managed_disk_type: Standard_LRS
-        os_profile:
-          computer_name: hostname
-          admin_username: testadmin
-          admin_password: Password1234!
-        os_profile_linux_config:
-          disable_password_authentication: false
-        tags:
-          environment: lyra-test
-        delete_os_disk_on_termination: true
-        delete_data_disks_on_termination: true
+steps:
+  resource_group:
+    returns:
+      resource_group_name: name
+    AzureRM::Resource_group:
+      name: lyra
+      location: ukwest
+      tags:
+        environment: "Lyra Example"
+  virtual_network:
+    returns:
+      virtual_network_name: name
+    AzureRM::Virtual_network:
+      name: lyraVnet
+      address_space: [10.0.0.0/16]
+      location: ukwest
+      resource_group_name: $resource_group_name
+  subnet:
+    returns: subnet_id
+    AzureRM::Subnet:
+      name: lyraSubnet
+      resource_group_name: $resource_group_name
+      virtual_network_name: $virtual_network_name
+      address_prefix: 10.0.1.0/24
+  public_ip:
+    returns: public_ip_id
+    AzureRM::Public_ip:
+      name: lyraPublicIP
+      location: ukwest
+      resource_group_name: $resource_group_name
+      allocation_method: dynamic
+  network_security_group:
+    returns: network_security_group_id
+    AzureRM::Network_security_group:
+      name: lyraNetworkSecurityGroup
+      location: ukwest
+      resource_group_name: $resource_group_name
+      security_rule:
+        - name: SSH
+          priority: 1001
+          direction: Inbound
+          access: Allow
+          protocol: Tcp
+          source_port_range: "*"
+          destination_port_range: "22"
+          source_address_prefix: "*"
+          destination_address_prefix: "*"
+  network_interface:
+    returns: network_interface_id
+    AzureRM::Network_interface:
+      name: lyraNIC
+      location: ukwest
+      resource_group_name: $resource_group_name
+      network_security_group_id: $network_security_group_id
+      ip_configuration:
+        - name: lyraNicConfiguration
+          subnet_id: $subnet_id
+          private_ip_address_allocation: dynamic
+          public_ip_address_id: $public_ip_id
+  virtual_machine:
+    AzureRM::Virtual_machine:
+      name: lyraVirtualMachine
+      location: UK West
+      resource_group_name: $resource_group_name
+      network_interface_ids: [$network_interface_id]
+      vm_size: Standard_B1s
+      storage_image_reference:
+        publisher: Canonical
+        offer: UbuntuServer
+        sku: 18.04-LTS
+        version: latest
+      storage_os_disk:
+        name: lyraosdisk1
+        caching: ReadWrite
+        create_option: FromImage
+        managed_disk_type: Standard_LRS
+      os_profile:
+        computer_name: hostname
+        admin_username: testadmin
+        admin_password: Password1234!
+      os_profile_linux_config:
+        disable_password_authentication: false
+      tags:
+        environment: lyra-test
+      delete_os_disk_on_termination: true
+      delete_data_disks_on_termination: true

--- a/workflows/azure_pp.pp
+++ b/workflows/azure_pp.pp
@@ -1,13 +1,14 @@
 workflow azure_pp {
-  typespace => 'AzureRM',
 } {
     resource resource_group {
+      type => AzureRM::Resource_group,
       returns => ($resource_group_name = name),
     } {
           name => 'lyra-pp',
           location =>  'ukwest'
     }
     resource virtual_network {
+      type => AzureRM::Virtual_network,
       parameters => ($resource_group_name),
       returns => ($virtual_network_name = name),
     } {
@@ -18,6 +19,7 @@ workflow azure_pp {
     }
 
     resource subnet {
+      type => AzureRM::Subnet,
       parameters => ($resource_group_name, $virtual_network_name),
       returns => ($subnet_id = subnet_id)
     } {
@@ -28,6 +30,7 @@ workflow azure_pp {
     }
 
     resource public_ip {
+      type => AzureRM::Public_ip,
       parameters => ($resource_group_name, $virtual_network_name),
       returns => ($public_ip_id = public_ip_id)
     } {
@@ -38,6 +41,7 @@ workflow azure_pp {
     }
 
     resource network_security_group {
+      type => AzureRM::Network_security_group,
       parameters => ($resource_group_name),
       returns => ($nsg_id = network_security_group_id)
     } {
@@ -58,6 +62,7 @@ workflow azure_pp {
     }
 
     resource network_interface {
+      type => AzureRM::Network_interface,
       parameters => ($resource_group_name, $nsg_id, $subnet_id, $public_ip_id),
       returns => ($nic_id = network_interface_id)
     } {
@@ -74,6 +79,7 @@ workflow azure_pp {
     }
 
     resource virtual_machine {
+      type => AzureRM::Virtual_machine,
       parameters => ($resource_group_name, $nic_id, $nsg_id),
     } {
           name =>  'lyraVirtualMachinePp',

--- a/workflows/foober_iter.yaml
+++ b/workflows/foober_iter.yaml
@@ -1,12 +1,11 @@
 # Foobernetes is an imaginary cloud provider used to illustrate and test the capabilities of Lyra.
 #
-# This file defines a workflow called "foober_iter" (which must be in a file of the
-# same name). The workflow contains a set of interrelated steps and Lyra will
-# determine the correct order in which to execute them based on the parameters and
-# returns of each. In this example we are deploying a (fictional) 3-tier application
-# consisting of a database, two application servers and two web servers, with a load
-# balancer in front. The fictional real-world resources are written to a file called
-# "deployment.json" allowing you to see the changes made by Lyra.
+# This file defines a workflow called "foober_iter" (named after the file that it resides in).
+# The workflow contains a set of interrelated steps and Lyra will determine the correct order in
+# which to execute them based on the parameters and returns of each. In this example we are
+# deploying a (fictional) 3-tier application consisting of a database, two application servers and
+# two web servers, with a load balancer in front. The fictional real-world resources are written to
+# a file called "deployment.json" allowing you to see the changes made by Lyra.
 #
 # Try the following:
 # 1. Use Lyra to apply the workflow:
@@ -20,117 +19,109 @@
 #    "lyra delete --debug foober_iter"
 #
 # This example is written in yaml. See the yaml documentation here: docs/workflow-yaml.md
-foober_iter:
 
-  # Typespaces are namespaces. Here we define the default typespace for
-  # this workflow, which allows us to omit it in some cases below.
-  # See "loadbalancer" for an example.
-  typespace: Foobernetes
+# The workflow expects a single parameter named "load_balancer_policy" and is used in the
+# "loadbalancers" collect step below.
+# The value itself comes from the "data.yaml" file at runtime based on the
+# "lookup" key specified here: in this case a key called "lb_policy" nested in
+# the "foober_iter" section. All top-level workflow parameters must be specified in
+# the "data.yaml" file at runtime.
+parameters:
+  load_balancer_policy:
+    type: String
+    lookup: foobernetes.lb_policy
 
-  # The workflow expects a single value as parameters. The parameters is named
-  # "load_balancer_policy" and is used in the "loadbalancers" iteration step below.
-  # The value itself comes from the "data.yaml" file at runtime based on the
-  # "lookup" key specified here: in this case a key called "lb_policy" nested in
-  # the "foober_iter" section. All top-level workflow parameters must be specified in
-  # the "data.yaml" file at runtime.
-  parameters:
-    load_balancer_policy:
-      type: String
-      lookup: foobernetes.lb_policy
+# The workflow returns a two element array containing the IDs produced by the
+# "loadBalancers" collect step. All top-level returns must be returns of
+# steps within this workflow.
+returns: loadbalancers
 
-  # The workflow returns two output values: the IDs produced by the
-  # "loadBalancers" iterator step. All top-level workflow returns must be returns of
-  # steps within this workflow.
-  returns: loadbalancers
+# Steps are the main body of the workflow and define its behavior. The
+# ordering of the steps is not important - Lyra will infer the correct
+# order in which to execute the steps based on their parameters and returns.
+#
+# The steps in this workflow are all declarative "stateful steps",
+# meaning they define the desired states of real-world resources. For each type
+# of stateful step, there is a "state handler" that takes responsibility for
+# ensuring the real-world resource matches the desired state. It does this by
+# creating, reading, updating or deleting those resources in response to
+# workflow changes. The types and state handlers for this workflow are defined
+# in Go and can be found in the "go-foobernetes" plugin.
+#
+# Although Lyra support imperative "stateless steps", it is not possible to
+# specify these in yaml.
+#
+# In yaml, step parameters are usually implicit (though can be made explicit if
+# desired) and any field value that starts with a dollar sign ($) is assumed to
+# be a parameter e.g. $databaseID. Step returns are always explicit. A step
+# can only be executed when all parameters are available. Those parameters must
+# come from either the top-level workflow parameters or the returns of other
+# steps. Parameters and returns are correlated by name and so must be unique
+# within a workflow.
+steps:
 
-  # Steps are the main body of the workflow and define its behavior. The
-  # ordering of the steps is not important - Lyra will infer the correct
-  # order in which to execute the steps based on their parameters and returns.
+  # This step defines an collect step called "webServers" which will
+  # create two identical webserver resources.
   #
-  # The steps in this workflow are all declarative "stateful steps",
-  # meaning they define the desired states of real-world resources. For each type
-  # of stateful step, there is a "state handler" that takes responsibility for
-  # ensuring the real-world resource matches the desired state. It does this by
-  # creating, reading, updating or deleting those resources in response to
-  # workflow changes. The types and state handlers for this workflow are defined
-  # in Go and can be found in the "go-foobernetes" plugin.
-  #
-  # Although Lyra support imperative "stateless steps", it is not possible to
-  # specify these in yaml.
-  #
-  # In yaml, step parameters are usually implicit (though can be made explicit if
-  # desired) and any field value that starts with a dollar sign ($) is assumed to
-  # be a parameter e.g. $databaseID. Step returns are always explicit. A step
-  # can only be executed when all parameters are available. Those parameters must
-  # come from either the top-level workflow parameters or the returns of other
-  # steps. Parameters and returns are correlated by name and so must be unique
-  # within a workflow.
-  steps:
+  # Since this is an collect step, it will always return a list where each entry is a value
+  # returned by the contained step. The returned list is named after step by default but can
+  # be changed using an 'into' property.
+  # The parameters are implicit and can be identified by
+  # the use of a dollar sign ($) i.e. appServers.
+  webServers:
+    times: 2
+    step:
+      # This step defines a Foobernetes::Webserver resource.
+      returns: webServerID
+      Foobernetes::Webserver:
+        port: 8080
+        appServers: $appServers
 
-    # This step defines an iteration step called "webServers" which will
-    # create two identical "Foobernetes::Webserver" resources. The type is explicit.
-    # Since this is an iteration, there is a single list "returns" named "webServers"
-    # containing values of the "webServerID" field declared in the "returns" section.
-    # The "webServerID" field is present in the actual state of the resource returned
-    # by the "webserver" state handler. The parameters are implicit and can be identified by
-    # the use of a dollar sign ($) i.e. appServers.
-    webServers:
-      times: 2
-      step:
-        type: Foobernetes::Webserver
-        returns: webServerID
-        state:
-          port: 8080
-          appServers: $appServers
-
-    # This iteration step iterates over an array of 3 element arrays. Each iteration
-    # assigns the 3 values to their corresponding variables $role, $ip, and $replica which
-    # are then used when declaring each loadbalancer's state.
-    loadbalancers:
-      each:
-        - [primary, '10.0.0.1', false]
-        - [secondary, '10.0.0.2', true]
-      as:
-        - role
-        - ip
-        - replica
-      step:
-        type: Foobernetes::Loadbalancer
-        returns: loadBalancerID
-        state:
-          loadBalancerIP: $ip
-          location: eu1
-          replica: $replica
-          webServerIDs: $webServers
-          tags:
-            team: "lyra team"
-            role: $role
-
-    # The state section of a step can be arbitrarily nested as shown in the
-    # "config" section.
-    appServers:
-      each:
-        - app-server1
-        - app-server2
-      as: name
-      step:
-        type: Foobernetes::Instance
-        returns: instanceID
-        state:
-          location: eu2
-          image: "lyra::application"
-          config:
-            name: $name
-            databaseID: $databaseID
-          cpus: 4
-          memory: 8G
-
-    database:
-      type: Foobernetes::Instance
-      returns:
-        databaseID: instanceID
-      state:
+  # This collect step iterates over an array of 3 element arrays. Each iteration
+  # assigns the 3 values to their corresponding variables $role, $ip, and $replica which
+  # are then used when declaring each loadbalancer's state.
+  loadbalancers:
+    each:
+      - [primary, '10.0.0.1', false]
+      - [secondary, '10.0.0.2', true]
+    as:
+      - role
+      - ip
+      - replica
+    step:
+      returns: loadBalancerID
+      Foobernetes::Loadbalancer:
+        loadBalancerIP: $ip
         location: eu1
-        image: "lyra::database"
-        cpus: 16
-        memory: 64G
+        replica: $replica
+        webServerIDs: $webServers
+        tags:
+          team: "lyra team"
+          role: $role
+
+  # The state section of a step is keyed by a valid type name and can be arbitrarily nested as shown in the
+  # "config" section.
+  appServers:
+    each:
+      - app-server1
+      - app-server2
+    as: name
+    step:
+      returns: instanceID
+      Foobernetes::Instance:
+        location: eu2
+        image: "lyra::application"
+        config:
+          name: $name
+          databaseID: $databaseID
+        cpus: 4
+        memory: 8G
+
+  database:
+    returns:
+      databaseID: instanceID
+    Foobernetes::Instance:
+      location: eu1
+      image: "lyra::database"
+      cpus: 16
+      memory: 64G

--- a/workflows/foobernetes.yaml
+++ b/workflows/foobernetes.yaml
@@ -1,7 +1,7 @@
 # Foobernetes is an imaginary cloud provider used to illustrate and test the capabilities of Lyra.
 #
-# This file defines a workflow called "foobernetes" (which must be in a file of the
-# same name). The workflow contains a set of interrelated steps and Lyra will
+# This file defines a workflow called "foobernetes". (named after the file that it resides in).
+# The workflow contains a set of interrelated steps and Lyra will
 # determine the correct order in which to execute them based on the parameters and
 # returns of each. In this example we are deploying a (fictional) 3-tier application
 # consisting of a database, two application servers and two web servers, with a load
@@ -20,149 +20,136 @@
 #    "lyra delete --debug foobernetes"
 #
 # This example is written in yaml. See the yaml documentation here: docs/workflow-yaml.md
-foobernetes:
 
-  # Typespaces are namespaces. Here we define the default typespace for
-  # this workflow, which allows us to omit it in some cases below.
-  # See "loadbalancer" for an example.
-  typespace: Foobernetes
+# The workflow expects a single parameter named "load_balancer_policy" and is used in the
+# two "loadbalancer" steps below. The value itself comes from the "data.yaml" file at runtime
+# based on the "lookup" key specified here: in this case a key called "lb_policy" nested in
+# the "foobernetes" section. All top-level workflow parameters must be specified in
+# the "data.yaml" file at runtime.
+parameters:
+  load_balancer_policy:
+    type: String
+    lookup: foobernetes.lb_policy
 
-  # The workflow expects a single value as parameters. The parameters is named
-  # "load_balancer_policy" and is used in the two "loadbalancer" steps below.
-  # The value itself comes from the "data.yaml" file at runtime based on the
-  # "lookup" key specified here: in this case a key called "lb_policy" nested in
-  # the "foobernetes" section. All top-level workflow parameters must be specified in
-  # the "data.yaml" file at runtime.
-  parameters:
-    load_balancer_policy:
-      type: String
-      lookup: foobernetes.lb_policy
+# The workflow returns two named values which are the IDs produced by the two
+# "loadbalancer" steps. All top-level workflow returns must be returns of
+# steps within this workflow.
+returns: [ loadBalancerID, secondaryLoadBalancerID ]
 
-  # The workflow returns two output values: the IDs produced by the two
-  # "loadbalancer" steps. All top-level workflow returns must be returns of
-  # steps within this workflow.
-  returns: [ loadBalancerID, secondaryLoadBalancerID ]
+# Steps are the main body of the workflow and define its behavior. The
+# ordering of the steps is not important - Lyra will infer the correct
+# order in which to execute the steps based on their parameters and returns.
+#
+# The steps in this workflow are all declarative "stateful steps",
+# meaning they define the desired states of real-world resources. For each type
+# of stateful step, there is a "state handler" that takes responsibility for
+# ensuring the real-world resource matches the desired state. It does this by
+# creating, reading, updating or deleting those resources in response to
+# workflow changes. The types and state handlers for this workflow are defined
+# in Go and can be found in the "go-foobernetes" plugin.
+#
+# Although Lyra support imperative "stateless steps", it is not possible to
+# specify these in yaml.
+#
+# Each resource has a type which can be specified explicitly or implicitly. In
+# the implicit case, the type field is omitted. The type is inferred from the
+# name and the workflow's top-level typespace e.g. a step named "loadbalancer"
+# has an inferred type of "Foobernetes::loadbalancer".
+#
+# In yaml, step parameters are usually implicit (though can be made explicit if
+# desired) and any field value that starts with a dollar sign ($) is assumed to
+# be an parameters e.g. $databaseID. Step returns are always explicit. An
+# step can only be executed when all parameters are available. Those parameters must
+# come from either the top-level workflow parameters or the returns of other
+# steps. Parameters and returns are correlated by name and so must be unique
+# within a workflow.
+steps:
 
-  # Steps are the main body of the workflow and define its behavior. The
-  # ordering of the steps is not important - Lyra will infer the correct
-  # order in which to execute the steps based on their parameters and returns.
-  #
-  # The steps in this workflow are all declarative "stateful steps",
-  # meaning they define the desired states of real-world resources. For each type
-  # of stateful step, there is a "state handler" that takes responsibility for
-  # ensuring the real-world resource matches the desired state. It does this by
-  # creating, reading, updating or deleting those resources in response to
-  # workflow changes. The types and state handlers for this workflow are defined
-  # in Go and can be found in the "go-foobernetes" plugin.
-  #
-  # Although Lyra support imperative "stateless steps", it is not possible to
-  # specify these in yaml.
-  #
-  # Each resource has a type which can be specified explicitly or implicitly. In
-  # the implicit case, the type field is omitted. The type is inferred from the
-  # name and the workflow's top-level typespace e.g. a step named "loadbalancer"
-  # has an inferred type of "Foobernetes::loadbalancer".
-  #
-  # In yaml, step parameters are usually implicit (though can be made explicit if
-  # desired) and any field value that starts with a dollar sign ($) is assumed to
-  # be an parameters e.g. $databaseID. Step returns are always explicit. An
-  # step can only be executed when all parameters are available. Those parameters must
-  # come from either the top-level workflow parameters or the returns of other
-  # steps. Parameters and returns are correlated by name and so must be unique
-  # within a workflow.
-  steps:
+  # This step defines a resource called "webserver1". The type is explicit.
+  # There is a single output, the value of the "webServerID" field, which has been
+  # aliased to "webServerID1" to ensure uniqueness. The "webServerID" field is
+  # present in the actual state of the resource returned by the "loadbalancer"
+  # state handler. The two parameters are implicit and can be identified by the use of
+  # a dollar sign ($) i.e. appServerID1 and appServerID2.
+  web-servers:
+    returns:
+      webServerID1: webServerID
+    Foobernetes::Webserver:
+      port: 8080
+      appServers: [$appServerID1, $appServerID2]
 
-    # This step defines a resource called "webserver1". The type is explicit.
-    # There is a single output, the value of the "webServerID" field, which has been
-    # aliased to "webServerID1" to ensure uniqueness. The "webServerID" field is
-    # present in the actual state of the resource returned by the "loadbalancer"
-    # state handler. The two parameters are implicit and can be identified by the use of
-    # a dollar sign ($) i.e. appServerID1 and appServerID2.
-    web-servers:
-      type: Foobernetes::Webserver
-      returns:
-        webServerID1: webServerID
-      state:
-        port: 8080
-        appServers: [$appServerID1, $appServerID2]
+  # Since each step needs to have a unique name, this one is called
+  # "web-server2" to differentiate it from the step above. The names in "returns" also
+  # need to be unique across the entire workflow and so again the "webServerID"
+  # field from the actual resource state is aliased.
+  web-server2:
+    returns:
+      webServerID2: webServerID
+    Foobernetes::Webserver:
+      port: 8080
+      appServers: [$appServerID1, $appServerID2]
 
-    # Since each step needs to have a unique name, this one is called
-    # "web-server2" to differentiate it from the step above. The names in "returns" also
-    # need to be unique across the entire workflow and so again the "webServerID"
-    # field from the actual resource state is aliased.
-    web-server2:
-      type: Foobernetes::Webserver
-      returns:
-        webServerID2: webServerID
-      state:
-        port: 8080
-        appServers: [$appServerID1, $appServerID2]
+  # This step has an implicit type, derived from its name i.e.
+  # Foobernetes::loadbalancer. The returns field in this case is not aliased because the
+  # field name is already unique.
+  loadbalancer:
+    returns: loadBalancerID
+    Foobernetes::Loadbalancer:
+      loadBalancerIP: 10.0.0.1
+      location: eu1
+      replica: false
+      webServerIDs: [$webServerID1, $webServerID2]
+      tags:
+        team: "lyra team"
+        role: primary
 
-    # This step has an implicit type, derived from its name i.e.
-    # Foobernetes::loadbalancer. The returns field in this case is not aliased because the
-    # field name is already unique.
-    loadbalancer:
-      returns: loadBalancerID
-      state:
-        loadBalancerIP: 10.0.0.1
-        location: eu1
-        replica: false
-        webServerIDs: [$webServerID1, $webServerID2]
-        tags:
-          team: "lyra team"
-          role: primary
+  # This second "loadbalancer" step cannot be typed implicitly since the
+  # step name must be unique. The step also declares its parameters
+  # explicitly, which is never necessary in yaml but can aid clarity.
+  secondary-loadbalancer:
+    parameters: [webServerID1, webServerID2]
+    returns:
+      secondaryLoadBalancerID: loadBalancerID
+    Foobernetes::Loadbalancer:
+      loadBalancerIP: '10.0.0.2'
+      location: eu2
+      replica: true
+      webServerIDs: [$webServerID1, $webServerID2]
+      tags:
+        team: "lyra team"
+        role: secondary
 
-    # This second "loadbalancer" step cannot be typed implicitly since the
-    # step name must be unique. The step also declares its parameters
-    # explicitly, which is never necessary in yaml but can aid clarity.
-    secondary-loadbalancer:
-      type: Foobernetes::Loadbalancer
-      parameters: [webServerID1, webServerID2]
-      returns:
-        secondaryLoadBalancerID: loadBalancerID
-      state:
-        loadBalancerIP: '10.0.0.2'
-        location: eu2
-        replica: true
-        webServerIDs: [$webServerID1, $webServerID2]
-        tags:
-          team: "lyra team"
-          role: secondary
+  # The state section of a step can be arbitrarily nested as shown in the
+  # "config" section.
+  app-server1:
+    returns:
+      appServerID1: instanceID
+    Foobernetes::Instance:
+      location: eu1
+      image: lyra::application
+      config:
+        name: app-server1
+        databaseID: $databaseID
+      cpus: 4
+      memory: 8G
 
-    # The state section of a step can be arbitrarily nested as shown in the
-    # "config" section.
-    app-server1:
-      type: Foobernetes::Instance
-      returns:
-        appServerID1: instanceID
-      state:
-        location: eu1
-        image: lyra::application
-        config:
-          name: app-server1
-          databaseID: $databaseID
-        cpus: 4
-        memory: 8G
+  app-server2:
+    returns:
+      appServerID2: instanceID
+    Foobernetes::Instance:
+      location: eu2
+      image: "lyra::application"
+      config:
+        name: app-server2
+        databaseID: $databaseID
+      cpus: 4
+      memory: 8G
 
-    app-server2:
-      type: Foobernetes::Instance
-      returns:
-        appServerID2: instanceID
-      state:
-        location: eu2
-        image: "lyra::application"
-        config:
-          name: app-server2
-          databaseID: $databaseID
-        cpus: 4
-        memory: 8G
-
-    database:
-      type: Foobernetes::Instance
-      returns:
-        databaseID: instanceID
-      state:
-        location: eu1
-        image: "lyra::database"
-        cpus: 16
-        memory: 64G
+  database:
+    returns:
+      databaseID: instanceID
+    Foobernetes::Instance:
+      location: eu1
+      image: "lyra::database"
+      cpus: 16
+      memory: 64G

--- a/workflows/foobernetes_pp.pp
+++ b/workflows/foobernetes_pp.pp
@@ -1,5 +1,4 @@
 workflow foobernetes_pp {
-  typespace => 'Foobernetes',
   parameters => (
     String $load_balancer_policy = lookup('foobernetes.lb_policy')
   ),

--- a/workflows/github.yaml
+++ b/workflows/github.yaml
@@ -1,11 +1,8 @@
 # You will need to set the following environment variables to authenticate with GitHub
 # export GITHUB_ORGANIZATION=lyraproj
 # export GITHUB_TOKEN=<token>
-
-github:
-  typespace: GitHub
-  steps:
-    repository:
-      state:
-        name: "lyra-provider-test"
-        description: "Created using Lyra"
+steps:
+  repository:
+    GitHub::Repository:
+      name: "lyra-provider-test"
+      description: "Created using Lyra"

--- a/workflows/github_pp.pp
+++ b/workflows/github_pp.pp
@@ -3,9 +3,9 @@
 # export GITHUB_TOKEN=<token>
 
 workflow github_pp {
-  typespace => 'GitHub',
 } {
   resource repository {
+    type => GitHub::Repository,
   } {
     name => 'lyra-provider-test-pp',
     description =>'Created using Lyra'

--- a/workflows/googlecloud.yaml
+++ b/workflows/googlecloud.yaml
@@ -1,18 +1,15 @@
 # You will need to set the following environment variables to authenticate with GCP
 # export GOOGLE_PROJECT=<some-project>
 # export GOOGLE_APPLICATION_CREDENTIALS=<credentials-file.json>
-
-googlecloud:
-  typespace: Google
-  steps:
-    compute_instance:
-      state:
-        name: "lyra-test"
-        zone: "us-central1-a"
-        machine_type: "f1-micro"
-        boot_disk:
-          initialize_params:
-            image: "debian-cloud/debian-9"
-        network_interface:
-          - network: "default"
-            access_config:
+steps:
+  compute_instance:
+    Google::Compute_instance:
+      name: "lyra-test"
+      zone: "us-central1-a"
+      machine_type: "f1-micro"
+      boot_disk:
+        initialize_params:
+          image: "debian-cloud/debian-9"
+      network_interface:
+        - network: "default"
+          access_config:

--- a/workflows/googlecloud_pp.pp
+++ b/workflows/googlecloud_pp.pp
@@ -2,9 +2,9 @@
 # export GOOGLE_PROJECT=<some-project>
 # export GOOGLE_APPLICATION_CREDENTIALS=<credentials-file.json>
 workflow googlecloud_pp {
-  typespace => 'Google',
 } {
   resource compute_instance {
+    type => Google::Compute_instance,
   }{
     name => 'lyra-test-pp',
     zone => 'us-central1-a',

--- a/workflows/kubernetes.yaml
+++ b/workflows/kubernetes.yaml
@@ -1,26 +1,24 @@
-kubernetes:
- typespace: Kubernetes
- returns:
-   namespace_id: String
-   service_id: String
- steps:
-    namespace:
-      returns: namespace_id
-      state:
-        metadata:
+returns:
+ namespace_id: String
+ service_id: String
+steps:
+  namespace:
+    returns: namespace_id
+    Kubernetes::Namespace:
+      metadata:
+        name: lyra-ns
+        labels:
           name: lyra-ns
-          labels:
-            name: lyra-ns
-    service:
-      returns: service_id
-      state:
-        metadata:
-          name: lyra-service
-        spec:
-          session_affinity: ClientIP
-          selector:
-            app : anything
-          port:
-            - port: 80
-              target_port: "80"
-          type: LoadBalancer
+  service:
+    returns: service_id
+    Kubernetes::Service:
+      metadata:
+        name: lyra-service
+      spec:
+        session_affinity: ClientIP
+        selector:
+          app : anything
+        port:
+          - port: 80
+            target_port: "80"
+        type: LoadBalancer

--- a/workflows/kubernetes_pp.pp
+++ b/workflows/kubernetes_pp.pp
@@ -1,11 +1,11 @@
 workflow kubernetes_pp {
-  typespace => 'Kubernetes',
   returns => (
       String $namespace_id,
       String $service_id
   )
 } {
     resource namespace {
+      type => Kubernetes::Namespace,
       returns=> ($namespace_id),
     } {
         metadata => {
@@ -14,6 +14,7 @@ workflow kubernetes_pp {
     }
 
     resource service {
+      type => Kubernetes::Service,
       returns => ($service_id)
     } {
         metadata => {

--- a/workflows/sample.yaml
+++ b/workflows/sample.yaml
@@ -1,10 +1,8 @@
-sample:
-  typespace: example
-  returns: [name, age]
-  steps:
-    person:
-      returns: [name, age]
-      state:
-        age: 66
-        name: Ann
-        human: true
+returns: [name, age]
+steps:
+  person:
+    returns: [name, age]
+    Example::Person:
+      age: 66
+      name: Ann
+      human: true

--- a/workflows/sample2.pp
+++ b/workflows/sample2.pp
@@ -1,5 +1,4 @@
 workflow sample2 {
-  typespace => 'example',
   parameters => (
   String $foo = lookup('foo', undef, undef, "foo"),
   String $bar = lookup('bar', undef, undef, "bar"),
@@ -12,6 +11,7 @@ workflow sample2 {
   )
 } {
   resource person {
+  type => Example::Person,
   returns => ($name)
   }{
     age => 28,

--- a/workflows/sample_alias.yaml
+++ b/workflows/sample_alias.yaml
@@ -1,14 +1,12 @@
-sample_alias:
-  typespace: example
-  returns:
-    longName: String
-    currentAge: Integer
-  steps:
-    person:
-      returns:
-        longName: name
-        currentAge: age
-      state:
-        age: 66
-        name: Ann
-        human: true
+returns:
+  longName: String
+  currentAge: Integer
+steps:
+  person:
+    returns:
+      longName: name
+      currentAge: age
+    Example::Person:
+      age: 66
+      name: Ann
+      human: true

--- a/workflows/sample_alias_pp.pp
+++ b/workflows/sample_alias_pp.pp
@@ -1,11 +1,11 @@
 workflow sample_alias_pp {
-  typespace => 'example',
   returns => (
     String $long_name,
     String $current_age
   )
 } {
   resource person {
+    type => Example::Person,
     returns => ($long_name = name, $current_age = age, $human)
   }{
     age => 48,

--- a/workflows/sample_output_hash.yaml
+++ b/workflows/sample_output_hash.yaml
@@ -1,12 +1,10 @@
-sample_returns_hash:
-  typespace: example
-  returns:
-    o: Hash
-  steps:
-    person:
-      returns:
-        o: [name, age]
-      state:
-        age: 25
-        name: Ann
-        human: true
+returns:
+  o: Hash
+steps:
+  person:
+    returns:
+      o: [name, age]
+    Example::Person:
+      age: 25
+      name: Ann
+      human: true

--- a/workflows/sample_pp.pp
+++ b/workflows/sample_pp.pp
@@ -1,10 +1,10 @@
 workflow sample_pp {
-  typespace => 'example',
   returns => (
     String $name
   )
 } {
   resource person {
+    type => Example::Person,
     returns => ($name)
   }{
     age => 28,


### PR DESCRIPTION
Updates the examples with respect to removal of 'typespace' in Puppet
and YAML manifests and removal of 'type', 'state', and the top level key
of YAML manifests.

Closes #253
Closes #254