### PR TITLE
Update foobernetes examples to use 'policy' parameter

### DIFF
--- a/cmd/goplugin-foobernetes/resource/loadbalancer.go
+++ b/cmd/goplugin-foobernetes/resource/loadbalancer.go
@@ -12,6 +12,7 @@ type LoadBalancer struct {
 	LoadBalancerID *string
 	LoadBalancerIP *string
 	Location       *string
+	Policy         *string
 	Replica        *bool
 	WebServerIDs   []string
 	Tags           *map[string]string

--- a/tests/expected/deployment.json
+++ b/tests/expected/deployment.json
@@ -11,7 +11,6 @@
         "ws-8944791324497208693"
       ],
       "Tags": {
-        "policy": "rr",
         "role": "secondary",
         "team": "lyra team"
       }
@@ -27,7 +26,6 @@
         "ws-8944791324497208693"
       ],
       "Tags": {
-        "policy": "rr",
         "role": "primary",
         "team": "lyra team"
       }

--- a/tests/expected/deployment.json
+++ b/tests/expected/deployment.json
@@ -5,6 +5,7 @@
       "LoadBalancerIP": "10.0.0.2",
       "Location": "eu2",
       "Replica": true,
+      "Policy": "rr",
       "WebServerIDs": [
         "ws-1887659887648687854",
         "ws-8944791324497208693"
@@ -20,6 +21,7 @@
       "LoadBalancerIP": "10.0.0.1",
       "Location": "eu1",
       "Replica": false,
+      "Policy": "rr",
       "WebServerIDs": [
         "ws-1887659887648687854",
         "ws-8944791324497208693"

--- a/workflows/foober_iter.yaml
+++ b/workflows/foober_iter.yaml
@@ -27,9 +27,9 @@
 # the "foober_iter" section. All top-level workflow parameters must be specified in
 # the "data.yaml" file at runtime.
 parameters:
-  load_balancer_policy:
-    type: String
-    lookup: foobernetes.lb_policy
+  policies:
+    type: Hash[String, String]
+    lookup: foobernetes.policies
 
 # The workflow returns a two element array containing the IDs produced by the
 # "loadBalancers" collect step. All top-level returns must be returns of
@@ -93,6 +93,7 @@ steps:
       Foobernetes::Loadbalancer:
         loadBalancerIP: $ip
         location: eu1
+        policy: $policies.lb_policy
         replica: $replica
         webServerIDs: $webServers
         tags:

--- a/workflows/foobernetes.yaml
+++ b/workflows/foobernetes.yaml
@@ -98,6 +98,7 @@ steps:
       loadBalancerIP: 10.0.0.1
       location: eu1
       replica: false
+      policy: $load_balancer_policy
       webServerIDs: [$webServerID1, $webServerID2]
       tags:
         team: "lyra team"
@@ -115,6 +116,7 @@ steps:
       loadBalancerIP: '10.0.0.2'
       location: eu2
       replica: true
+      policy: $load_balancer_policy
       webServerIDs: [$webServerID1, $webServerID2]
       tags:
         team: "lyra team"

--- a/workflows/foobernetes.yaml
+++ b/workflows/foobernetes.yaml
@@ -98,12 +98,11 @@ steps:
       loadBalancerIP: 10.0.0.1
       location: eu1
       replica: false
-      policy: $load_balancer_policy
+      policy: $policies.lb_policy
       webServerIDs: [$webServerID1, $webServerID2]
       tags:
         team: "lyra team"
         role: primary
-        policy: $policies.lb_policy
 
   # This second "loadbalancer" step cannot be typed implicitly since the
   # step name must be unique. The step also declares its parameters
@@ -116,12 +115,11 @@ steps:
       loadBalancerIP: '10.0.0.2'
       location: eu2
       replica: true
-      policy: $load_balancer_policy
+      policy: $policies.lb_policy
       webServerIDs: [$webServerID1, $webServerID2]
       tags:
         team: "lyra team"
         role: secondary
-        policy: $policies.lb_policy
 
   # The state section of a step can be arbitrarily nested as shown in the
   # "config" section.

--- a/workflows/foobernetes_pp.pp
+++ b/workflows/foobernetes_pp.pp
@@ -1,6 +1,6 @@
 workflow foobernetes_pp {
   parameters => (
-    String $load_balancer_policy = lookup('foobernetes.lb_policy')
+    String $load_balancer_policy = lookup('foobernetes.policies.lb_policy')
   ),
   returns => (
     String $primary_load_balancer_id,
@@ -21,7 +21,7 @@ workflow foobernetes_pp {
     webServerIDs => [$webserver1_id, $webserver2_id],
     tags => {
         'team' => 'lyra team',
-        'role' => 'primary'
+        'role' => 'primary',
     }
   }
 
@@ -45,7 +45,7 @@ workflow foobernetes_pp {
     webServerIDs => [$webserver1_id, $webserver2_id],
     tags => {
         'team' => 'lyra team',
-        'role' => 'secondary'
+        'role' => 'secondary',
     }
   }
 

--- a/workflows/foobernetes_pp.pp
+++ b/workflows/foobernetes_pp.pp
@@ -17,6 +17,7 @@ workflow foobernetes_pp {
     loadBalancerIP => '10.0.0.1',
     location => 'eu1',
     replica => false,
+    policy => $load_balancer_policy,
     webServerIDs => [$webserver1_id, $webserver2_id],
     tags => {
         'team' => 'lyra team',
@@ -40,6 +41,7 @@ workflow foobernetes_pp {
     loadBalancerIP => '10.0.0.2',
     location => 'eu2',
     replica => true,
+    policy => $load_balancer_policy,
     webServerIDs => [$webserver1_id, $webserver2_id],
     tags => {
         'team' => 'lyra team',


### PR DESCRIPTION
While debugging hiera lookups, I noticed that although
we had the load balancer policy as the single external
parameter to the workflows, it was neither defined in
the resource type nor used in the body of the workflows.

This commit adds it to the Foobernetes::Loadbalancer
struct, the test data, and the resource definitions
in the workflows themselves.

(NB foober_iter is not fixed in this commit, but it
no longer applies cleanly and I'm not sure we need to
keep it at all)