### PR TITLE
Default make target should not enforce node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         - nvm install 11
         - nvm use 11
         - node --version
-        - make all
+        - make all smoke-test-ts
       before_deploy:
         - sudo apt-get install -y upx
         - make dist-release

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all: TESTFLAGS = --race
 all: everything
 
 PHONY+= everything
-everything: check-mods clean lint test lyra plugins smoke-test smoke-test-ts
+everything: check-mods clean lint test lyra plugins smoke-test
 
 PHONY+= shrink
 shrink:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The project requires [Go](https://golang.org/doc/install) 1.11 or higher, and [g
 
 1. Clone this repository: `git clone https://github.com/lyraproj/lyra`
 2. Build Lyra: `cd lyra; make`
+3. Optionally, if you intend to work with typescript, run `make smoke-test-ts` (this will check for an appropriate version of Node.js)
 
 ### Deploying Workflows with the Lyra CLI
 


### PR DESCRIPTION
Node.js (and TypeScript) is completely optional for lyra so `make` (default) should not fail.  This commit removes the `smoke-test-ts` from the default make target, continues to run that check in travis and notes in the readme how to run the TypeScript smoke tests

Closes #255 