### PR TITLE
Issue 267 - the types folder should live under the build folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,5 @@ COPY --from=builder /src/lyra/build/goplugins /src/lyra/build/goplugins
 COPY --from=builder /src/lyra/workflows /src/lyra/workflows
 COPY --from=builder /src/lyra/examples /src/lyra/examples
 COPY --from=builder /src/lyra/docs /src/lyra/docs
-COPY --from=builder /src/lyra/types /src/lyra/types
 COPY --from=builder /src/lyra/data.yaml /src/lyra
 CMD lyra apply foobernetes

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ COPY --from=builder /src/lyra/build/goplugins /src/lyra/build/goplugins
 COPY --from=builder /src/lyra/workflows /src/lyra/workflows
 COPY --from=builder /src/lyra/examples /src/lyra/examples
 COPY --from=builder /src/lyra/docs /src/lyra/docs
+COPY --from=builder /src/lyra/build/types /src/lyra/build/types
 COPY --from=builder /src/lyra/data.yaml /src/lyra
 CMD lyra apply foobernetes


### PR DESCRIPTION
Amends the Dockerfile to follow #267 - tested running foobernetes on the docker container e.g.

```sh
/src/lyra # lyra apply foobernetes

▸ apply done: foobernetes

/src/lyra #```