### PR TITLE
Error if fmt or tidy is not clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ tmp/
 types/
 LICENSE_TMPFILE.txt
 *.db
+*.bak
 /deployment.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ jobs:
   include:
     - stage: Test and build
       script:
-        - rm go.sum # Workaround for https://github.com/kubernetes/kubernetes/issues/69040
         - node --version
         - nvm install 11
         - nvm use 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         - nvm install 11
         - nvm use 11
         - node --version
-        - make all smoke-test-ts smoke-test-go-wf
+        - make format tidy all smoke-test-ts smoke-test-go-wf
       before_deploy:
         - sudo apt-get install -y upx
         - make dist-release

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ clean:
 	@echo "🔘 Cleaning ts dist..."
 	@rm -rf examples/ts-samples/dist
 
+# This is not run as a pre-commit hook unless configured locally using .git/hooks
 PHONY+= pre-commit
 pre-commit: format tidy lint
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ PHONY+= lyra
 lyra: check-mods
 	@$(call build,bin/lyra,cmd/lyra/main.go)
 
-PHONY+= test
 test:
 	@echo "🔘 Running unit tests... (`date '+%H:%M:%S'`)"
 	$(BUILDARGS) go test $(TESTFLAGS) github.com/lyraproj/lyra/...
@@ -82,6 +81,24 @@ clean:
 	@echo "🔘 Cleaning ts dist..."
 	@rm -rf examples/ts-samples/dist
 
+PHONY+= pre-commit
+pre-commit: format tidy lint
+
+# Run go mod tidy and check go.sum is unchanged
+PHONY+= tidy
+tidy:
+	@echo "🔘 Checking that go mod tidy does not make a change..."
+	@cp go.sum go.sum.bak
+	@go mod tidy
+	@diff go.sum go.sum.bak || (echo "🔴 go mod tidy would make a change, exiting"; exit 1)
+	@echo "✅ Checking go mod tidy complete"
+
+# Format go code and error if any changes are made
+PHONY+= format
+format:
+	@echo "🔘 Checking that go fmt does not make any changes..."
+	@test -z $$(go fmt ./...) || (echo "🔴 go fmt would make a change, exiting"; exit 1)
+	@echo "✅ Checking go fmt complete"
 
 PHONY+= lint
 lint: $(GOPATH)/bin/golangci-lint

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,6 @@ github.com/lyraproj/puppet-evaluator v0.0.0-20190430133644-e723fda87b97 h1:FhuoX
 github.com/lyraproj/puppet-evaluator v0.0.0-20190430133644-e723fda87b97/go.mod h1:vdkj2zAsXYPkHwxr/J/eeIJFYiQYHF+Von3mbq0UvOU=
 github.com/lyraproj/puppet-parser v0.0.0-20190430133542-e2f2062b9126 h1:7GRijiODjFJCn9yVzYfoPZkvj7GtPM7zFVi897wbBYg=
 github.com/lyraproj/puppet-parser v0.0.0-20190430133542-e2f2062b9126/go.mod h1:SBAnx/uxMMKy29qME9jFlgHtVJOLI4q7dVMu0UTcIk0=
-github.com/lyraproj/puppet-workflow v0.0.0-20190509101801-6dfb91962bde h1:2NoSHYPu7NXt29MOIkydmnyUPxTcdbQPcn0aTW/vGJY=
-github.com/lyraproj/puppet-workflow v0.0.0-20190509101801-6dfb91962bde/go.mod h1:+3dJHqb/lF8asu6nQwwiGD+ztHWxyKs41GbTCvPhc3Q=
 github.com/lyraproj/puppet-workflow v0.0.0-20190510110814-2b8a82d3b710 h1:CNG1kmgFIFZhIZbCJNrc99Jqaj/sYrvxABR9LnXlAOw=
 github.com/lyraproj/puppet-workflow v0.0.0-20190510110814-2b8a82d3b710/go.mod h1:+3dJHqb/lF8asu6nQwwiGD+ztHWxyKs41GbTCvPhc3Q=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=


### PR DESCRIPTION
* Add new target `format` which runs `go fmt ./...` and errors if any files were changed
* Add new target `tidy` which runs `go mod tidy` and errors if any change to go.sum was made.
* Add new target `pre-commit` which runs these along with a lint (contributors can choose to add a pre-commit hook locally by adding `.git/hooks/pre-commit`)
* Run `format` and `tidy` in travis to fail a build in the event of any changes
* Change go.sum to be output of `go mod tidy` where go version is 1.12.5 (different from 1.11.5) 

Fixes #268