### PR TITLE
Disable IAM role due to error

### DIFF
--- a/workflows/aws.yaml
+++ b/workflows/aws.yaml
@@ -7,28 +7,28 @@ returns:
     type: String
 steps:
 
-  iam_role:
-    resource: Aws::Iam_role
-    value:
-      name: lyra-iam-role
-      assume_role_policy: |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-                "Action": "sts:AssumeRoleWithSAML",
-                "Effect": "Allow",
-                "Condition": {
-                  "StringEquals": {
-                      "SAML:aud": "https://signin.aws.amazon.com/saml"
-                  }
-                },
-                "Principal": {
-                  "Federated": "arn:aws:iam::1234567890:saml-provider/myidp"
-                }
-            }
-          ]
-        }
+  # iam_role:
+  #   resource: Aws::Iam_role
+  #   value:
+  #     name: lyra-iam-role
+  #     assume_role_policy: |
+  #       {
+  #         "Version": "2012-10-17",
+  #         "Statement": [
+  #           {
+  #               "Action": "sts:AssumeRoleWithSAML",
+  #               "Effect": "Allow",
+  #               "Condition": {
+  #                 "StringEquals": {
+  #                     "SAML:aud": "https://signin.aws.amazon.com/saml"
+  #                 }
+  #               },
+  #               "Principal": {
+  #                 "Federated": "arn:aws:iam::1234567890:saml-provider/myidp"
+  #               }
+  #           }
+  #         ]
+  #       }
 
   #
   # Application of key_pair succeeds on the first run then fails: see https://github.com/lyraproj/lyra/issues/203


### PR DESCRIPTION
Comment out currently broken IAM role resource in AWS.

```
2019-06-18T12:01:37.169+0100 [DEBUG] lyra: Associate state: intId=lyra://puppet.com/aws/instance2?hid=Aws%3A%3AInstance&rt=Aws%3A%3AInstance extId=i-04f270e7ac1e598ef
2019-06-18T12:01:37.169+0100 [DEBUG] lyra.identity: Invoke: @module=Identity api=Identity::Service name=associate timestamp=2019-06-18T12:01:37.169+0100
2019-06-18T12:01:37.181+0100 [ERROR] lyra: apply failed: Error="Failed to invoke method build/goplugins/aws#Aws::Iam_roleHandler/create() (file: workflows/aws.yaml)
 at /Users/scott/go/pkg/mod/github.com/lyraproj/servicesdk@v0.0.0-20190617121125-a22cb98187cb/grpc/client.go:106 (github.com/lyraproj/servicesdk/grpc.(*Client).Invoke)
```