### PR TITLE
Terraform config as a resource

### DIFF
--- a/cmd/goplugin-terraform/main.go
+++ b/cmd/goplugin-terraform/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/lyra/cmd/goplugin-terraform/terraform"
+)
+
+func init() {
+	if hclog.DefaultOptions.Level <= hclog.Debug {
+		issue.IncludeStacktrace(true)
+	}
+	hclog.DefaultOptions = &hclog.LoggerOptions{
+		Name:            "terraform",
+		Level:           hclog.LevelFromString(os.Getenv("LYRA_LOG_LEVEL")),
+		JSONFormat:      true,
+		IncludeLocation: false,
+		Output:          os.Stderr,
+	}
+}
+
+func main() {
+	terraform.Start()
+}

--- a/cmd/goplugin-terraform/main.go
+++ b/cmd/goplugin-terraform/main.go
@@ -9,15 +9,15 @@ import (
 )
 
 func init() {
-	if hclog.DefaultOptions.Level <= hclog.Debug {
-		issue.IncludeStacktrace(true)
-	}
 	hclog.DefaultOptions = &hclog.LoggerOptions{
 		Name:            "terraform",
 		Level:           hclog.LevelFromString(os.Getenv("LYRA_LOG_LEVEL")),
 		JSONFormat:      true,
 		IncludeLocation: false,
 		Output:          os.Stderr,
+	}
+	if hclog.DefaultOptions.Level <= hclog.Debug {
+		issue.IncludeStacktrace(true)
 	}
 }
 

--- a/cmd/goplugin-terraform/resource/configuration.go
+++ b/cmd/goplugin-terraform/resource/configuration.go
@@ -48,7 +48,8 @@ func (*ConfigHandler) Read(externalID string) (*Config, error) {
 	//HACK return a new uniqueID to ensure update is always called
 	s := uniqueString()
 	return &Config{
-		UniqueID: &s,
+		WorkingDir: externalID,
+		UniqueID:   &s,
 	}, nil
 }
 
@@ -130,9 +131,10 @@ func convertOutput(b []byte) px.Value {
 	if hash, ok := c.PopLast().(px.OrderedMap); ok {
 		ie := make([]*types.HashEntry, 0, hash.Len())
 		hash.EachPair(func(k, v px.Value) {
-			innerHash := v.(px.OrderedMap)
-			if innerV, ok := innerHash.Get4(`value`); ok {
-				ie = append(ie, types.WrapHashEntry(k, innerV))
+			if innerHash, ok := v.(px.OrderedMap); ok {
+				if innerV, ok := innerHash.Get4(`value`); ok {
+					ie = append(ie, types.WrapHashEntry(k, innerV))
+				}
 			}
 		})
 		return types.WrapHash(ie)

--- a/cmd/goplugin-terraform/resource/configuration.go
+++ b/cmd/goplugin-terraform/resource/configuration.go
@@ -1,0 +1,110 @@
+package resource
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
+)
+
+// Config is a terraform configuration identified by a working directory
+type Config struct {
+	WorkingDir string
+	UniqueID   *string //HACK to force Read to return a new value, in order to always trigger an Update
+	Output     *map[string]string
+}
+
+// ConfigHandler is used to perform CRUD operations on a Config resource
+type ConfigHandler struct{}
+
+// Create a new set of resources
+func (*ConfigHandler) Create(desiredState *Config) (*Config, string, error) {
+	hclog.Default().Debug("Creating Config", "desiredState", desiredState)
+
+	apply(desiredState)
+
+	return desiredState, extID(*desiredState), nil
+}
+
+// Read an existing Config
+func (*ConfigHandler) Read(externalID string) (*Config, error) {
+	hclog.Default().Debug("Reading Config", "externalID", externalID)
+
+	s := uniqueString()
+	//HACK return a new uniqueID to ensure update is always called
+	return &Config{
+		UniqueID: &s,
+	}, nil
+}
+
+// Update an existing Config
+func (*ConfigHandler) Update(externalID string, desiredState *Config) (*Config, error) {
+	hclog.Default().Debug("Updating Instance", "externalID", externalID, "desiredState", desiredState)
+
+	apply(desiredState)
+	return desiredState, nil
+}
+
+// Delete an existing Config
+func (*ConfigHandler) Delete(externalID string) error {
+	hclog.Default().Debug("Deleting Config:", "externalID", externalID)
+
+	_ = mustRun(externalID, "terraform", "init")
+
+	//HACK: externalID is the working dir of the terraform config, so that we can delete
+	_ = mustRun(externalID, "terraform", "destroy", "-auto-approve")
+	return nil
+}
+
+func apply(in *Config) map[string]string {
+	log := hclog.Default()
+	log.Debug("apply entered", "in", in)
+
+	_ = mustRun(in.WorkingDir, "terraform", "init")
+	_ = mustRun(in.WorkingDir, "terraform", "apply", "-auto-approve")
+	out := mustRun(in.WorkingDir, "terraform", "output")
+	m := convertOutput(out)
+	return m
+}
+
+func mustRun(dir string, name string, arg ...string) []byte {
+	log := hclog.Default()
+	log.Debug("Running command", "name", name, "arg", arg, "dir", dir)
+	cmd := exec.Command(name, arg...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	output := fmt.Sprintf("%s", out)
+	log.Debug("applied", "output", output, "err", err)
+	if err != nil {
+		panic(fmt.Errorf("error running cmd %v \n error is %v \n output is %v", cmd, err, output))
+	}
+	return out
+}
+
+// convertOutput converts the passed byte array to a map of strings to strings
+// expected format of input is that of `terraform output` e.g zero or more lines in format `a = b`
+func convertOutput(b []byte) map[string]string {
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	m := make(map[string]string)
+	for scanner.Scan() {
+		s := scanner.Text()
+		tokens := strings.Split(s, "=")
+		key := strings.Trim(tokens[0], " ")
+		value := strings.Trim(tokens[1], " ")
+		m[key] = value
+	}
+	return m
+}
+
+func extID(r Config) string {
+	//HACK: externalID is the working dir of the terraform config, so that we can delete
+	return r.WorkingDir
+}
+
+func uniqueString() string {
+	return uuid.New().String()
+}

--- a/cmd/goplugin-terraform/resource/configuration.go
+++ b/cmd/goplugin-terraform/resource/configuration.go
@@ -60,7 +60,7 @@ func (*ConfigHandler) Delete(externalID string) error {
 	return nil
 }
 
-func apply(in *Config) map[string]string {
+func apply(in *Config) {
 	log := hclog.Default()
 	log.Debug("apply entered", "in", in)
 
@@ -68,7 +68,8 @@ func apply(in *Config) map[string]string {
 	_ = mustRun(in.WorkingDir, "terraform", "apply", "-auto-approve")
 	out := mustRun(in.WorkingDir, "terraform", "output")
 	m := convertOutput(out)
-	return m
+	log.Debug("apply complete", "m", m)
+	in.Output = &m
 }
 
 func mustRun(dir string, name string, arg ...string) []byte {

--- a/cmd/goplugin-terraform/resource/configuration_test.go
+++ b/cmd/goplugin-terraform/resource/configuration_test.go
@@ -1,0 +1,52 @@
+package resource
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertOutput(t *testing.T) {
+	s := `rgId = /subscriptions/c82736ee-c108-452b-8178-f548c95d18fe/resourceGroups/lyra-tf-test
+rgLocation = westeurope
+rgName = lyra-tf-test
+1 = 2
+false = true`
+
+	m := convertOutput([]byte(s))
+	require.Len(t, m, 5)
+	require.Equal(t, "/subscriptions/c82736ee-c108-452b-8178-f548c95d18fe/resourceGroups/lyra-tf-test", m["rgId"])
+	require.Equal(t, "westeurope", m["rgLocation"])
+	require.Equal(t, "lyra-tf-test", m["rgName"])
+	require.Equal(t, "2", m["1"])
+	require.Equal(t, "true", m["false"])
+}
+
+func TestConvertOutput_EmptyOutput(t *testing.T) {
+	m := convertOutput([]byte(""))
+	require.Len(t, m, 0)
+}
+
+func TestUniqueString(t *testing.T) {
+	s := uniqueString()
+	re := regexp.MustCompile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8}")
+	b := re.Match([]byte(s))
+	require.True(t, b)
+
+}
+
+func TestEndToEnd(t *testing.T) {
+	t.Skip("Only to be run as needed.  Will probably time out on deletion")
+	ch := ConfigHandler{}
+	c := Config{
+		WorkingDir: "/Users/Mark/code/lyraproj/lyra/examples/go-samples/terraform_go/tfroot",
+	}
+	_, externalID, err := ch.Create(&c)
+	require.NoError(t, err)
+	require.Equal(t, c.WorkingDir, externalID)
+	_, err = ch.Update(externalID, &c)
+	require.NoError(t, err)
+	err = ch.Delete(externalID)
+	require.NoError(t, err)
+}

--- a/cmd/goplugin-terraform/terraform/start.go
+++ b/cmd/goplugin-terraform/terraform/start.go
@@ -1,0 +1,27 @@
+package terraform
+
+import (
+	"github.com/lyraproj/lyra/cmd/goplugin-terraform/resource"
+	"github.com/lyraproj/pcore/pcore"
+	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/grpc"
+	"github.com/lyraproj/servicesdk/service"
+)
+
+// Start the plugin
+func Start() {
+	pcore.Do(func(c px.Context) {
+		s := Server(c)
+		grpc.Serve(c, s)
+	})
+}
+
+// Server returns the built server to be served
+func Server(c px.Context) *service.Server {
+	sb := service.NewServiceBuilder(c, "Terraform")
+
+	evs := sb.RegisterTypes("Terraform", resource.Config{})
+	sb.RegisterHandler("Terraform::ConfigHandler", &resource.ConfigHandler{}, evs[0])
+
+	return sb.Server()
+}

--- a/examples/go-samples/spewer/run.go
+++ b/examples/go-samples/spewer/run.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/go-hclog"
+	"github.com/lyraproj/servicesdk/lang/go/lyra"
+)
+
+type spewIn struct {
+	It interface{}
+}
+
+func run(in spewIn) {
+	s := fmt.Sprintf("\n%v", spew.Sdump(in.It))
+
+	//FIXME replace Warn with Debug, this is just for illustration
+	hclog.Default().Warn("********Spew ********", "s", s)
+}
+
+func main() {
+	lyra.Serve(`spewer`, nil, &lyra.Action{Do: run})
+}

--- a/examples/go-samples/spewer/run.go
+++ b/examples/go-samples/spewer/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-hclog"
@@ -9,16 +10,35 @@ import (
 )
 
 type spewIn struct {
-	It interface{}
+	It    interface{}
+	Level *string
 }
 
 func run(in spewIn) {
 	s := fmt.Sprintf("\n%v", spew.Sdump(in.It))
-
-	//FIXME replace Warn with Debug, this is just for illustration
-	hclog.Default().Warn("********Spew ********", "s", s)
+	lf := logFunc(hclog.Default(), in.Level)
+	lf("**Spewer **", "s", s)
 }
 
+func logFunc(logger hclog.Logger, level *string) func(msg string, args ...interface{}) {
+	s := "debug"
+	if level != nil {
+		s = *level
+	}
+	s = strings.ToLower(strings.TrimSpace(s)) //ignore case
+	switch s {
+	case "trace":
+		return logger.Trace
+	case "info":
+		return logger.Info
+	case "warn":
+		return logger.Warn
+	case "error":
+		return logger.Error
+	default:
+		return logger.Debug
+	}
+}
 func main() {
 	lyra.Serve(`spewer`, nil, &lyra.Action{Do: run})
 }

--- a/examples/go-samples/spewer/run.go
+++ b/examples/go-samples/spewer/run.go
@@ -1,23 +1,21 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-hclog"
+	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/servicesdk/lang/go/lyra"
 )
 
 type spewIn struct {
-	It    interface{}
+	It    px.Value
 	Level *string
 }
 
 func run(in spewIn) {
-	s := fmt.Sprintf("\n%v", spew.Sdump(in.It))
 	lf := logFunc(hclog.Default(), in.Level)
-	lf("**Spewer **", "s", s)
+	lf("**Spewer **", "s", px.ToPrettyString(in.It))
 }
 
 func logFunc(logger hclog.Logger, level *string) func(msg string, args ...interface{}) {

--- a/examples/go-samples/terraform_go/tfroot/azure.tf
+++ b/examples/go-samples/terraform_go/tfroot/azure.tf
@@ -1,15 +1,20 @@
 resource "azurerm_resource_group" "test" {
-  name     = "lyra-tf-test"
+  count = 2
+  name     = "lyra-tf-test-${count.index}"
   location = "West Europe"
 }
-
-# this is an id we can only get from cloud/tfstate
 output "rgId" {
-  value = "${azurerm_resource_group.test.id}"
+  value = "${azurerm_resource_group.test.*.id}"
 }
 output "rgName" {
-  value = "${azurerm_resource_group.test.name}"
+  value = "${azurerm_resource_group.test.1.name}"
 }
 output "rgLocation" {
-  value = "${azurerm_resource_group.test.location}"
+  value = "${azurerm_resource_group.test.*.location}"
+}
+output "rgCount" {
+  value = "${length(azurerm_resource_group.test)}"
+}
+output "testBool" {
+  value = true
 }

--- a/examples/go-samples/terraform_go/tfroot/azure.tf
+++ b/examples/go-samples/terraform_go/tfroot/azure.tf
@@ -1,0 +1,15 @@
+resource "azurerm_resource_group" "test" {
+  name     = "lyra-tf-test"
+  location = "West Europe"
+}
+
+# this is an id we can only get from cloud/tfstate
+output "rgId" {
+  value = "${azurerm_resource_group.test.id}"
+}
+output "rgName" {
+  value = "${azurerm_resource_group.test.name}"
+}
+output "rgLocation" {
+  value = "${azurerm_resource_group.test.location}"
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lyraproj/lyra
 require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
+	github.com/google/uuid v1.1.0
 	github.com/hashicorp/go-hclog v0.9.0
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/hashicorp/terraform v0.11.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/lyraproj/lyra
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/google/uuid v1.1.0

--- a/workflows/spewer.ll
+++ b/workflows/spewer.ll
@@ -1,0 +1,4 @@
+executable: go
+arguments:
+ - run
+ - 'examples/go-samples/spewer/run.go'

--- a/workflows/terraform.yaml
+++ b/workflows/terraform.yaml
@@ -7,15 +7,9 @@ steps:
       workingDir: examples/go-samples/terraform_go/tfroot
   spew:
     parameters:
-      tf_out: it
-    call: spewer
-  spew2:
-    parameters:
-      # how could we use just the value of $output.rgId
-      # $tf_out.rgId: it #value '$tf_out.rgId' is never produced
-      # tf_out.rgId: it #value 'tf_out.rgId' is never produced
-      # $tf_out: it #value '$tf_out' is never produced
-      it: # put it in a map
-        value:
-          anything: $tf_out.rgId
+      # it: {value: $tf_out.rgName, type: "String"} # spews -> (string) (len=56) "Deferred('name' => '$tf_out', 'arguments' => ['rgName'])"
+      it: {value: $tf_out.rgName, type: "Deferred"}
+      # it: {value: $tf_out.testBool, type: "Deferred"}
+      # it: {value: $tf_out.rgCount, type: "Deferred"}
+      # it: {value: $tf_out.rgLocation, type: "Deferred"}
     call: spewer

--- a/workflows/terraform.yaml
+++ b/workflows/terraform.yaml
@@ -1,7 +1,21 @@
-returns: [terraform_output]
+returns: [tf_out]
 steps:
   config:
     returns:
-      terraform_output: output
+      tf_out: output
     Terraform::Config:  
       workingDir: examples/go-samples/terraform_go/tfroot
+  spew:
+    parameters:
+      tf_out: it
+    call: spewer
+  spew2:
+    parameters:
+      # how could we use just the value of $output.rgId
+      # $tf_out.rgId: it #value '$tf_out.rgId' is never produced
+      # tf_out.rgId: it #value 'tf_out.rgId' is never produced
+      # $tf_out: it #value '$tf_out' is never produced
+      it: # put it in a map
+        value:
+          anything: $tf_out.rgId
+    call: spewer

--- a/workflows/terraform.yaml
+++ b/workflows/terraform.yaml
@@ -7,9 +7,15 @@ steps:
       workingDir: examples/go-samples/terraform_go/tfroot
   spew:
     parameters:
-      # it: {value: $tf_out.rgName, type: "String"} # spews -> (string) (len=56) "Deferred('name' => '$tf_out', 'arguments' => ['rgName'])"
-      it: {value: $tf_out.rgName, type: "Deferred"}
-      # it: {value: $tf_out.testBool, type: "Deferred"}
-      # it: {value: $tf_out.rgCount, type: "Deferred"}
+      it:
+        value:
+            a: $tf_out.rgName
+            b: $tf_out.testBool
+            c: $tf_out.rgCount
+            d: $tf_out.rgLocation
+      # we can get a single value from a map as long as we explicitly specify the type
       # it: {value: $tf_out.rgLocation, type: "Deferred"}
+      # we can set a level at which to log, the default is debug
+      # level: {value: "wARn", type: "String"}
+      
     call: spewer

--- a/workflows/terraform.yaml
+++ b/workflows/terraform.yaml
@@ -1,0 +1,7 @@
+returns: [terraform_output]
+steps:
+  config:
+    returns:
+      terraform_output: output
+    Terraform::Config:  
+      workingDir: examples/go-samples/terraform_go/tfroot


### PR DESCRIPTION
This commit adds a Terraform::Config resource with a Read which always returns a new value, in order to force the (idempotent) Update to be called each time.  The output is returned as a map based on the `terraform output` command.  Update and Create to the resource both run `terraform init`, `terraform apply` and `terraform output` whilst Delete calls `terraform destroy`